### PR TITLE
build: Drop legacy release notes check.

### DIFF
--- a/multi-storage-client/justfile
+++ b/multi-storage-client/justfile
@@ -47,8 +47,6 @@ analyze: prepare-toolchain
     if [[ -z "${CI:-}" ]]; then ruff check --fix; else ruff check --output-file .reports/ruff.json --output-format gitlab; fi
     # Type check.
     uv run pyright
-    # Check for release notes.
-    if [[ ! -s "../.release_notes/{{package-version}}.md" ]]; then echo "Missing {{package-version}} release notes!" && exit 1; fi
 
 # Stop storage systems.
 stop-storage-systems:


### PR DESCRIPTION
## Description

Drop legacy release notes check.

This was a placeholder for the GitLab side. Since we no longer bump the MSC version on the GitLab side, this isn't needed anymore.

Our new GitHub workflows run a more advanced set of checks using `uv run msc-scripts publish-release --phase check` (includes a release notes check).

- GitHub Actions job: https://github.com/NVIDIA/multi-storage-client/blob/ab3366290e163c0d041d7ab27d2c0f6dc480fbad/.github/workflows/.source.yml#L218-L247
- Script: https://github.com/NVIDIA/multi-storage-client/blob/ab3366290e163c0d041d7ab27d2c0f6dc480fbad/multi-storage-client-scripts/src/multistorageclient_scripts/cli/publish_release/__init__.py#L80-L217

Relates to NGCDP-7922.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The Beta stage is passing in GitLab CI/CD.
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.
