### PR TITLE
build: Fix GitHub release asset uploads. Make wheel publishing automatic.

### DIFF
--- a/.gitlab/pipelines/.pypi.yml
+++ b/.gitlab/pipelines/.pypi.yml
@@ -59,11 +59,6 @@ default:
 Publish Wheels:
   extends:
     - .default
-  rules:
-    # GitHub creates the draft release + tag simultaneously.
-    #
-    # The release may not be published when GitLab pull mirrors the tag.
-    - when: manual
   script:
     - |
       nix develop --command bash -c "

--- a/multi-storage-client-scripts/src/multistorageclient_scripts/cli/publish_release/__init__.py
+++ b/multi-storage-client-scripts/src/multistorageclient_scripts/cli/publish_release/__init__.py
@@ -225,6 +225,11 @@ def func(arguments: Arguments) -> argparse_extensions.CommandFunction.ExitCode:
         # ----------------------------------------------------------------------------------------------------
 
         github_client = githubkit.GitHub(auth=githubkit.TokenAuthStrategy(token=arguments.github_token))
+        # https://github.com/yanyongyu/githubkit/issues/150#issuecomment-2407032372
+        github_uploads_client = githubkit.GitHub(
+            auth=githubkit.TokenAuthStrategy(token=arguments.github_token),
+            base_url="https://uploads.github.com/",
+        )
 
         # Find existing release + tag (concurrent transaction).
         #
@@ -298,7 +303,7 @@ def func(arguments: Arguments) -> argparse_extensions.CommandFunction.ExitCode:
         # Upload draft release assets.
         for release_asset in release_assets:
             with release_asset.open(mode="rb") as release_asset_stream:
-                upload_release_asset_response = github_client.rest.repos.upload_release_asset(
+                upload_release_asset_response = github_uploads_client.rest.repos.upload_release_asset(
                     owner="NVIDIA",
                     repo="multi-storage-client",
                     release_id=create_release_response.parsed_data.id,


### PR DESCRIPTION
## Description

Fix GitHub release asset uploads. Make wheel publishing automatic.

The release asset upload URL is `uploads.github.com` instead of `api.github.com`.

https://github.com/yanyongyu/githubkit/issues/150#issuecomment-2407032372

GitHub also won't create the tag for a draft release until it's published. This means we don't have to worry about the release not being published when the GitLab-side tag pipeline runs.

Relates to NGCDP-7471.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The Beta stage is passing in GitLab CI/CD.
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.
