### PR TITLE
feat: config-driven partial file caching

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -6,6 +6,8 @@
 
 ### New Features
 
+- Added `cache.prefetch_file` to let `open()` use partial file caching by default when configured.
+
 ### Bug Fixes
 
 ## Multi-Storage File System (MSFS)

--- a/multi-storage-client-docs/src/references/configuration.rst
+++ b/multi-storage-client-docs/src/references/configuration.rst
@@ -970,6 +970,10 @@ Options:
 
   * Use ETag for cache validation, it introduces a small overhead by checking the Etag agains the remote object on every read (optional, default: ``true``)
 
+* ``prefetch_file``
+
+  * Controls the default behavior for ``open()`` when caching is enabled. When ``true``, ``open()`` downloads and caches the full file before reads. When ``false``, binary ``open()`` reads use partial file caching and download chunks on demand. Explicit ``open(..., prefetch_file=...)`` arguments override this config value (optional, default: ``true``)
+
 * ``eviction_policy``: Cache eviction policy configuration (optional, default policy is ``"fifo"``)
 
   * ``policy``: Eviction policy type
@@ -995,6 +999,15 @@ Options:
    cache:
      size: 500G
      location: /path/to/msc_cache
+
+.. code-block:: yaml
+   :caption: Example configuration to make open() use partial file caching by default.
+
+   cache:
+     size: 500G
+     location: /path/to/msc_cache
+     cache_line_size: 64M
+     prefetch_file: false
 
 .. code-block:: yaml
    :caption: Example configuration to configure cache eviction policy.

--- a/multi-storage-client-docs/src/user_guide/cache.rst
+++ b/multi-storage-client-docs/src/user_guide/cache.rst
@@ -69,6 +69,7 @@ The ``cache_line_size`` parameter controls the size of each chunk. This should b
      location: /path/to/msc_cache
      cache_line_size: 64M    # 64MB chunks
      check_source_version: true
+     prefetch_file: false    # use partial file caching instead of full-file caching
 
 **Usage:**
 
@@ -88,7 +89,7 @@ Partial file caching is automatically enabled when using ``client.read()`` with 
    data = client.read("path/to/large_file.bin", 
                      byte_range=Range(offset=1024*1024, size=512*1024))  # 512KB read from 1MB offset
    
-   # For full file access, use client.open() with prefetch_file parameter
+   # For file-like access, disable prefetch explicitly or set cache.prefetch_file: false
    with client.open("path/to/large_file.bin", prefetch_file=False) as f:
        # This will use partial file caching instead of downloading the entire file
        data = f.read(1024*1024)  # Read 1MB
@@ -130,12 +131,21 @@ When using ``SourceVersionCheckMode.INHERIT`` (the default), the cache configura
 
 **Prefetch File Control:**
 
-The ``prefetch_file`` parameter in ``client.open()`` controls whether the entire file is downloaded upfront or uses partial file caching:
+The ``prefetch_file`` parameter in ``client.open()`` controls whether the entire file is downloaded upfront or uses partial file caching. If omitted, ``client.open()`` inherits ``cache.prefetch_file`` from the configuration, which defaults to ``true``.
+
+.. code-block:: yaml
+   :caption: Configuring open() to use partial file caching by default.
+
+   cache:
+     size: 500G
+     location: /path/to/msc_cache
+     cache_line_size: 64M
+     prefetch_file: false
 
 .. code-block:: python
    :caption: Controlling file prefetch behavior.
 
-   # Download entire file upfront (default behavior)
+   # Download entire file upfront (explicit override)
    with client.open("path/to/large_file.bin", prefetch_file=True) as f:
        data = f.read(1024*1024)  # Fast local read after download
    
@@ -150,6 +160,8 @@ The ``prefetch_file`` parameter in ``client.open()`` controls whether the entire
 * **prefetch_file=True** (default): Use when you expect to read most or all of the file. The entire file is downloaded once, then all subsequent reads are served from local cache at maximum speed.
 
 * **prefetch_file=False**: Use for large files where you only need specific portions, or when you want to start processing data immediately without waiting for the full download. This enables partial file caching with chunk-based downloads.
