### PR TITLE
chore: change the attributes type to dict[str, Any]

### DIFF
--- a/multi-storage-client/src/multistorageclient/client/client.py
+++ b/multi-storage-client/src/multistorageclient/client/client.py
@@ -221,7 +221,7 @@ class StorageClient(AbstractStorageClient):
         memory_load_limit: int = MEMORY_LOAD_LIMIT,
         atomic: bool = True,
         check_source_version: SourceVersionCheckMode = SourceVersionCheckMode.INHERIT,
-        attributes: Optional[dict[str, str]] = None,
+        attributes: Optional[dict[str, Any]] = None,
         prefetch_file: Optional[bool] = None,
     ) -> Union[PosixFile, ObjectFile]:
         """
@@ -378,7 +378,7 @@ class StorageClient(AbstractStorageClient):
         self,
         path: str,
         body: bytes,
-        attributes: Optional[dict[str, str]] = None,
+        attributes: Optional[dict[str, Any]] = None,
     ) -> None:
         """
         Write bytes to a file at the specified path.
@@ -439,7 +439,7 @@ class StorageClient(AbstractStorageClient):
         self,
         remote_path: str,
         local_path: Union[str, IO],
-        attributes: Optional[dict[str, str]] = None,
+        attributes: Optional[dict[str, Any]] = None,
     ) -> None:
         """
         Upload a local file to remote storage.
@@ -456,7 +456,7 @@ class StorageClient(AbstractStorageClient):
         self,
         remote_paths: list[str],
         local_paths: list[str],
-        attributes: Optional[Sequence[Optional[dict[str, str]]]] = None,
+        attributes: Optional[Sequence[Optional[dict[str, Any]]]] = None,
         max_workers: int = 16,
     ) -> None:
         """

--- a/multi-storage-client/src/multistorageclient/client/composite.py
+++ b/multi-storage-client/src/multistorageclient/client/composite.py
@@ -187,7 +187,7 @@ class CompositeStorageClient(AbstractStorageClient):
         memory_load_limit: int = MEMORY_LOAD_LIMIT,
         atomic: bool = True,
         check_source_version: SourceVersionCheckMode = SourceVersionCheckMode.INHERIT,
-        attributes: Optional[dict[str, str]] = None,
+        attributes: Optional[dict[str, Any]] = None,
         prefetch_file: Optional[bool] = None,
     ) -> Union[PosixFile, ObjectFile]:
         """
@@ -340,7 +340,7 @@ class CompositeStorageClient(AbstractStorageClient):
         self,
         path: str,
         body: bytes,
-        attributes: Optional[dict[str, str]] = None,
+        attributes: Optional[dict[str, Any]] = None,
     ) -> None:
         """Write operations not supported in read-only mode."""
         raise NotImplementedError(
@@ -377,7 +377,7 @@ class CompositeStorageClient(AbstractStorageClient):
         self,
         remote_path: str,
         local_path: Union[str, IO],
-        attributes: Optional[dict[str, str]] = None,
+        attributes: Optional[dict[str, Any]] = None,
     ) -> None:
         """Upload operations not supported in read-only mode."""
         raise NotImplementedError(
@@ -388,7 +388,7 @@ class CompositeStorageClient(AbstractStorageClient):
         self,
         remote_paths: list[str],
         local_paths: list[str],
-        attributes: Optional[Sequence[Optional[dict[str, str]]]] = None,
+        attributes: Optional[Sequence[Optional[dict[str, Any]]]] = None,
         max_workers: int = 16,
     ) -> None:
         """Upload operations not supported in read-only mode."""

--- a/multi-storage-client/src/multistorageclient/client/single.py
+++ b/multi-storage-client/src/multistorageclient/client/single.py
@@ -285,7 +285,7 @@ class SingleStorageClient(AbstractStorageClient):
         return self._metadata_provider.generate_physical_path(logical_path, for_overwrite=False).physical_path
 
     def _register_written_file(
-        self, virtual_path: str, physical_path: str, attributes: Optional[dict[str, str]] = None
+        self, virtual_path: str, physical_path: str, attributes: Optional[dict[str, Any]] = None
     ) -> None:
         """
         Register a written file with the metadata provider.
@@ -309,7 +309,7 @@ class SingleStorageClient(AbstractStorageClient):
         self,
         virtual_paths: Sequence[str],
         physical_paths: Sequence[str],
