### PR TITLE
feat: Enable POSIX parallel recursive listing

### DIFF
--- a/multi-storage-client/src/multistorageclient/providers/posix_file.py
+++ b/multi-storage-client/src/multistorageclient/providers/posix_file.py
@@ -256,6 +256,34 @@ class PosixFileStorageProvider(BaseStorageProvider):
 
         return self._translate_errors(_invoke_api, operation="LIST", path=path)
 
+    @property
+    def supports_parallel_listing(self) -> bool:
+        """
+        Whether this provider supports heap-based parallel recursive listing.
+
+        :return: ``True`` for POSIX file storage.
+        """
+        return True
+
+    def _shallow_list(self, path: str, symlink_handling: SymlinkHandling) -> tuple[list[str], list[ObjectMetadata]]:
+        """
+        Adapt POSIX relative listing keys to the full-key contract expected by the recursive listing heap.
+        """
+        prefixes: list[str] = []
+        objects: list[ObjectMetadata] = []
+
+        for item in self._list_objects(path, include_directories=True, symlink_handling=symlink_handling):
+            full_key = self._prepend_base_path(item.key)
+            if item.type == "directory" and item.symlink_target is None:
+                child_prefix = full_key + "/"
+                if child_prefix != path.rstrip("/") + "/":
+                    prefixes.append(child_prefix)
+            else:
+                item.key = full_key
+                objects.append(item)
+
+        return prefixes, objects
+
     def _explore_directory(
         self,
         dir_path: str,

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_parallel_listing.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_parallel_listing.py
@@ -138,7 +138,7 @@ def oci_provider():
         yield OracleStorageProvider(namespace="test-ns", base_path="bucket")
 
 
-PARALLEL_PROVIDERS = ["s3_provider", "s3_provider_rust", "gcs_provider", "azure_provider"]
+PARALLEL_PROVIDERS = ["s3_provider", "s3_provider_rust", "gcs_provider", "azure_provider", "posix_provider"]
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -254,7 +254,7 @@ STRUCTURE_CASES = [
         ("gcs_provider", True),
         ("azure_provider", True),
         ("oci_provider", True),
-        ("posix_provider", False),
+        ("posix_provider", True),
     ],
     ids=["s3", "s3_rust", "gcs", "azure", "oci", "posix"],
 )
@@ -351,15 +351,15 @@ def test_invalid_start_after_end_at_raises(s3_provider):
 
 
 # ---------------------------------------------------------------------------
-# Tests: sequential fallback for non-parallel providers
+# Tests: POSIX uses the parallel listing adapter
 # ---------------------------------------------------------------------------
 
 
-def test_sequential_fallback(posix_provider):
-    """Non-parallel providers bypass the heap algorithm and fall back to _list_objects directly."""
+def test_posix_recursive_listing_uses_shallow_list(posix_provider):
+    """POSIX recursive listing should use the heap algorithm's shallow-list adapter."""
     _create_test_files(posix_provider, {"a": ["f1.txt"], "b": ["f2.txt"]})
 
     with patch.object(type(posix_provider), "_shallow_list", wraps=posix_provider._shallow_list) as spy:
         list(posix_provider.list_objects_recursive(path=""))
 
-    spy.assert_not_called()
+    spy.assert_called()

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_posix_file.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_posix_file.py
@@ -17,11 +17,9 @@
 import glob
 import os
 import tempfile
-import uuid
+from unittest.mock import patch
 
 from multistorageclient.providers.posix_file import PosixFileStorageProvider
-from test_multistorageclient.unit.providers.test_parallel_listing import _build_s3_provider
-from test_multistorageclient.unit.utils import tempdatastore
 
 
 def test_list_objects_with_ascending_order():
@@ -224,33 +222,40 @@ def test_list_objects_with_paths():
         assert len(results) == 0, "Partial path that doesn't exist should return empty results"
 
 
+def test_list_objects_recursive_skips_unreadable_directories():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        ok_dir = os.path.join(temp_dir, "ok")
+        os.makedirs(ok_dir)
+        with open(os.path.join(ok_dir, "a.txt"), "w") as f:
+            f.write("content")
+
+        blocked_dir = os.path.join(temp_dir, "blocked")
+        os.makedirs(blocked_dir)
+        with open(os.path.join(blocked_dir, "hidden.txt"), "w") as f:
+            f.write("hidden")
+
+        original_listdir = os.listdir
+
+        def listdir_with_blocked_dir(path):
+            if os.path.realpath(path.rstrip("/")) == os.path.realpath(blocked_dir):
+                raise PermissionError("blocked")
+            return original_listdir(path)
+
+        provider = PosixFileStorageProvider(base_path=temp_dir)
+        with patch("os.listdir", side_effect=listdir_with_blocked_dir):
+            sequential = [obj.key for obj in provider.list_objects(path="")]
+            recursive = [obj.key for obj in provider.list_objects_recursive(path="")]
+
+        assert sequential == ["ok/a.txt"]
+        assert recursive == ["ok/a.txt"]
+
+
 def test_posix_list_objects_matches_s3_lexicographic_order_when_directory_prefix_collides_with_file():
     """
     Directory ``a/`` and file ``a.txt`` at the same level: S3 ``list_objects_v2`` orders keys by
     raw UTF-8 bytes, so ``a.txt`` (``.``) comes before ``a/b.txt`` (``/``). POSIX must match.
-
-    The test first uploads the same layout to a temporary S3 bucket (versitygw, same as other
-    provider integration tests), lists with ``list_objects``, and uses that order as the
-    reference. It then checks POSIX against that same relative key order.
-
-    Bug: ``_explore_directory`` sorts the bare directory name ``a`` before ``a.txt``, then walks
-    ``a`` first, so POSIX yields ``a/b.txt`` then ``a.txt`` instead of the S3 order.
     """
     expected_relative_order = ["a.txt", "a/b.txt"]