+
+* **cache.prefetch_file=False**: Use when libraries call ``open()`` on your behalf and cannot pass ``prefetch_file=False``. Explicit ``client.open(..., prefetch_file=True)`` still overrides the config for individual calls.
 
 *************************
 Cache Directory Structure

--- a/multi-storage-client/src/multistorageclient/cache.py
+++ b/multi-storage-client/src/multistorageclient/cache.py
@@ -206,6 +206,10 @@ class CacheManager:
         """Check if etag is used in the cache config."""
         return self._cache_config.check_source_version
 
+    def prefetch_file(self) -> bool:
+        """Return whether open() should prefetch full files by default."""
+        return self._cache_config.prefetch_file
+
     def get_max_cache_size(self) -> int:
         """Return the cache size in bytes from the cache config."""
         return self._max_cache_size

--- a/multi-storage-client/src/multistorageclient/caching/cache_config.py
+++ b/multi-storage-client/src/multistorageclient/caching/cache_config.py
@@ -59,6 +59,8 @@ class CacheConfig:
     cache_line_size: str
     #: Use check_source_version(e.g. etag) to update the cached files. Default is True.
     check_source_version: bool = True
+    #: Whether open() prefetches full files by default. False enables partial file caching by default.
+    prefetch_file: bool = True
     #: The location of the cache. Default is tempdir/msc-cache.
     location: Optional[str] = None
     #: Cache eviction policy configuration. Default is LRU with 300s refresh.

--- a/multi-storage-client/src/multistorageclient/client/client.py
+++ b/multi-storage-client/src/multistorageclient/client/client.py
@@ -222,7 +222,7 @@ class StorageClient(AbstractStorageClient):
         atomic: bool = True,
         check_source_version: SourceVersionCheckMode = SourceVersionCheckMode.INHERIT,
         attributes: Optional[dict[str, str]] = None,
-        prefetch_file: bool = True,
+        prefetch_file: Optional[bool] = None,
     ) -> Union[PosixFile, ObjectFile]:
         """
         Open a file for reading or writing.
@@ -241,7 +241,8 @@ class StorageClient(AbstractStorageClient):
         :param attributes: Attributes to add to the file.
             This parameter is only applicable when the mode is "w" or "wb" or "a" or "ab". Defaults to None.
         :param prefetch_file: Whether to prefetch the file content.
-            This parameter is only applicable to ObjectFile when the mode is "r" or "rb". Defaults to True.
+            This parameter is only applicable to ObjectFile when the mode is "r" or "rb".
+            If None, inherits from cache configuration.
         :return: A file-like object (PosixFile or ObjectFile) for the specified path.
         :raises FileNotFoundError: If the file does not exist (read mode).
         :raises NotImplementedError: If the operation is not supported (e.g., write on CompositeStorageClient).

--- a/multi-storage-client/src/multistorageclient/client/composite.py
+++ b/multi-storage-client/src/multistorageclient/client/composite.py
@@ -188,7 +188,7 @@ class CompositeStorageClient(AbstractStorageClient):
         atomic: bool = True,
         check_source_version: SourceVersionCheckMode = SourceVersionCheckMode.INHERIT,
         attributes: Optional[dict[str, str]] = None,
-        prefetch_file: bool = True,
+        prefetch_file: Optional[bool] = None,
     ) -> Union[PosixFile, ObjectFile]:
         """
         Open a file for reading or writing.
@@ -207,7 +207,8 @@ class CompositeStorageClient(AbstractStorageClient):
         :param attributes: Attributes to add to the file.
             This parameter is only applicable when the mode is "w" or "wb" or "a" or "ab". Defaults to None.
         :param prefetch_file: Whether to prefetch the file content.
