### PR TITLE
feat: forward s3 config dict to botocore.config.Config

### DIFF
--- a/multi-storage-client/src/multistorageclient/providers/s3.py
+++ b/multi-storage-client/src/multistorageclient/providers/s3.py
@@ -153,6 +153,7 @@ class S3StorageProvider(BaseStorageProvider):
             connect_timeout=kwargs.get("connect_timeout", DEFAULT_CONNECT_TIMEOUT),
             read_timeout=kwargs.get("read_timeout", DEFAULT_READ_TIMEOUT),
             retries=kwargs.get("retries"),
+            s3=kwargs.get("s3"),
         )
         self._transfer_config = TransferConfig(
             multipart_threshold=int(kwargs.get("multipart_threshold", MULTIPART_THRESHOLD)),
@@ -195,6 +196,7 @@ class S3StorageProvider(BaseStorageProvider):
         connect_timeout: Union[float, int, None] = None,
         read_timeout: Union[float, int, None] = None,
         retries: Optional[dict[str, Any]] = None,
+        s3: Optional[dict[str, Any]] = None,
     ):
         """
         Creates and configures the boto3 S3 client, using refreshable credentials if possible.
@@ -205,6 +207,7 @@ class S3StorageProvider(BaseStorageProvider):
         :param connect_timeout: The time in seconds till a timeout exception is thrown when attempting to make a connection.
         :param read_timeout: The time in seconds till a timeout exception is thrown when attempting to read from a connection.
         :param retries: A dictionary for configuration related to retry behavior.
+        :param s3: A dictionary of S3-specific configuration options passed directly to ``botocore.config.Config(s3=...)``. Supported keys include ``addressing_style`` (``"virtual"`` or ``"path"``), ``payload_signing_enabled``, ``use_accelerate_endpoint``, and ``use_dualstack_endpoint``. See `botocore Config reference <https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html>`_.
 
         :return: The configured S3 client.
         """
@@ -217,6 +220,7 @@ class S3StorageProvider(BaseStorageProvider):
                 retries=retries or {"mode": "standard"},
                 request_checksum_calculation=request_checksum_calculation,
                 response_checksum_validation=response_checksum_validation,
+                s3=s3,
             ),
         }
 

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_config.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_config.py
@@ -724,6 +724,9 @@ def test_s3_storage_provider_passthrough_options() -> None:
                                     "max_attempts": 1,
                                     "mode": "adaptive",
                                 },
+                                "s3": {
+                                    "addressing_style": "virtual",
+                                },
                             },
                         }
                     }
@@ -757,6 +760,9 @@ def test_gcs_s3_storage_provider_passthrough_options() -> None:
                                     "max_attempts": 1,
                                     "mode": "adaptive",
                                 },
+                                "s3": {
+                                    "addressing_style": "virtual",
+                                },
                             },
                         }
                     }
@@ -789,6 +795,9 @@ def test_s8k_storage_provider_passthrough_options() -> None:
                                     "total_max_attempts": 2,
                                     "max_attempts": 1,
                                     "mode": "adaptive",
+                                },
+                                "s3": {
+                                    "addressing_style": "path",
                                 },
                             },
                         }


### PR DESCRIPTION
S3StorageProvider builds a boto3 Config but never passes the `s3` dict,
which controls addressing_style, payload_signing_enabled,
use_accelerate_endpoint, and use_dualstack_endpoint.

Without this, S3-compatible stores that need virtual-hosted addressing
(e.g., CoreWeave AI Object Storage) can't be configured through MSC's
YAML config. The only workaround is injecting a ~/.aws/config file with
`s3 = addressing_style = virtual`, which is easy to get wrong in
containers.

This adds an `s3` dict to storage_provider.options, passed straight to
botocore.config.Config(s3=...). Same pattern as `retries`.

Example:

```yaml
storage_provider:
  type: s3
  options:
    base_path: my-bucket
    endpoint_url: https://cwobject.com
    s3:
      addressing_style: virtual
```

When `s3` is absent from the YAML, Config(s3=None) is passed and
~/.aws/config remains the sole source for these settings (no behavior
change). When present, YAML values win per-key, and non-overlapping
keys from the config file still apply.

This fits the direction from #14: configure the base S3 provider for
S3-compatible stores rather than adding per-vendor subclasses.

An alternative would be a named `addressing_style` parameter instead
of a generic dict. The dict was chosen for consistency with `retries`
and to avoid a new parameter for each botocore s3 config key.