-    list_prefix = f"list_order_prefix_collision/{uuid.uuid4().hex}/"
-
-    with tempdatastore.TemporaryAWSS3Bucket(enable_rust_client=False) as bucket:
-        s3 = _build_s3_provider(bucket, enable_rust=False)
-        s3.put_object(list_prefix + "a/b.txt", b"")
-        s3.put_object(list_prefix + "a.txt", b"")
-        s3_relative_keys = [
-            obj.key.removeprefix(list_prefix) for obj in s3.list_objects(path=list_prefix) if obj.type == "file"
-        ]
-
-    assert s3_relative_keys == expected_relative_order, (
-        "S3 list_objects reference (upload nested key first): expect API lexicographic order; "
-        f"got {s3_relative_keys!r}, want {expected_relative_order!r}"
-    )
 
     with tempfile.TemporaryDirectory() as temp_dir:
         os.makedirs(os.path.join(temp_dir, "a"))
@@ -259,8 +264,13 @@ def test_posix_list_objects_matches_s3_lexicographic_order_when_directory_prefix
 
         provider = PosixFileStorageProvider(base_path=temp_dir)
         posix_keys = [obj.key for obj in provider.list_objects(path="")]
+        recursive_keys = [obj.key for obj in provider.list_objects_recursive(path="")]
 