-            This parameter is only applicable to ObjectFile when the mode is "r" or "rb". Defaults to True.
+            This parameter is only applicable to ObjectFile when the mode is "r" or "rb".
+            If None, inherits from cache configuration.
         :return: A file-like object (PosixFile or ObjectFile) for the specified path.
         :raises FileNotFoundError: If the file does not exist (read mode).
         :raises NotImplementedError: If the operation is not supported (e.g., write on CompositeStorageClient).

--- a/multi-storage-client/src/multistorageclient/client/single.py
+++ b/multi-storage-client/src/multistorageclient/client/single.py
@@ -840,7 +840,7 @@ class SingleStorageClient(AbstractStorageClient):
         atomic: bool = True,
         check_source_version: SourceVersionCheckMode = SourceVersionCheckMode.INHERIT,
         attributes: Optional[dict[str, str]] = None,
-        prefetch_file: bool = True,
+        prefetch_file: Optional[bool] = None,
     ) -> Union[PosixFile, ObjectFile]:
         """
         Open a file for reading or writing.
@@ -859,7 +859,8 @@ class SingleStorageClient(AbstractStorageClient):
         :param attributes: Attributes to add to the file.
             This parameter is only applicable when the mode is "w" or "wb" or "a" or "ab". Defaults to None.
         :param prefetch_file: Whether to prefetch the file content.
-            This parameter is only applicable to ObjectFile when the mode is "r" or "rb". Defaults to True.
+            This parameter is only applicable to ObjectFile when the mode is "r" or "rb".
+            If None, inherits from cache configuration.
         :return: A file-like object (PosixFile or ObjectFile) for the specified path.
         :raises FileNotFoundError: If the file does not exist (read mode).
         """

--- a/multi-storage-client/src/multistorageclient/client/types.py
+++ b/multi-storage-client/src/multistorageclient/client/types.py
@@ -133,7 +133,7 @@ class AbstractStorageClient(ABC):
         atomic: bool = True,
         check_source_version: SourceVersionCheckMode = SourceVersionCheckMode.INHERIT,
         attributes: Optional[dict[str, str]] = None,
-        prefetch_file: bool = True,
+        prefetch_file: Optional[bool] = None,
     ) -> Union[PosixFile, ObjectFile]:
         """
         Open a file for reading or writing.
@@ -152,7 +152,8 @@ class AbstractStorageClient(ABC):
         :param attributes: Attributes to add to the file.
             This parameter is only applicable when the mode is "w" or "wb" or "a" or "ab". Defaults to None.
         :param prefetch_file: Whether to prefetch the file content.
-            This parameter is only applicable to ObjectFile when the mode is "r" or "rb". Defaults to True.
+            This parameter is only applicable to ObjectFile when the mode is "r" or "rb".
+            If None, inherits from cache configuration.
         :return: A file-like object (PosixFile or ObjectFile) for the specified path.
         :raises FileNotFoundError: If the file does not exist (read mode).
         :raises NotImplementedError: If the operation is not supported (e.g., write on CompositeStorageClient).

--- a/multi-storage-client/src/multistorageclient/config.py
+++ b/multi-storage-client/src/multistorageclient/config.py
@@ -1158,6 +1158,7 @@ class StorageClientConfigLoader:
                 size=cache_dict.get("size", DEFAULT_CACHE_SIZE),
                 location=cache_dict.get("location", location),
                 check_source_version=check_source_version,
+                prefetch_file=cache_dict.get("prefetch_file", True),
                 eviction_policy=eviction_policy,
                 cache_line_size=cache_dict.get("cache_line_size", DEFAULT_CACHE_LINE_SIZE),
             )

--- a/multi-storage-client/src/multistorageclient/file.py
+++ b/multi-storage-client/src/multistorageclient/file.py
@@ -213,7 +213,7 @@ class ObjectFile(IOBase, IO):
         memory_load_limit: int = MEMORY_LOAD_LIMIT,
         check_source_version: SourceVersionCheckMode = SourceVersionCheckMode.INHERIT,
         attributes: Optional[dict[str, str]] = None,
-        prefetch_file: bool = True,
+        prefetch_file: Optional[bool] = None,
     ):
         """
         Initialize the ObjectFile instance.
