### PR TITLE
build: Fix GitHub Pages publish.

### DIFF
--- a/.github/workflows/.github_pages.yml
+++ b/.github/workflows/.github_pages.yml
@@ -19,8 +19,44 @@ defaults:
   run:
     shell: nix develop --command bash -e {0}
 jobs:
+  multi-storage-client-docs:
+    name: multi-storage-client-docs
+    permissions:
+      contents: read
+    outputs:
+      github_artifact_id: ${{ steps.upload-pages-artifact.outputs.artifact_id }}
+    runs-on: linux-amd64-cpu16
+    steps:
+      # Checkout.
+      - uses: actions/checkout@v6
+        with:
+          ref: refs/tags/${{ inputs.git_tag }}
+      # Build cache.
+      - id: build-cache
+        uses: actions/cache@v5
+        with:
+          key: ${{ github.job }}-${{ hashFiles('flake.lock', 'flake.nix', 'nix/**/*', 'pyproject.toml', 'uv.lock', 'multi-storage-client/**/*', 'multi-storage-client-docs/**/*') }}
+          path: |
+            -
+            multi-storage-client-docs/dist/
+      # Install Nix.
+      - if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
+        uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          summarize: false
+      # Main.
+      - if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
+        working-directory: multi-storage-client-docs
+        run: |
+          just build
+      - id: upload-pages-artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: multi-storage-client-docs/dist/
   publish-documentation:
     name: Publish Documentation
+    needs:
+      - multi-storage-client-docs
     environment:
       name: GitHub Pages
     permissions:
@@ -38,4 +74,4 @@ jobs:
       # Main.
       - working-directory: multi-storage-client-scripts
         run: |
-          uv run msc-scripts publish-documentation --github-token ${{ secrets.GITHUB_TOKEN }} --git-tag ${{ inputs.git_tag }} --phase publish
+          uv run msc-scripts publish-documentation --github-artifact-id ${{ needs.multi-storage-client-docs.outputs.github_artifact_id }} --github-token ${{ github.token }} --git-tag ${{ inputs.git_tag }} --phase publish

--- a/.github/workflows/.production.yml
+++ b/.github/workflows/.production.yml
@@ -40,4 +40,4 @@ jobs:
           merge-multiple: true
       - working-directory: multi-storage-client-scripts
         run: |
-          uv run msc-scripts publish-release --github-token ${{ secrets.GITHUB_TOKEN }} --phase publish
+          uv run msc-scripts publish-release --github-token ${{ github.token }} --phase publish

--- a/multi-storage-client-scripts/pyproject.toml
+++ b/multi-storage-client-scripts/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "multi-storage-client",
     "dulwich>=1.1.0,<2",
     "githubkit>=0.15.3,<1",
-    "id>=1.6.1,<2",
     "packaging>=26.1,<27",
     "pyartifactory>=2.11.2,<3"
 ]

--- a/multi-storage-client-scripts/src/multistorageclient_scripts/cli/publish_documentation/__init__.py
+++ b/multi-storage-client-scripts/src/multistorageclient_scripts/cli/publish_documentation/__init__.py
@@ -24,7 +24,8 @@ from types import FrameType
 from typing import Final, Optional
 
 import githubkit
-import id
+import githubkit.versions.latest.models
+import urllib3
 
 import multistorageclient_scripts.cli as cli
 import multistorageclient_scripts.utils.argparse_extensions as argparse_extensions