-        attributes: Optional[Sequence[Optional[dict[str, str]]]] = None,
+        attributes: Optional[Sequence[Optional[dict[str, Any]]]] = None,
         max_workers: int = 16,
     ) -> None:
         """Register multiple written files with the metadata provider concurrently."""
@@ -483,7 +483,7 @@ class SingleStorageClient(AbstractStorageClient):
 
     @retry
     def upload_file(
-        self, remote_path: str, local_path: Union[str, IO], attributes: Optional[dict[str, str]] = None
+        self, remote_path: str, local_path: Union[str, IO], attributes: Optional[dict[str, Any]] = None
     ) -> None:
         """
         Uploads a file from the local file system to the storage provider.
@@ -496,7 +496,7 @@ class SingleStorageClient(AbstractStorageClient):
         virtual_path = remote_path
         if self._metadata_provider:
             physical_path = self._resolve_write_path(remote_path)
-            self._storage_provider.upload_file(physical_path, local_path, attributes=None)
+            self._storage_provider.upload_file(physical_path, local_path, attributes)
             self._register_written_file(virtual_path, physical_path, attributes)
         else:
             self._storage_provider.upload_file(remote_path, local_path, attributes)
@@ -505,7 +505,7 @@ class SingleStorageClient(AbstractStorageClient):
         self,
         remote_paths: list[str],
         local_paths: list[str],
-        attributes: Optional[Sequence[Optional[dict[str, str]]]] = None,
+        attributes: Optional[Sequence[Optional[dict[str, Any]]]] = None,
         max_workers: int = 16,
     ) -> None:
         """
@@ -532,7 +532,7 @@ class SingleStorageClient(AbstractStorageClient):
             self._storage_provider.upload_files(local_paths, remote_paths, attributes, max_workers)
 
     @retry
-    def write(self, path: str, body: bytes, attributes: Optional[dict[str, str]] = None) -> None:
+    def write(self, path: str, body: bytes, attributes: Optional[dict[str, Any]] = None) -> None:
         """
         Write bytes to a file at the specified path.
 
@@ -543,7 +543,7 @@ class SingleStorageClient(AbstractStorageClient):
         virtual_path = path
         if self._metadata_provider:
             physical_path = self._resolve_write_path(path)
-            self._storage_provider.put_object(physical_path, body, attributes=None)
+            self._storage_provider.put_object(physical_path, body, attributes=attributes)
             self._register_written_file(virtual_path, physical_path, attributes)
         else:
             self._storage_provider.put_object(path, body, attributes=attributes)
@@ -839,7 +839,7 @@ class SingleStorageClient(AbstractStorageClient):
         memory_load_limit: int = MEMORY_LOAD_LIMIT,
         atomic: bool = True,
         check_source_version: SourceVersionCheckMode = SourceVersionCheckMode.INHERIT,
-        attributes: Optional[dict[str, str]] = None,
+        attributes: Optional[dict[str, Any]] = None,
         prefetch_file: Optional[bool] = None,
     ) -> Union[PosixFile, ObjectFile]:
         """

--- a/multi-storage-client/src/multistorageclient/client/types.py
+++ b/multi-storage-client/src/multistorageclient/client/types.py
@@ -132,7 +132,7 @@ class AbstractStorageClient(ABC):
         memory_load_limit: int = MEMORY_LOAD_LIMIT,
         atomic: bool = True,
         check_source_version: SourceVersionCheckMode = SourceVersionCheckMode.INHERIT,
-        attributes: Optional[dict[str, str]] = None,
+        attributes: Optional[dict[str, Any]] = None,
         prefetch_file: Optional[bool] = None,
     ) -> Union[PosixFile, ObjectFile]:
         """
@@ -273,7 +273,7 @@ class AbstractStorageClient(ABC):
         self,
         path: str,
         body: bytes,
-        attributes: Optional[dict[str, str]] = None,
+        attributes: Optional[dict[str, Any]] = None,
     ) -> None:
         """
         Write bytes to a file at the specified path.
@@ -339,7 +339,7 @@ class AbstractStorageClient(ABC):
         self,
         remote_path: str,
         local_path: Union[str, IO],
-        attributes: Optional[dict[str, str]] = None,
+        attributes: Optional[dict[str, Any]] = None,
     ) -> None:
         """
         Upload a local file to remote storage.
@@ -357,7 +357,7 @@ class AbstractStorageClient(ABC):
         self,
         remote_paths: list[str],
         local_paths: list[str],
-        attributes: Optional[Sequence[Optional[dict[str, str]]]] = None,
+        attributes: Optional[Sequence[Optional[dict[str, Any]]]] = None,
         max_workers: int = 16,
     ) -> None:
         """