@@ -226,7 +226,7 @@ class ObjectFile(IOBase, IO):
         :param memory_load_limit: Size limit in bytes for loading files into memory. Defaults to 512MB. This parameter is only applicable when the mode is "r" or "rb".
         :param check_source_version: Whether to check the source version of cached objects.
         :param attributes: The attributes to add to the file if a new file is created.
-        :param prefetch_file: If True, downloads the entire file to cache in the background for faster subsequent reads. If False, uses RemoteFileReader for streaming reads without caching. Defaults to True.
+        :param prefetch_file: If True, downloads the entire file to cache in the background for faster subsequent reads. If False, uses RemoteFileReader for streaming reads without caching. If None, inherits from cache configuration.
         """
         if mode not in ("r", "w", "rb", "wb", "a", "ab"):
             raise ValueError(f'Invalid mode "{mode}", only "w", "r", "a", "wb", "rb" and "ab" are supported.')
@@ -242,10 +242,16 @@ class ObjectFile(IOBase, IO):
         self._memory_load_limit = memory_load_limit
         self._open_files = []
         self._check_source_version = check_source_version
-        self._prefetch_file = prefetch_file
 
         if disable_read_cache:
             self._cache_manager = None
+
+        if prefetch_file is not None:
+            self._prefetch_file = prefetch_file
+        elif self._cache_manager:
+            self._prefetch_file = self._cache_manager.prefetch_file()
+        else:
+            self._prefetch_file = True
 
         if self._cache_manager:
             # Use local file as the fileobj
@@ -421,7 +427,12 @@ class ObjectFile(IOBase, IO):
                 f"Failed to open large file {self._remote_path} in text mode; "
                 f'use mode "rb" to open files larger than {self._memory_load_limit}.'
             )
-        self._file = RemoteFileReader(self._remote_path, file_size, self._storage_client)
+        self._file = RemoteFileReader(
+            self._remote_path,
+            file_size,
+            self._storage_client,
+            check_source_version=self._check_source_version,
+        )
         self._download_complete.set()
 
     @property

--- a/multi-storage-client/src/multistorageclient/schema.py
+++ b/multi-storage-client/src/multistorageclient/schema.py
@@ -62,6 +62,7 @@ CACHE_SCHEMA = {
         "location": {"type": "string"},
         "use_etag": {"type": "boolean"},
         "check_source_version": {"type": "boolean"},
+        "prefetch_file": {"type": "boolean"},
         "cache_line_size": {
             "type": "string",
             "pattern": "(?i)^[0-9]+[MGT]$",  # Accepts size with M, G suffix

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_config.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_config.py
@@ -1082,6 +1082,7 @@ def test_cache_config_defaults():
     # Verify default values
     assert config.cache_config.size == "100M"
     assert config.cache_config.check_source_version is True  # Default value
+    assert config.cache_config.prefetch_file is True  # Default value
     assert config.cache_config.eviction_policy.policy == "fifo"  # Default value
     assert config.cache_config.eviction_policy.refresh_interval == 300  # Default value
 
@@ -1975,6 +1976,41 @@ def test_cache_config_check_source_version_false() -> None:
         sc_cfg = StorageClientConfig.from_dict(cfg_dict, profile="p")
         assert sc_cfg.cache_config is not None
         assert sc_cfg.cache_config.check_source_version is False
+
+
+def test_cache_config_prefetch_file_false() -> None:
+    """cache.prefetch_file can disable full-file prefetch by default."""
+
+    with tempfile.TemporaryDirectory() as cache_dir:
+        cfg_dict = _minimal_cache_profile(
+            {
+                "size": "10M",
+                "cache_line_size": "1M",
+                "location": cache_dir,
+                "prefetch_file": False,
+            }
+        )
+
+        sc_cfg = StorageClientConfig.from_dict(cfg_dict, profile="p")
+        assert sc_cfg.cache_config is not None
+        assert sc_cfg.cache_config.prefetch_file is False
+
+
+def test_cache_config_prefetch_file_must_be_boolean() -> None:
+    """cache.prefetch_file rejects non-boolean values."""
+
+    with tempfile.TemporaryDirectory() as cache_dir:
+        cfg_dict = _minimal_cache_profile(
+            {
+                "size": "10M",
+                "cache_line_size": "1M",
+                "location": cache_dir,
+                "prefetch_file": "false",
+            }
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to validate the config file"):
+            StorageClientConfig.from_dict(cfg_dict, profile="p")
 
 
 def test_telemetry_init_manual() -> None:

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_partial_file_caching.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_partial_file_caching.py
@@ -836,6 +836,60 @@ def test_partial_file_caching_3mb_file_1mb_read():
                 pass
 
 
+def test_open_inherits_prefetch_file_false_from_cache_config():
+    """Test that open() uses partial file caching when cache.prefetch_file is false."""
+    with tempdatastore.TemporaryAWSS3Bucket() as origin_store:
+        with tempfile.TemporaryDirectory() as cache_dir:
+            config = create_partial_caching_config(origin_store, cache_location=cache_dir)
+            config["cache"]["prefetch_file"] = False
+
+            client = StorageClient(StorageClientConfig.from_dict(config, profile="origin"))
+
+            test_content = b"X" * (3 * 1024 * 1024)
+            test_file_path = "config_prefetch_false.bin"
+            client.write(test_file_path, test_content)
+
+            with client.open(test_file_path, "rb") as f:
+                data = f.read(1024 * 1024)
+
+            assert data == test_content[: 1024 * 1024]
+
+            origin_dir = os.path.join(cache_dir, "origin")
+            chunk0_path = os.path.join(origin_dir, f".{test_file_path}#chunk0")
+            full_cache_path = os.path.join(origin_dir, test_file_path)
+
+            assert os.path.exists(chunk0_path), "Chunk 0 should be created when prefetch_file is inherited as false"
+            assert os.path.getsize(chunk0_path) == 1024 * 1024
+            assert not os.path.exists(full_cache_path), "Full file should not be cached for partial open reads"
+
+
+def test_open_explicit_prefetch_file_true_overrides_cache_config():
+    """Test that explicit prefetch_file=True overrides cache.prefetch_file=false."""
+    with tempdatastore.TemporaryAWSS3Bucket() as origin_store:
+        with tempfile.TemporaryDirectory() as cache_dir:
+            config = create_partial_caching_config(origin_store, cache_location=cache_dir)
+            config["cache"]["prefetch_file"] = False
+
+            client = StorageClient(StorageClientConfig.from_dict(config, profile="origin"))
+
+            test_content = b"X" * (3 * 1024 * 1024)
+            test_file_path = "explicit_prefetch_true.bin"
+            client.write(test_file_path, test_content)
+
+            with client.open(test_file_path, "rb", prefetch_file=True) as f:
+                data = f.read(1024 * 1024)
+
+            assert data == test_content[: 1024 * 1024]
+
+            origin_dir = os.path.join(cache_dir, "origin")
+            chunk0_path = os.path.join(origin_dir, f".{test_file_path}#chunk0")
+            full_cache_path = os.path.join(origin_dir, test_file_path)
+
+            assert os.path.exists(full_cache_path), "Full file should be cached when explicitly prefetching"
+            assert os.path.getsize(full_cache_path) == len(test_content)
+            assert not os.path.exists(chunk0_path), "Chunk cache should not be used when explicit prefetch wins"
+
+
 def test_chunk_download_lock_file_cleanup():
     """Test that lock files are automatically cleaned up when FileLock context manager exits.
 


### PR DESCRIPTION
## Description

Add config-driven partial file caching for `open()` via `cache.prefetch_file`. This lets binary `open()` download chunks on demand when users cannot pass `prefetch_file=False` directly, while preserving explicit call-site overrides.

Relates to N/A.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The Beta stage is passing in GitLab CI/CD.
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.

## Validation

- [x] `just build`