### PR TITLE
fix: download file will throw error when dir is empty

### DIFF
--- a/src/multistorageclient/providers/ais.py
+++ b/src/multistorageclient/providers/ais.py
@@ -357,7 +357,8 @@ class AIStoreStorageProvider(BaseStorageProvider):
             metadata = self._get_object_metadata(remote_path)
 
         if isinstance(f, str):
-            os.makedirs(os.path.dirname(f), exist_ok=True)
+            if os.path.dirname(f):
+                os.makedirs(os.path.dirname(f), exist_ok=True)
             with open(f, "wb") as fp:
                 fp.write(self._get_object(remote_path))
         else:

--- a/src/multistorageclient/providers/azure.py
+++ b/src/multistorageclient/providers/azure.py
@@ -481,7 +481,8 @@ class AzureBlobStorageProvider(BaseStorageProvider):
         self._refresh_blob_service_client_if_needed()
 
         if isinstance(f, str):
-            os.makedirs(os.path.dirname(f), exist_ok=True)
+            if os.path.dirname(f):
+                os.makedirs(os.path.dirname(f), exist_ok=True)
 
             def _invoke_api() -> int:
                 blob_client = self._blob_service_client.get_blob_client(container=container_name, blob=blob_name)

--- a/src/multistorageclient/providers/gcs.py
+++ b/src/multistorageclient/providers/gcs.py
@@ -580,7 +580,8 @@ class GoogleStorageProvider(BaseStorageProvider):
         bucket, key = split_path(remote_path)
 
         if isinstance(f, str):
-            os.makedirs(os.path.dirname(f), exist_ok=True)
+            if os.path.dirname(f):
+                os.makedirs(os.path.dirname(f), exist_ok=True)
             # Download small files
             if metadata.content_length <= self._multipart_threshold:
                 with tempfile.NamedTemporaryFile(mode="wb", delete=False, dir=os.path.dirname(f), prefix=".") as fp:

--- a/src/multistorageclient/providers/oci.py
+++ b/src/multistorageclient/providers/oci.py
@@ -527,7 +527,8 @@ class OracleStorageProvider(BaseStorageProvider):
         bucket, key = split_path(remote_path)
 
         if isinstance(f, str):
-            os.makedirs(os.path.dirname(f), exist_ok=True)
+            if os.path.dirname(f):
+                os.makedirs(os.path.dirname(f), exist_ok=True)
 
             def _invoke_api() -> int:
                 response = self._oci_client.get_object(

--- a/src/multistorageclient/providers/posix_file.py
+++ b/src/multistorageclient/providers/posix_file.py
@@ -345,7 +345,8 @@ class PosixFileStorageProvider(BaseStorageProvider):
         if isinstance(f, str):
 
             def _invoke_api() -> int:
-                os.makedirs(os.path.dirname(f), exist_ok=True)
+                if os.path.dirname(f):
+                    os.makedirs(os.path.dirname(f), exist_ok=True)
                 atomic_write(source=remote_path, destination=f)
 
                 return filesize

--- a/src/multistorageclient/providers/s3.py
+++ b/src/multistorageclient/providers/s3.py
@@ -748,7 +748,8 @@ class S3StorageProvider(BaseStorageProvider):
 
         if isinstance(f, str):
             bucket, key = split_path(remote_path)
-            os.makedirs(os.path.dirname(f), exist_ok=True)
+            if os.path.dirname(f):
+                os.makedirs(os.path.dirname(f), exist_ok=True)
 
             # Download small files
             if metadata.content_length <= self._transfer_config.multipart_threshold:


### PR DESCRIPTION
## Summary



## Details

if we run client like this ` client.download_file("dir/to-copy.py", "to-copy.py")`
will got this 
```
  File "/mnt/d/workspace/pythong/venv/lib/python3.12/site-packages/multistorageclient/providers/s3.py", line 751, in _download_file
    os.makedirs(os.path.dirname(f), exist_ok=True)
  File "<frozen os>", line 225, in makedirs
FileNotFoundError: [Errno 2] No such file or directory: ''
```

## Usage

_You can potentially add a usage example below._

```python
# Add a code snippet demonstrating how to use this.
```

## Before your PR is "Ready for review"

- [ ] Make sure you read and followed [Contributor guidelines](../CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Did you add notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR to `.release_notes/.unreleased.md`?

## Additional Information

- Related to _issue link (an issue is needed to notify us on Slack)_.