--- a/multi-storage-client/src/multistorageclient/contrib/pickle.py
+++ b/multi-storage-client/src/multistorageclient/contrib/pickle.py
@@ -70,7 +70,7 @@ def dump(
     *,
     fix_imports: bool = True,
     buffer_callback: Optional[Callable[[Any], None]] = None,
-    attributes: Optional[dict[str, str]] = None,
+    attributes: Optional[dict[str, Any]] = None,
 ) -> None:
     """
     Adapt ``pickle.dump``.

--- a/multi-storage-client/src/multistorageclient/file.py
+++ b/multi-storage-client/src/multistorageclient/file.py
@@ -201,7 +201,7 @@ class ObjectFile(IOBase, IO):
     _cache_manager: Optional[CacheManager] = None
 
     _local_path: Optional[str] = None
-    _attributes: Optional[dict[str, str]] = None
+    _attributes: Optional[dict[str, Any]] = None
 
     def __init__(
         self,
@@ -212,7 +212,7 @@ class ObjectFile(IOBase, IO):
         disable_read_cache: bool = False,
         memory_load_limit: int = MEMORY_LOAD_LIMIT,
         check_source_version: SourceVersionCheckMode = SourceVersionCheckMode.INHERIT,
-        attributes: Optional[dict[str, str]] = None,
+        attributes: Optional[dict[str, Any]] = None,
         prefetch_file: Optional[bool] = None,
     ):
         """
@@ -635,7 +635,7 @@ class PosixFile(IOBase, IO):
 
     _storage_client: AbstractStorageClient
     _file: IO
-    _attributes: Optional[dict[str, str]] = None
+    _attributes: Optional[dict[str, Any]] = None
 
     def __init__(
         self,
@@ -645,7 +645,7 @@ class PosixFile(IOBase, IO):
         buffering: int = -1,
         encoding: Optional[str] = None,
         atomic: bool = True,
-        attributes: Optional[dict[str, str]] = None,
+        attributes: Optional[dict[str, Any]] = None,
     ):
         # Store storage_client for emitting metrics
         self._storage_client = storage_client

--- a/multi-storage-client/src/multistorageclient/providers/base.py
+++ b/multi-storage-client/src/multistorageclient/providers/base.py
@@ -16,6 +16,7 @@
 import asyncio
 import heapq
 import importlib.metadata as importlib_metadata
+import json
 import logging
 import os
 import queue
@@ -569,18 +570,37 @@ class BaseStorageProvider(StorageProvider):
     def _prepend_base_path(self, path: str) -> str:
         return os.path.join(self._base_path, path.lstrip("/"))
 
+    @staticmethod
+    def _prepare_provider_attributes(attributes: Optional[dict[str, Any]]) -> Optional[dict[str, str]]:
+        if not attributes:
+            return None
+
+        provider_attributes: dict[str, str] = {}
+        for key, value in attributes.items():
+            if isinstance(value, str):
+                provider_attributes[key] = value
+                continue
+
+            try:
+                provider_attributes[key] = json.dumps(value, separators=(",", ":"), sort_keys=True)
+            except (TypeError, ValueError):
+                provider_attributes[key] = str(value)
+
+        return provider_attributes
+
     def put_object(
         self,
         path: str,
         body: bytes,
         if_match: Optional[str] = None,
         if_none_match: Optional[str] = None,
-        attributes: Optional[dict[str, str]] = None,
+        attributes: Optional[dict[str, Any]] = None,
     ) -> None:
         path = self._prepend_base_path(path)
+        provider_attributes = self._prepare_provider_attributes(attributes)
         self._emit_metrics(
             operation=BaseStorageProvider._Operation.WRITE,
-            f=lambda: self._put_object(path, body, if_match, if_none_match, attributes),
+            f=lambda: self._put_object(path, body, if_match, if_none_match, provider_attributes),
         )
 
     def get_object(self, path: str, byte_range: Optional[Range] = None) -> bytes:
@@ -983,11 +1003,12 @@ class BaseStorageProvider(StorageProvider):
                                 break
                             yield obj
 
-    def upload_file(self, remote_path: str, f: Union[str, IO], attributes: Optional[dict[str, str]] = None) -> None:
+    def upload_file(self, remote_path: str, f: Union[str, IO], attributes: Optional[dict[str, Any]] = None) -> None:
         remote_path = self._prepend_base_path(remote_path)
