### PR TITLE
build: Fix merge queue status check.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,5 +34,5 @@ jobs:
               context: context.workflow,
               sha: context.sha,
               state: ${{ toJSON(needs.*.result) }}.every(status => status == 'success') ? 'success' : 'error',
-              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}?pr=${context.ref.match(/^refs\/heads\/pull-request\/(\d+)$/)[1]}`
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             })


### PR DESCRIPTION
## Description

Fix merge queue status check.

We were trying to populate the `pr={PR ID}` query parameter in the backlink, but it isn't possible to get this data in a `merge_group` event.

https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group

https://docs.github.com/en/webhooks/webhook-events-and-payloads#merge_group

Just drop it entirely since it's just a convenience feature to make a GitHub Actions workflow page link back to the PR that triggered it. This is confusing in its own right because the GitHub Actions workflow for the merge queue doesn't have this backlink when accessed through the UI.

Relates to NGCDP-7471.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The Beta stage is passing in GitLab CI/CD.
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.
