### PR TITLE
chore: Remove GitHub API model bug workarounds.

### DIFF
--- a/multi-storage-client-scripts/pyproject.toml
+++ b/multi-storage-client-scripts/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 dependencies = [
     "multi-storage-client",
     "dulwich>=1.1.0,<2",
-    "githubkit>=0.15.3,<1",
+    "githubkit>=0.15.5,<1",
     "packaging>=26.1,<27",
     "pyartifactory>=2.11.2,<3"
 ]

--- a/multi-storage-client-scripts/src/multistorageclient_scripts/cli/publish_documentation/__init__.py
+++ b/multi-storage-client-scripts/src/multistorageclient_scripts/cli/publish_documentation/__init__.py
@@ -186,46 +186,24 @@ def func(arguments: Arguments) -> argparse_extensions.CommandFunction.ExitCode:
     if not isinstance(oidc_token, str):
         raise ValueError("GitHub Actions OIDC token is not a string!")
 
-    # create_pages_deployment_response = github_client.rest.repos.create_pages_deployment(
-    #     owner="NVIDIA",
-    #     repo="multi-storage-client",
-    #     # TODO: Upload the documentation archive release asset as a GitHub Actions artifact in this script.
-    #     #
-    #     # GitHub's artifact upload API isn't documented so we have to rely on `actions/upload-pages-artifact` for now.
-    #     #
-    #     # https://github.com/actions/upload-artifact/issues/180#issuecomment-1086306269
-    #     artifact_id=arguments.github_artifact_id,
-    #     environment="GitHub Pages",
-    #     # This must be a Git commit revision.
-    #     #
-    #     # https://github.com/orgs/community/discussions/170184
-    #     # https://github.com/actions/deploy-pages/issues/383
-    #     #
-    #     # publish-release uses a Git commit revision.
-    #     pages_build_version=get_release_by_tag_response.parsed_data.target_commitish,
-    #     oidc_token=oidc_token,
-    # )
-    create_pages_deployment_response = github_client.request(
-        method="POST",
-        url="/repos/NVIDIA/multi-storage-client/pages/deployments",
-        headers={
-            "Accept": "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2026-03-10",
-        },
-        json={
-            # The `artifact_id` parameter is broken on `github_client.rest.repos.create_pages_deployment()`
-            #
-            # This is because GitHub's API model has type `number` which is turned into a Python `float`.
-            #
-            # When serialized, `.0` is appended to the artifact ID which causes the GitHub Pages deployment to get stuck in `deployment_queued`.
-            #
-            # https://github.com/yanyongyu/githubkit/issues/300
-            "artifact_id": arguments.github_artifact_id,
-            "environment": "GitHub Pages",
-            "pages_build_version": get_release_by_tag_response.parsed_data.target_commitish,
-            "oidc_token": oidc_token,
-        },
-        response_model=githubkit.versions.latest.models.PageDeployment,
+    create_pages_deployment_response = github_client.rest.repos.create_pages_deployment(
+        owner="NVIDIA",
+        repo="multi-storage-client",
+        # TODO: Upload the documentation archive release asset as a GitHub Actions artifact in this script.
+        #
+        # GitHub's artifact upload API isn't documented so we have to rely on `actions/upload-pages-artifact` for now.
+        #
+        # https://github.com/actions/upload-artifact/issues/180#issuecomment-1086306269
+        artifact_id=arguments.github_artifact_id,
+        environment="GitHub Pages",
+        # This must be a Git commit revision.
+        #
+        # https://github.com/orgs/community/discussions/170184
+        # https://github.com/actions/deploy-pages/issues/383
+        #
+        # publish-release uses a Git commit revision for the release's target commitish.
+        pages_build_version=get_release_by_tag_response.parsed_data.target_commitish,
+        oidc_token=oidc_token,
     )
     logger.info(
         "\n".join(
@@ -257,9 +235,8 @@ def func(arguments: Arguments) -> argparse_extensions.CommandFunction.ExitCode:
             repo="multi-storage-client",
             pages_deployment_id=create_pages_deployment_response.parsed_data.id,
         )
-        # https://github.com/yanyongyu/githubkit/issues/299
         logger.info(
-            f"GitHub Pages deployment {create_pages_deployment_response.parsed_data.id} is in {get_pages_deployment_response.json().get('status')} status."
+            f"GitHub Pages deployment {create_pages_deployment_response.parsed_data.id} is in {get_pages_deployment_response.parsed_data.status} status."
         )
         return get_pages_deployment_response
 
@@ -279,19 +256,19 @@ def func(arguments: Arguments) -> argparse_extensions.CommandFunction.ExitCode:
         get_pages_deployment_response = wait(
             waitable=poll_github_pages_deployment_status,
             should_wait=lambda get_pages_deployment_response: (
-                get_pages_deployment_response.json().get("status") not in github_pages_deployment_end_statuses
+                get_pages_deployment_response.parsed_data.status not in github_pages_deployment_end_statuses
             ),
             # 5 seconds * 120 attempts = 600 seconds (10 minutes).
             attempt_interval_seconds=5,
             max_attempts=120,
         )
         logger.info(
-            f"GitHub Pages deployment {create_pages_deployment_response.parsed_data.id} ended in {get_pages_deployment_response.json().get('status')} status."
+            f"GitHub Pages deployment {create_pages_deployment_response.parsed_data.id} ended in {get_pages_deployment_response.parsed_data.status} status."
         )
 
-        if get_pages_deployment_response.json().get("status") not in github_pages_deployment_success_statuses:
+        if get_pages_deployment_response.parsed_data.status not in github_pages_deployment_success_statuses:
             raise RuntimeError(
-                f"GitHub Pages deployment {create_pages_deployment_response.parsed_data.id} failed with status {get_pages_deployment_response.json().get('status')}!"
+                f"GitHub Pages deployment {create_pages_deployment_response.parsed_data.id} failed with status {get_pages_deployment_response.parsed_data.status}!"
             )
     except AssertionError:
         logger.error(

--- a/uv.lock
+++ b/uv.lock
@@ -1004,7 +1004,7 @@ wheels = [
 
 [[package]]
 name = "githubkit"
-version = "0.15.3"
+version = "0.15.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1013,9 +1013,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/34/371114facd4562abba2028c411863c33b1efd7958b6d430fc879bb1b574f/githubkit-0.15.3.tar.gz", hash = "sha256:85da32c1ce9a0d09ec70cae320564a6900ca5c3c96483c4cffece5b2140e8e62", size = 5511518, upload-time = "2026-04-11T06:55:10.114Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/ac/857b78d82bf95a91413322614d6751db2f55ab214b24239f31729d8821e6/githubkit-0.15.5.tar.gz", hash = "sha256:5ee487b77d3f4332c73fe5dbc69f932d8012ff0bb1aa9c544c238aef74ef1ae0", size = 5550333, upload-time = "2026-05-01T08:57:12.016Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/aa/65494bf3fc4a66dd91b1614e4d068dae97addbf3ebab30f6e7f8cc631a3a/githubkit-0.15.3-py3-none-any.whl", hash = "sha256:1711db646d993a7ec533c489f60f32653bccad0c1196a1ce785afedf67c401f0", size = 13511252, upload-time = "2026-04-11T06:55:13.562Z" },
+    { url = "https://files.pythonhosted.org/packages/76/ed/d08de6b425a6cce4554ea70a559e03d545058881b5b1d2d0a193d886d3a8/githubkit-0.15.5-py3-none-any.whl", hash = "sha256:69934fdce7e4f197f24d85ea91d808ef245f4463bb982e4c19ac32d827bc7a40", size = 13436716, upload-time = "2026-05-01T08:57:07.644Z" },
 ]
 
 [[package]]
@@ -2071,7 +2071,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "dulwich", specifier = ">=1.1.0,<2" },
-    { name = "githubkit", specifier = ">=0.15.3,<1" },
+    { name = "githubkit", specifier = ">=0.15.5,<1" },
     { name = "multi-storage-client", editable = "multi-storage-client" },
     { name = "packaging", specifier = ">=26.1,<27" },
     { name = "pyartifactory", specifier = ">=2.11.2,<3" },


### PR DESCRIPTION
## Description

Remove GitHub API model bug workarounds.

GitHub has several bugs in their API models which manifest in clients that are auto-generated from them. githubkit's maintainer was very quick to patch in fixes so we no longer need our workarounds.

Relates to NGCDP-8022.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `githubkit` dependency to version 0.15.5 or higher.

* **Refactor**
  * Enhanced GitHub Pages deployment process with improved code structure and type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->