-    assert posix_keys == s3_relative_keys, (
+    assert posix_keys == expected_relative_order, (
         "POSIX list_objects must match S3 list_objects for the same tree layout (relative keys); "
-        f"posix={posix_keys!r}, s3={s3_relative_keys!r}"
+        f"posix={posix_keys!r}, expected={expected_relative_order!r}"
+    )
+    assert recursive_keys == expected_relative_order, (
+        "POSIX list_objects_recursive must match S3 list_objects for the same tree layout (relative keys); "
+        f"posix={recursive_keys!r}, expected={expected_relative_order!r}"
     )

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_symlinks.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_symlinks.py
@@ -410,6 +410,43 @@ def test_list_symlinks_from_posix_with_preserve(temp_data_store_type: type[tempd
 
 
 @pytest.mark.parametrize(
+    argnames=["temp_data_store_type", "symlink_handling"],
+    argvalues=[
+        [tempdatastore.TemporaryPOSIXDirectory, SymlinkHandling.FOLLOW],
+        [tempdatastore.TemporaryPOSIXDirectory, SymlinkHandling.SKIP],
+        [tempdatastore.TemporaryPOSIXDirectory, SymlinkHandling.PRESERVE],
+    ],
+)
+def test_list_recursive_symlinks_from_posix_matches_list(
+    temp_data_store_type: type[tempdatastore.TemporaryDataStore],
+    symlink_handling: SymlinkHandling,
+):
+    with temp_data_store_type() as temp_data_store:
+        storage_client = _build_posix_storage_client_with_symlink_tree(temp_data_store)
+
+        list_objects = list(storage_client.list(prefix="", symlink_handling=symlink_handling))
+        recursive_objects = list(storage_client.list_recursive(path="", symlink_handling=symlink_handling))
+
+        assert [(o.key, o.type, o.symlink_target) for o in recursive_objects] == [
+            (o.key, o.type, o.symlink_target) for o in list_objects
+        ]
+
+
+def _build_posix_storage_client_for_preserve_error(
+    temp_data_store: tempdatastore.TemporaryDataStore,
+) -> tuple[StorageClient, str]:
+    profile = "data"
+    profile_config = temp_data_store.profile_config_dict()
+    base_path = os.path.realpath(profile_config["storage_provider"]["options"]["base_path"])
+    profile_config["storage_provider"]["options"]["base_path"] = base_path
+    config_dict = {"profiles": {profile: profile_config}}
+    storage_client = StorageClient(config=StorageClientConfig.from_dict(config_dict=config_dict, profile=profile))
+
+    storage_client.write(path="c.txt", body=b"c content")
+    return storage_client, base_path
+
+
+@pytest.mark.parametrize(
     argnames=["temp_data_store_type"],
     argvalues=[[tempdatastore.TemporaryPOSIXDirectory]],
 )
@@ -439,14 +476,7 @@ def test_list_symlinks_from_posix_with_preserve_raises_on_external_target(
     external symlinks end up on a real POSIX tree.
     """
     with temp_data_store_type() as temp_data_store:
-        profile = "data"
-        profile_config = temp_data_store.profile_config_dict()
-        base_path = os.path.realpath(profile_config["storage_provider"]["options"]["base_path"])
-        profile_config["storage_provider"]["options"]["base_path"] = base_path
-        config_dict = {"profiles": {profile: profile_config}}
-        storage_client = StorageClient(config=StorageClientConfig.from_dict(config_dict=config_dict, profile=profile))
-
-        storage_client.write(path="c.txt", body=b"c content")
+        storage_client, base_path = _build_posix_storage_client_for_preserve_error(temp_data_store)
 
         with tempfile.TemporaryDirectory() as outside_dir:
             outside_file = os.path.join(os.path.realpath(outside_dir), "outside.txt")
@@ -457,6 +487,27 @@ def test_list_symlinks_from_posix_with_preserve_raises_on_external_target(
 
             with pytest.raises(ValueError, match="points outside the base directory"):
                 list(storage_client.list(prefix="", symlink_handling=SymlinkHandling.PRESERVE))
+
+
+@pytest.mark.parametrize(
+    argnames=["temp_data_store_type"],
+    argvalues=[[tempdatastore.TemporaryPOSIXDirectory]],
+)
+def test_list_recursive_symlinks_from_posix_with_preserve_raises_on_external_target(
+    temp_data_store_type: type[tempdatastore.TemporaryDataStore],
+):
+    with temp_data_store_type() as temp_data_store:
+        storage_client, base_path = _build_posix_storage_client_for_preserve_error(temp_data_store)
+
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_file = os.path.join(os.path.realpath(outside_dir), "outside.txt")
+            with open(outside_file, "wb") as f:
+                f.write(b"outside content")
+
+            os.symlink(outside_file, os.path.join(base_path, "escaping"))
+
+            with pytest.raises(ValueError, match="points outside the base directory"):
+                list(storage_client.list_recursive(path="", symlink_handling=SymlinkHandling.PRESERVE))
 
 
 @pytest.mark.parametrize(
@@ -482,19 +533,28 @@ def test_list_symlinks_from_posix_with_preserve_raises_on_broken_target(
         └── dangling   -> missing.txt   (target does not exist)
     """
     with temp_data_store_type() as temp_data_store:
-        profile = "data"
-        profile_config = temp_data_store.profile_config_dict()
-        base_path = os.path.realpath(profile_config["storage_provider"]["options"]["base_path"])
-        profile_config["storage_provider"]["options"]["base_path"] = base_path
-        config_dict = {"profiles": {profile: profile_config}}
-        storage_client = StorageClient(config=StorageClientConfig.from_dict(config_dict=config_dict, profile=profile))
-
-        storage_client.write(path="c.txt", body=b"c content")
+        storage_client, base_path = _build_posix_storage_client_for_preserve_error(temp_data_store)
 
         os.symlink(os.path.join(base_path, "missing.txt"), os.path.join(base_path, "dangling"))
 
         with pytest.raises(ValueError, match="Broken symlink"):
             list(storage_client.list(prefix="", symlink_handling=SymlinkHandling.PRESERVE))
+
+
+@pytest.mark.parametrize(
+    argnames=["temp_data_store_type"],
+    argvalues=[[tempdatastore.TemporaryPOSIXDirectory]],
+)
+def test_list_recursive_symlinks_from_posix_with_preserve_raises_on_broken_target(
+    temp_data_store_type: type[tempdatastore.TemporaryDataStore],
+):
+    with temp_data_store_type() as temp_data_store:
+        storage_client, base_path = _build_posix_storage_client_for_preserve_error(temp_data_store)
+
+        os.symlink(os.path.join(base_path, "missing.txt"), os.path.join(base_path, "dangling"))
+
+        with pytest.raises(ValueError, match="Broken symlink"):
+            list(storage_client.list_recursive(path="", symlink_handling=SymlinkHandling.PRESERVE))
 
 
 @pytest.mark.serial


### PR DESCRIPTION
## Summary
- Enable POSIX storage to use the existing heap-based parallel recursive listing path.
- Add a POSIX shallow-list adapter that preserves ordering, symlink behavior, and skip-and-log handling for unreadable filesystem entries.
- Add POSIX recursive listing tests, symlink regression coverage, and a short docs note.

## Validation
- uv run pytest multi-storage-client/tests/test_multistorageclient/unit/providers/test_posix_file.py multi-storage-client/tests/test_multistorageclient/unit/providers/test_symlinks.py multi-storage-client/tests/test_multistorageclient/unit/providers/test_parallel_listing.py -q
- nix develop --command just multi-storage-client/analyze
- nix develop --command just multi-storage-client-docs/build
- Local /tmp large-tree stress check covering broad, wide, deep, bounds, symlink, unreadable-directory, and invalid-symlink cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * POSIX file storage provider now supports parallel listing for improved performance.

* **Bug Fixes**
  * Improved error handling for permission-denied scenarios during directory traversal.
  * Enhanced consistency in symlink handling across recursive and non-recursive listing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->