### PR TITLE
chore: Clarify release checklist's CI/CD item.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ _{Relates to/Closes} {Task ID}._
     - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
 - Release PR
   - CI/CD
-    - [ ] The Beta stage is passing in GitLab CI/CD.
+    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
   - `multi-storage-client/pyproject.toml`
     - [ ] The package version has been bumped.
   - `.release_notes/.unreleased.md`


### PR DESCRIPTION
## Description

Clarify release checklist's CI/CD item.

The current checklist item is a bit confusing. Just talk about the state of `main`'s CI/CD pipelines.

Relates to NGCDP-7471.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.
