### PR TITLE
build: Remove tag message condition in GitLab tag pipeline.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ workflow:
       auto_cancel:
         on_new_commit: none
     # Tag push.
-    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_TAG != null && $CI_COMMIT_TAG_MESSAGE =~ /^(latest|backport)$/
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_TAG != null
       when: always
       auto_cancel:
         on_new_commit: none
@@ -48,7 +48,7 @@ include:
   # Tag push.
   - local: .gitlab/pipelines/tag.yml
     rules:
-      - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_TAG != null && $CI_COMMIT_TAG_MESSAGE =~ /^(latest|backport)$/
+      - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_TAG != null
 
 #
 # Jobs.


### PR DESCRIPTION
## Description

Remove tag message condition in GitLab tag pipeline.

Forgot to remove the tag message condition so the tag pipeline didn't run on pull mirror to GitLab.

Relates to NGCDP-7471.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.
