### PR TITLE
chore: Remove legacy publishing dependencies from the Nix shell.

### DIFF
--- a/.github/workflows/.pypi.yml
+++ b/.github/workflows/.pypi.yml
@@ -38,4 +38,4 @@ jobs:
       - working-directory: multi-storage-client-scripts
         run: |
           just get-publish-credentials
-          uv run msc-scripts publish-wheels --github-token ${{ secrets.GITHUB_TOKEN }} --kitmaker-token TODO --git-tag ${{ inputs.git_tag }} --phase publish
+          uv run msc-scripts publish-wheels --github-token ${{ github.token }} --kitmaker-token TODO --git-tag ${{ inputs.git_tag }} --phase publish

--- a/nix/overlays/development/multi-storage-client/devShells/default.nix
+++ b/nix/overlays/development/multi-storage-client/devShells/default.nix
@@ -8,7 +8,6 @@
   dpkg,
   fake-gcs-server,
   gettext,
-  gh,
   git,
   git-lfs,
   gnused,
@@ -17,7 +16,6 @@
   google-cloud-sdk,
   golangci-lint,
   grafana,
-  jfrog-cli,
   jq,
   just,
   lib,
@@ -30,7 +28,6 @@
   nixfmt,
   nodejs-slim,
   openbao,
-  openssh,
   openssl,
   pyright,
   python310,
@@ -130,12 +127,6 @@ mkShell {
     google-cloud-sdk
     # OpenSSL.
     openssl
-    # JFrog CLI.
-    jfrog-cli
-    # OpenSSH.
-    openssh
-    # GitHub CLI.
-    gh
   ];
 
   shellHook =


### PR DESCRIPTION
## Description

Remove legacy publishing dependencies from the Nix shell.

We've replaced our Bash spaghetti with `multi-storage-client-scripts`.

If someone would like these tools back, please install them user-wide or system-wide instead (e.g. `nix profile add nixpkgs#gh` or `brew install gh`).

Relates to NGCDP-7471.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow authentication mechanism for wheel publishing process.
  * Streamlined development environment configuration by removing unused CLI tools from development shell setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->