### PR TITLE
feat: add backstage catalog descriptor

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,100 @@
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: multi-storage-client
+  title: Multi-Storage Client
+  description: Unified storage access across object stores, POSIX filesystems, documentation, and explorer tooling.
+  annotations:
+    github.com/project-slug: NVIDIA/multi-storage-client
+    backstage.io/source-location: url:https://github.com/NVIDIA/multi-storage-client/
+    nvidia.com/nspect-id: NSPECT-XYXH-7R42
+  tags:
+    - storage
+    - cloud-storage
+spec:
+  owner: group:default/multi-storage-client-maintainers
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: multi-storage-client
+  title: Multi-Storage Client
+  description: Unified high-performance client for object and file stores across S3, Azure Blob Storage, GCS, AIStore, OCI Object Storage, POSIX file systems, and more.
+  annotations:
+    github.com/project-slug: NVIDIA/multi-storage-client
+    backstage.io/source-location: url:https://github.com/NVIDIA/multi-storage-client/
+    nvidia.com/nspect-id: NSPECT-XYXH-7R42
+  tags:
+    - python
+    - rust
+    - go
+    - storage
+    - cloud-storage
+  links:
+    - url: https://nvidia.github.io/multi-storage-client/
+      title: Documentation
+      icon: docs
+      type: docs
+    - url: https://github.com/NVIDIA/multi-storage-client
+      title: Source
+      icon: github
+      type: source
+spec:
+  type: library
+  lifecycle: experimental
+  owner: group:default/multi-storage-client-maintainers
+  system: multi-storage-client
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: multi-storage-file-system
+  title: Multi-Storage File System
+  description: Go FUSE filesystem that exposes object storage through POSIX-style file access.
+  annotations:
+    github.com/project-slug: NVIDIA/multi-storage-client
+    backstage.io/source-location: url:https://github.com/NVIDIA/multi-storage-client/tree/main/multi-storage-file-system/
+    nvidia.com/nspect-id: NSPECT-XYXH-7R42
+  tags:
+    - go
+    - fuse
+    - filesystem
+    - storage
+    - cloud-storage
+  links:
+    - url: https://github.com/NVIDIA/multi-storage-client/tree/main/multi-storage-file-system
+      title: Source
+      icon: github
+      type: source
+spec:
+  type: library
+  lifecycle: experimental
+  owner: group:default/multi-storage-client-maintainers
+  system: multi-storage-client
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: multi-storage-explorer
+  title: Multi-Storage Explorer
+  description: Web UI for browsing and interacting with storage through the Multi-Storage Client project.
+  annotations:
+    github.com/project-slug: NVIDIA/multi-storage-client
+    backstage.io/source-location: url:https://github.com/NVIDIA/multi-storage-client/tree/main/multi-storage-explorer/
+    nvidia.com/nspect-id: NSPECT-XYXH-7R42
+  tags:
+    - web
+    - ui
+    - explorer
+    - storage
+    - cloud-storage
+  links:
+    - url: https://github.com/NVIDIA/multi-storage-client/tree/main/multi-storage-explorer
+      title: Source
+      icon: github
+      type: source
+spec:
+  type: website
+  lifecycle: experimental
+  owner: group:default/multi-storage-client-maintainers
+  system: multi-storage-client


### PR DESCRIPTION
## Description

Adds a Backstage `catalog-info.yaml` for Multi-Storage Client.

The catalog descriptor registers the project as a Backstage system with component entries for:
- Multi-Storage Client
- Multi-Storage File System
- Multi-Storage Explorer

It also includes GitHub/source metadata, documentation links, project tags, and the required NVIDIA NSPECT annotation.

## Validation

- Validated `catalog-info.yaml` with `@backstage/catalog-model`

Closes NGCDP-8100

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The Beta stage is passing in GitLab CI/CD.
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.
