### PR TITLE
build: Add merge queue trigger to PR workflow.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,6 +6,7 @@
 
 name: Pull Request
 on:
+  merge_group:
   push:
     branches:
       - pull-request/[0-9]+


### PR DESCRIPTION
## Description

Add merge queue trigger to PR workflow.

Merge queue was stalling otherwise.

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#configuring-continuous-integration-ci-workflows-for-merge-queues

Relates to NGCDP-7471.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The Beta stage is passing in GitLab CI/CD.
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.