@@ -50,6 +51,8 @@ class Arguments(argparse_extensions.Arguments):
     Command arguments.
     """
 
+    #: GitHub artifact ID.
+    github_artifact_id: Final[int]
     #: GitHub token.
     github_token: Final[str]
     #: Git tag of the GitHub release.
@@ -67,6 +70,9 @@ PARSER = cli.SUBPARSERS.add_parser(
 )
 
 
+argparse_extensions.add_argument_partial(parser=PARSER, arguments_type=Arguments, argument_key="github_artifact_id")(
+    help="GitHub artifact ID."
+)
 argparse_extensions.add_argument_partial(parser=PARSER, arguments_type=Arguments, argument_key="github_token")(
     help="GitHub token. For local runs, log in with the GitHub CLI and pass `$(gh auth token)`."
 )
@@ -159,28 +165,75 @@ def func(arguments: Arguments) -> argparse_extensions.CommandFunction.ExitCode:
         logger.info(f"Existing GitHub release for {arguments.git_tag} is not the latest release. Nothing to do.")
         return 0
 
-    # The `id` Python package can fetch GitHub Actions OIDC tokens with retries.
-    #
     # https://docs.github.com/en/actions/reference/security/oidc#methods-for-requesting-the-oidc-token
     # https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-cloud-providers#using-custom-actions
-    #
-    # Use the default audience claim (GitHub repository owner URL) to match `actions/deploy-pages`.
-    #
-    # https://docs.github.com/en/actions/reference/security/oidc#standard-audience-issuer-and-subject-claims
-    oidc_token = id.detect_credential(
-        audience=f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY_OWNER']}"
+    get_oidc_token_response = urllib3.request(
+        method="GET",
+        url=os.environ["ACTIONS_ID_TOKEN_REQUEST_URL"],
+        headers={"Authorization": f"Bearer {os.environ['ACTIONS_ID_TOKEN_REQUEST_TOKEN']}"},
+        timeout=30,
+        retries=urllib3.Retry(),
     )
+    if get_oidc_token_response.status != 200:
+        raise RuntimeError(
+            "Failed to get GitHub Actions OIDC token!",
+            get_oidc_token_response.status,
+            get_oidc_token_response.data.decode(),
+        )
+    oidc_token = get_oidc_token_response.json().get("value")
     if oidc_token is None:
-        raise ValueError("Failed to get GitHub Actions OIDC token!")
+        raise ValueError("GitHub Actions OIDC token is missing from response!")
+    if not isinstance(oidc_token, str):
+        raise ValueError("GitHub Actions OIDC token is not a string!")
 
-    create_pages_deployment_response = github_client.rest.repos.create_pages_deployment(
-        owner="NVIDIA",
-        repo="multi-storage-client",
-        artifact_url=multi_storage_client_docs_archives[0].browser_download_url,
-        environment="GitHub Pages",
-        # publish-release uses a Git commit revision.
-        pages_build_version=get_release_by_tag_response.parsed_data.target_commitish,
-        oidc_token=oidc_token,
+    # create_pages_deployment_response = github_client.rest.repos.create_pages_deployment(
+    #     owner="NVIDIA",
+    #     repo="multi-storage-client",
+    #     # TODO: Upload the documentation archive release asset as a GitHub Actions artifact in this script.
+    #     #
+    #     # GitHub's artifact upload API isn't documented so we have to rely on `actions/upload-pages-artifact` for now.
+    #     #
+    #     # https://github.com/actions/upload-artifact/issues/180#issuecomment-1086306269
+    #     artifact_id=arguments.github_artifact_id,
+    #     environment="GitHub Pages",
+    #     # This must be a Git commit revision.
+    #     #
+    #     # https://github.com/orgs/community/discussions/170184
+    #     # https://github.com/actions/deploy-pages/issues/383
+    #     #
+    #     # publish-release uses a Git commit revision.
+    #     pages_build_version=get_release_by_tag_response.parsed_data.target_commitish,
+    #     oidc_token=oidc_token,
+    # )
+    create_pages_deployment_response = github_client.request(
+        method="POST",
+        url="/repos/NVIDIA/multi-storage-client/pages/deployments",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2026-03-10",
+        },
+        json={
+            # The `artifact_id` parameter is broken on `github_client.rest.repos.create_pages_deployment()`
+            #
+            # This is because GitHub's API model has type `number` which is turned into a Python `float`.
+            #
+            # When serialized, `.0` is appended to the artifact ID which causes the GitHub Pages deployment to get stuck in `deployment_queued`.
+            #
+            # https://github.com/yanyongyu/githubkit/issues/300
+            "artifact_id": arguments.github_artifact_id,
+            "environment": "GitHub Pages",
+            "pages_build_version": get_release_by_tag_response.parsed_data.target_commitish,
+            "oidc_token": oidc_token,
+        },
+        response_model=githubkit.versions.latest.models.PageDeployment,
+    )
+    logger.info(
+        "\n".join(
+            [
+                "Created a GitHub Pages deployment:",
+                pprint.pformat(create_pages_deployment_response.parsed_data.model_dump()),
+            ]
+        )
     )
 
     def cancel_github_pages_deployment() -> None:
@@ -199,11 +252,16 @@ def func(arguments: Arguments) -> argparse_extensions.CommandFunction.ExitCode:
     signal.signal(signalnum=signal.SIGTERM, handler=cancel_github_pages_deployment_signal_handler)
 
     def poll_github_pages_deployment_status():
-        return github_client.rest.repos.get_pages_deployment(
+        get_pages_deployment_response = github_client.rest.repos.get_pages_deployment(
             owner="NVIDIA",
             repo="multi-storage-client",
             pages_deployment_id=create_pages_deployment_response.parsed_data.id,
         )
+        # https://github.com/yanyongyu/githubkit/issues/299
+        logger.info(
+            f"GitHub Pages deployment {create_pages_deployment_response.parsed_data.id} is in {get_pages_deployment_response.json().get('status')} status."
+        )
+        return get_pages_deployment_response
 
     github_pages_deployment_success_statuses = {"succeed"}
     github_pages_deployment_failure_statuses = {
@@ -221,17 +279,19 @@ def func(arguments: Arguments) -> argparse_extensions.CommandFunction.ExitCode:
         get_pages_deployment_response = wait(
             waitable=poll_github_pages_deployment_status,
             should_wait=lambda get_pages_deployment_response: (
-                get_pages_deployment_response.parsed_data.status not in github_pages_deployment_end_statuses
+                get_pages_deployment_response.json().get("status") not in github_pages_deployment_end_statuses
             ),
             # 5 seconds * 120 attempts = 600 seconds (10 minutes).
             attempt_interval_seconds=5,
             max_attempts=120,
         )
-        logger.info(f"GitHub Pages deployment {create_pages_deployment_response.parsed_data.id} finished.")
+        logger.info(
+            f"GitHub Pages deployment {create_pages_deployment_response.parsed_data.id} ended in {get_pages_deployment_response.json().get('status')} status."
+        )
 
-        if get_pages_deployment_response.parsed_data.status not in github_pages_deployment_success_statuses:
+        if get_pages_deployment_response.json().get("status") not in github_pages_deployment_success_statuses:
             raise RuntimeError(
-                f"GitHub Pages deployment failed with status {get_pages_deployment_response.parsed_data.status}!"
+                f"GitHub Pages deployment {create_pages_deployment_response.parsed_data.id} failed with status {get_pages_deployment_response.json().get('status')}!"
             )
     except AssertionError:
         logger.error(

--- a/uv.lock
+++ b/uv.lock
@@ -1358,18 +1358,6 @@ wheels = [
 ]
 
 [[package]]
-name = "id"
-version = "1.6.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/04/c2156091427636080787aac190019dc64096e56a23b7364d3c1764ee3a06/id-1.6.1.tar.gz", hash = "sha256:d0732d624fb46fd4e7bc4e5152f00214450953b9e772c182c1c22964def1a069", size = 18088, upload-time = "2026-02-04T16:19:41.26Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl", hash = "sha256:f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca", size = 14689, upload-time = "2026-02-04T16:19:40.051Z" },
-]
-
-[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -2075,7 +2063,6 @@ source = { editable = "multi-storage-client-scripts" }
 dependencies = [
     { name = "dulwich" },
     { name = "githubkit" },
-    { name = "id" },
     { name = "multi-storage-client" },
     { name = "packaging" },
     { name = "pyartifactory" },
@@ -2085,7 +2072,6 @@ dependencies = [
 requires-dist = [
     { name = "dulwich", specifier = ">=1.1.0,<2" },
     { name = "githubkit", specifier = ">=0.15.3,<1" },
-    { name = "id", specifier = ">=1.6.1,<2" },
     { name = "multi-storage-client", editable = "multi-storage-client" },
     { name = "packaging", specifier = ">=26.1,<27" },
     { name = "pyartifactory", specifier = ">=2.11.2,<3" },


### PR DESCRIPTION
## Description

Fix GitHub Pages publish.

Turns out we can't use a GitHub release asset URL directly for a GitHub Pages deployment. Rather, we must use a GitHub Actions artifact.

Since GitHub hasn't publicly documented the artifact upload API (pending a refactor on GitHub's side), we have to rely on `actions/upload-pages-artifact` instead.

Relates to NGCDP-8022.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a dedicated docs build/upload job and artifact-based deployment to make site publishing more reliable.
  * Updated documentation publishing workflow to consume the produced artifact and coordinate steps via job dependency.
  * Publishing commands now accept an explicit artifact identifier and report deployment status from the service.
  * Token handling changed to a different runtime token source for publishing commands.
  * Removed an unused dependency from the scripts package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->