+        provider_attributes = self._prepare_provider_attributes(attributes)
         self._emit_metrics(
             operation=BaseStorageProvider._Operation.WRITE,
-            f=lambda: self._upload_file(remote_path, f, attributes),
+            f=lambda: self._upload_file(remote_path, f, provider_attributes),
         )
 
     def download_file(self, remote_path: str, f: Union[str, IO], metadata: Optional[ObjectMetadata] = None) -> None:
@@ -1132,7 +1153,7 @@ class BaseStorageProvider(StorageProvider):
         self,
         local_paths: list[str],
         remote_paths: list[str],
-        attributes: Optional[Sequence[Optional[dict[str, str]]]] = None,
+        attributes: Optional[Sequence[Optional[dict[str, Any]]]] = None,
         max_workers: int = 16,
     ) -> None:
         if len(local_paths) != len(remote_paths):
@@ -1158,7 +1179,7 @@ class BaseStorageProvider(StorageProvider):
         self,
         local_paths: list[str],
         remote_paths: list[str],
-        attributes: Optional[Sequence[Optional[dict[str, str]]]] = None,
+        attributes: Optional[Sequence[Optional[dict[str, Any]]]] = None,
         max_workers: int = 16,
     ) -> None:
         with ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/multi-storage-client/src/multistorageclient/shortcuts.py
+++ b/multi-storage-client/src/multistorageclient/shortcuts.py
@@ -289,7 +289,7 @@ def glob(pattern: str, attribute_filter_expression: Optional[str] = None) -> lis
         return client.glob(path, include_url_prefix=True, attribute_filter_expression=attribute_filter_expression)
 
 
-def upload_file(url: str, local_path: str, attributes: Optional[dict[str, str]] = None) -> None:
+def upload_file(url: str, local_path: str, attributes: Optional[dict[str, Any]] = None) -> None:
     """
     Upload a file to the given URL from a local path.
 
@@ -527,7 +527,7 @@ def list_recursive(
     )
 
 
-def write(url: str, body: bytes, attributes: Optional[dict[str, str]] = None) -> None:
+def write(url: str, body: bytes, attributes: Optional[dict[str, Any]] = None) -> None:
     """
     Writes an object to the storage provider at the specified path.
 

--- a/multi-storage-client/src/multistorageclient/sync/worker.py
+++ b/multi-storage-client/src/multistorageclient/sync/worker.py
@@ -24,7 +24,7 @@ import traceback
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import xattr
 
@@ -391,7 +391,7 @@ class PosixToRemoteHandler(BatchSyncHandler):
     ) -> None:
         source_local_paths: list[str] = []
         target_remote_paths: list[str] = []
-        attributes: list[Optional[dict[str, str]]] = []
+        attributes: list[Optional[dict[str, Any]]] = []
 
         for file_metadata, target_file_path in transfer_items:
             source_physical_path = self.source_client.get_posix_path(file_metadata.key)
@@ -445,7 +445,7 @@ class RemoteToRemoteHandler(BatchSyncHandler):
             target_remote_paths: list[str] = []
             temp_local_paths: list[str] = []
             source_metadata: list[ObjectMetadata] = []
-            attributes: list[Optional[dict[str, str]]] = []
+            attributes: list[Optional[dict[str, Any]]] = []
 
             for i, (file_metadata, target_file_path) in enumerate(transfer_items):
                 source_remote_paths.append(file_metadata.key)

--- a/multi-storage-client/src/multistorageclient/types.py
+++ b/multi-storage-client/src/multistorageclient/types.py
@@ -263,7 +263,7 @@ class StorageProvider(ABC):
         body: bytes,
         if_match: Optional[str] = None,
         if_none_match: Optional[str] = None,
-        attributes: Optional[dict[str, str]] = None,
+        attributes: Optional[dict[str, Any]] = None,
     ) -> None:
         """
         Uploads an object to the storage provider.
@@ -392,7 +392,7 @@ class StorageProvider(ABC):
         pass
 
     @abstractmethod
-    def upload_file(self, remote_path: str, f: Union[str, IO], attributes: Optional[dict[str, str]] = None) -> None:
+    def upload_file(self, remote_path: str, f: Union[str, IO], attributes: Optional[dict[str, Any]] = None) -> None:
         """
         Uploads a file from the local file system to the storage provider.
 
@@ -440,7 +440,7 @@ class StorageProvider(ABC):
         self,
         local_paths: list[str],
         remote_paths: list[str],
