### PR TITLE
fix: parallelize metadata registration for batch uploads

### DIFF
--- a/multi-storage-client/src/multistorageclient/client/single.py
+++ b/multi-storage-client/src/multistorageclient/client/single.py
@@ -19,6 +19,7 @@ import logging
 import os
 import threading
 from collections.abc import Iterator, Sequence
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from io import BytesIO
 from pathlib import PurePosixPath
@@ -292,7 +293,7 @@ class SingleStorageClient(AbstractStorageClient):
         Fetches metadata from the storage provider, optionally merges custom attributes,
         and registers the file with the metadata provider.
 
-        Caller must hold ``_metadata_provider_lock`` if thread-safety is required.
+        Protects metadata provider mutation with ``_metadata_provider_lock`` when configured.
 
         .. note::
             TODO(NGCDP-3016): Handle eventual consistency of Swiftstack, without wait.
@@ -301,7 +302,32 @@ class SingleStorageClient(AbstractStorageClient):
         obj_metadata = self._storage_provider.get_object_metadata(physical_path)
         if attributes:
             obj_metadata.metadata = (obj_metadata.metadata or {}) | attributes
-        self._metadata_provider.add_file(virtual_path, obj_metadata)
+        with self._metadata_provider_lock or contextlib.nullcontext():
+            self._metadata_provider.add_file(virtual_path, obj_metadata)
+
+    def _register_written_files(
+        self,
+        virtual_paths: Sequence[str],
+        physical_paths: Sequence[str],
+        attributes: Optional[Sequence[Optional[dict[str, str]]]] = None,
+        max_workers: int = 16,
+    ) -> None:
+        """Register multiple written files with the metadata provider concurrently."""
+        if not virtual_paths:
+            return
+
+        def _register_one(index: int, virtual_path: str, physical_path: str) -> None:
+            file_attrs = attributes[index] if attributes is not None else None
+            self._register_written_file(virtual_path, physical_path, file_attrs)
+
+        worker_count = max(1, min(len(virtual_paths), max_workers))
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            future_to_virtual_path = {
+                executor.submit(_register_one, i, virtual_path, physical_path): virtual_path
+                for i, (virtual_path, physical_path) in enumerate(zip(virtual_paths, physical_paths))
+            }
+            for future in as_completed(future_to_virtual_path):
+                future.result()
 
     @retry
     def read(
@@ -471,8 +497,7 @@ class SingleStorageClient(AbstractStorageClient):
         if self._metadata_provider:
             physical_path = self._resolve_write_path(remote_path)
             self._storage_provider.upload_file(physical_path, local_path, attributes=None)
-            with self._metadata_provider_lock or contextlib.nullcontext():
-                self._register_written_file(virtual_path, physical_path, attributes)
+            self._register_written_file(virtual_path, physical_path, attributes)
         else:
             self._storage_provider.upload_file(remote_path, local_path, attributes)
 
@@ -502,10 +527,7 @@ class SingleStorageClient(AbstractStorageClient):
         if self._metadata_provider:
             physical_paths = [self._resolve_write_path(rp) for rp in remote_paths]
             self._storage_provider.upload_files(local_paths, physical_paths, attributes, max_workers)
-            with self._metadata_provider_lock or contextlib.nullcontext():
-                for i, (virtual_path, physical_path) in enumerate(zip(remote_paths, physical_paths)):
-                    file_attrs = attributes[i] if attributes is not None else None
-                    self._register_written_file(virtual_path, physical_path, file_attrs)
+            self._register_written_files(remote_paths, physical_paths, attributes, max_workers)
         else:
             self._storage_provider.upload_files(local_paths, remote_paths, attributes, max_workers)
 
@@ -522,8 +544,7 @@ class SingleStorageClient(AbstractStorageClient):
         if self._metadata_provider:
             physical_path = self._resolve_write_path(path)
             self._storage_provider.put_object(physical_path, body, attributes=None)
-            with self._metadata_provider_lock or contextlib.nullcontext():
-                self._register_written_file(virtual_path, physical_path, attributes)
+            self._register_written_file(virtual_path, physical_path, attributes)
         else:
             self._storage_provider.put_object(path, body, attributes=attributes)
 
@@ -540,8 +561,7 @@ class SingleStorageClient(AbstractStorageClient):
             src_path = self._resolve_read_path(src_path)
             dest_path = self._resolve_write_path(dest_path)
             self._storage_provider.copy_object(src_path, dest_path)
-            with self._metadata_provider_lock or contextlib.nullcontext():
-                self._register_written_file(virtual_dest_path, dest_path)
+            self._register_written_file(virtual_dest_path, dest_path)
         else:
             self._storage_provider.copy_object(src_path, dest_path)
 

--- a/multi-storage-client/tests/test_multistorageclient/unit/client/test_client.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/client/test_client.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 
 import pickle
+import threading
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import pytest
 
@@ -569,6 +570,54 @@ def test_single_upload_files_with_metadata_and_attributes(single_backend_config)
     assert added_meta_a.metadata == {"tag": "first"}
     added_meta_b = metadata_provider.add_file.call_args_list[1][0][1]
     assert added_meta_b.metadata == {"existing": "val", "tag": "second"}
+
+
+def test_single_upload_files_registers_metadata_in_parallel(single_backend_config):
+    client = StorageClient(single_backend_config)
+    single = client._delegate
+    assert isinstance(single, SingleStorageClient)
+
+    metadata_provider = MagicMock()
+    metadata_provider.realpath.side_effect = [
+        ResolvedPath(physical_path="logical/a", state=ResolvedPathState.UNTRACKED),
+        ResolvedPath(physical_path="logical/b", state=ResolvedPathState.UNTRACKED),
+    ]
+    metadata_provider.generate_physical_path.side_effect = [
+        ResolvedPath(physical_path="physical/a", state=ResolvedPathState.UNTRACKED),
+        ResolvedPath(physical_path="physical/b", state=ResolvedPathState.UNTRACKED),
+    ]
+    metadata_provider.allow_overwrites.return_value = False
+    single._metadata_provider = metadata_provider
+    single._metadata_provider_lock = threading.Lock()
+    single._storage_provider.upload_files = MagicMock()
+
+    started_count = 0
+    started_lock = threading.Lock()
+    both_started = threading.Event()
+
+    def get_object_metadata(path: str, strict: bool = True):
+        nonlocal started_count
+        with started_lock:
+            started_count += 1
+            if started_count == 2:
+                both_started.set()
+
+        if not both_started.wait(timeout=1):
+            raise AssertionError("metadata registration did not run in parallel")
+
+        return ObjectMetadata(key=path, content_length=100, last_modified=datetime.now(tz=timezone.utc))
+
+    single._storage_provider.get_object_metadata = get_object_metadata
+
+    client.upload_files(["logical/a", "logical/b"], ["/la", "/lb"], max_workers=2)
+
+    assert metadata_provider.add_file.call_count == 2
+    metadata_provider.add_file.assert_any_call(
+        "logical/a", ObjectMetadata(key="physical/a", content_length=100, last_modified=ANY)
+    )
+    metadata_provider.add_file.assert_any_call(
+        "logical/b", ObjectMetadata(key="physical/b", content_length=100, last_modified=ANY)
+    )
 
 
 def test_single_upload_files_with_metadata_rejects_overwrite(single_backend_config):


### PR DESCRIPTION
## Description

- Added `_register_written_files()` to register metadata for batch uploads via a thread pool.
- Moved `_metadata_provider_lock` ownership into `_register_written_file()`, scoped around `metadata_provider.add_file()`.
- Added a regression test that fails if batch metadata registration remains serial.

Closes NGCDP-8231

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The Beta stage is passing in GitLab CI/CD.
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.