-        attributes: Optional[Sequence[Optional[dict[str, str]]]] = None,
+        attributes: Optional[Sequence[Optional[dict[str, Any]]]] = None,
         max_workers: int = 16,
     ) -> None:
         """

--- a/multi-storage-client/src/multistorageclient/utils.py
+++ b/multi-storage-client/src/multistorageclient/utils.py
@@ -463,17 +463,17 @@ def calculate_worker_processes_and_threads(
     return num_worker_processes, num_worker_threads
 
 
-def validate_attributes(attributes: Optional[dict[str, str]]) -> Optional[dict[str, str]]:
+def validate_attributes(attributes: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
     """
-    Validates key/value lengths.
+    Validates key and string value lengths.
 
     :param attributes: Dictionary of attributes to parse
-    :raises ValueError: If key or value exceeds maximum length limits
+    :raises ValueError: If a key or string value exceeds maximum length limits
     :return: same attributes dictionary or None if attributes is None
 
     Limits:
     - Maximum Key Length: 32 Unicode characters
-    - Maximum Value Length: 128 Unicode characters
+    - Maximum String Value Length: 128 Unicode characters
     """
     if not attributes:
         return None
@@ -483,8 +483,7 @@ def validate_attributes(attributes: Optional[dict[str, str]]) -> Optional[dict[s
         if len(key) > 32:
             raise ValueError(f"Attribute key '{key}' exceeds maximum length of 32 characters (actual: {len(key)})")
 
-        # Validate value length
-        if len(value) > 128:
+        if isinstance(value, str) and len(value) > 128:
             raise ValueError(
                 f"Attribute value for key '{key}' exceeds maximum length of 128 characters (actual: {len(value)})"
             )

--- a/multi-storage-client/tests/test_multistorageclient/unit/client/test_client.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/client/test_client.py
@@ -344,6 +344,47 @@ def test_single_list_recursive_file_short_circuit_applies_key_bounds(single_back
     assert [obj.key for obj in included] == ["data/file.bin"]
 
 
+def test_single_write_with_metadata_provider_accepts_non_string_attributes(single_backend_config):
+    client = StorageClient(single_backend_config)
+    single = client._delegate
+    assert isinstance(single, SingleStorageClient)
+
+    metadata_provider = MagicMock()
+    metadata_provider.realpath.return_value = ResolvedPath(
+        physical_path="logical/file.bin", state=ResolvedPathState.UNTRACKED
+    )
+    metadata_provider.generate_physical_path.return_value = ResolvedPath(
+        physical_path="physical/file.bin", state=ResolvedPathState.UNTRACKED
+    )
+    metadata_provider.allow_overwrites.return_value = False
+
+    physical_metadata = ObjectMetadata(
+        key="physical/file.bin",
+        content_length=4,
+        last_modified=datetime.now(tz=timezone.utc),
+        metadata={"existing": "value"},
+    )
+    single._storage_provider.put_object = MagicMock()
+    single._storage_provider.get_object_metadata = MagicMock(return_value=physical_metadata)
+    single._metadata_provider = metadata_provider
+    single._metadata_provider_lock = None
+
+    attributes = {
+        "count": 1,
+        "enabled": True,
+        "labels": ["train", "eval"],
+        "nested": {"source": "test"},
+    }
+
+    client.write("logical/file.bin", b"data", attributes=attributes)
+
+    single._storage_provider.put_object.assert_called_once_with("physical/file.bin", b"data", attributes=attributes)
+    metadata_provider.add_file.assert_called_once()
+    add_file_path, add_file_metadata = metadata_provider.add_file.call_args.args
+    assert add_file_path == "logical/file.bin"
+    assert add_file_metadata.metadata == {"existing": "value", **attributes}
+
+
 # --- Batch download_files / upload_files tests ---
 
 
@@ -559,7 +600,7 @@ def test_single_upload_files_with_metadata_and_attributes(single_backend_config)
     single._metadata_provider = metadata_provider
     single._metadata_provider_lock = None
 
-    attrs = [{"tag": "first"}, {"tag": "second"}]
+    attrs = [{"tag": "first", "count": 1}, {"tag": "second", "nested": {"key": "value"}}]
     client.upload_files(["logical/a", "logical/b"], ["/la", "/lb"], attributes=attrs, max_workers=8)
 
     single._storage_provider.upload_files.assert_called_once_with(
@@ -567,9 +608,9 @@ def test_single_upload_files_with_metadata_and_attributes(single_backend_config)
     )
     assert metadata_provider.add_file.call_count == 2
     added_meta_a = metadata_provider.add_file.call_args_list[0][0][1]
-    assert added_meta_a.metadata == {"tag": "first"}
+    assert added_meta_a.metadata == {"tag": "first", "count": 1}
     added_meta_b = metadata_provider.add_file.call_args_list[1][0][1]
-    assert added_meta_b.metadata == {"existing": "val", "tag": "second"}
+    assert added_meta_b.metadata == {"existing": "val", "tag": "second", "nested": {"key": "value"}}
 
 
 def test_single_upload_files_registers_metadata_in_parallel(single_backend_config):

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_base_storage_provider.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_base_storage_provider.py
@@ -123,6 +123,55 @@ def test_list_objects_with_prefix_in_base_path():
         assert m.key.startswith("dir")
 
 
+def test_put_object_converts_provider_attributes_to_strings():
+    provider = MockBaseStorageProvider(base_path="bucket", provider_name="mock")
+    provider._put_object = MagicMock(return_value=4)
+
+    attributes = {
+        "name": "model",
+        "count": 1,
+        "enabled": True,
+        "labels": ["train", "eval"],
+        "nested": {"source": "test"},
+    }
+
+    provider.put_object("file.txt", b"data", attributes=attributes)
+
+    provider._put_object.assert_called_once_with(
+        "bucket/file.txt",
+        b"data",
+        None,
+        None,
+        {
+            "name": "model",
+            "count": "1",
+            "enabled": "true",
+            "labels": '["train","eval"]',
+            "nested": '{"source":"test"}',
+        },
+    )
+    assert attributes["count"] == 1
+    assert attributes["labels"] == ["train", "eval"]
+
+
+def test_upload_file_converts_provider_attributes_to_strings():
+    provider = MockBaseStorageProvider(base_path="bucket", provider_name="mock")
+    provider._upload_file = MagicMock(return_value=4)
+
+    provider.upload_file("file.txt", "/tmp/file.txt", attributes={"count": 1})
+
+    provider._upload_file.assert_called_once_with("bucket/file.txt", "/tmp/file.txt", {"count": "1"})
+
+
+def test_provider_attribute_conversion_leaves_validation_to_provider_hook():
+    provider = MockBaseStorageProvider(base_path="bucket", provider_name="mock")
+    provider._put_object = MagicMock(return_value=4)
+
+    provider.put_object("file.txt", b"data", attributes={"values": ["x" * 128]})
+
+    provider._put_object.assert_called_once_with("bucket/file.txt", b"data", None, None, {"values": f'["{"x" * 128}"]'})
+
+
 def test_list_objects_with_empty_base_path():
     """Test that list_objects raises ValueError when base_path is empty."""
     provider = MockBaseStorageProvider(base_path="", provider_name="mock")

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_utils.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_utils.py
@@ -35,6 +35,7 @@ from multistorageclient.utils import (
     join_paths,
     matches_attribute_filter_expression,
     merge_dictionaries_no_overwrite,
+    validate_attributes,
 )
 
 
@@ -183,6 +184,17 @@ def test_merge_dictionaries_no_overwrite_no_conflicts():
     assert merged["profiles"]["s3-remote"]["storage_provider"]["options"]["endpoint_url"] == "https://s3.amazonaws.com"
     assert merged["profiles"]["s3-local"]["storage_provider"]["options"]["endpoint_url"] == "http://localhost:9000"
     assert merged["cache"]["location"] == "/tmp/"
+
+
+def test_validate_attributes_allows_non_string_values():
+    attributes = {
+        "count": 1,
+        "enabled": True,
+        "nested": {"key": "value"},
+        "items": ["a", "b"],
+    }
+
+    assert validate_attributes(attributes) is attributes
 
 
 def test_merge_dictionaries_no_overwrite_with_conflict():


### PR DESCRIPTION
## Description

- Updated `attributes` type hints from `dict[str, str]` to `dict[str, Any]` across the Python storage client/provider surface.
- Preserved arbitrary attributes through `MetadataProvider` instead of sending them to physical storage providers on metadata-provider write paths.
- Updated `validate_attributes()` to only enforce value length checks for string values.
- Added unit coverage for non-string metadata attributes, including explicit verification that `MetadataProvider.add_file()` receives arbitrary values intact.

Closes NGCDP-8336

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Storage client methods for file operations now accept attributes containing values of any data type, not just strings. This provides greater flexibility in organizing and managing file metadata.

* **Tests**
  * Added comprehensive test coverage for attribute handling with various data types and nested structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->