### PR TITLE
feat: use recursive listing in sync producer

### DIFF
--- a/multi-storage-client-docs/src/user_guide/cli.rst
+++ b/multi-storage-client-docs/src/user_guide/cli.rst
@@ -390,6 +390,9 @@ MSC automatically determines optimal parallelism based on your system's CPU coun
    # Set threads per process (default: max(16, CPU_count/processes))
    $ export MSC_NUM_THREADS_PER_PROCESS=8
 
+   # Disable parallel source/target listing during sync
+   $ export MSC_SYNC_DISABLE_PARALLEL_LISTING=true
+
    # Run sync with custom parallelism
    $ msc sync msc://source-profile/data --target-url msc://target-profile/data
 

--- a/multi-storage-client/src/multistorageclient/client/types.py
+++ b/multi-storage-client/src/multistorageclient/client/types.py
@@ -217,8 +217,9 @@ class AbstractStorageClient(ABC):
         max_workers: int = 32,
         look_ahead: int = 2,
         include_url_prefix: bool = False,
-        follow_symlinks: bool = True,
+        follow_symlinks: Optional[bool] = None,
         patterns: Optional[PatternList] = None,
+        symlink_handling: SymlinkHandling = SymlinkHandling.FOLLOW,
     ) -> Iterator[ObjectMetadata]:
         """
         List files recursively under the specified path.
@@ -229,8 +230,9 @@ class AbstractStorageClient(ABC):
         :param max_workers: Maximum concurrent workers for provider-level recursive listing.
         :param look_ahead: Prefixes to buffer per worker for provider-level recursive listing.
         :param include_url_prefix: Whether to include the URL prefix ``msc://profile`` in the result.
-        :param follow_symlinks: Whether to follow symbolic links. Only applicable for POSIX file storage providers. When ``False``, symlinks are skipped during listing.
+        :param follow_symlinks: **Deprecated.** Use ``symlink_handling`` instead.
         :param patterns: PatternList for include/exclude filtering. If None, all files are included.
+        :param symlink_handling: How to handle symbolic links during listing.
         :return: An iterator over ObjectMetadata for matching files.
         """
         pass

--- a/multi-storage-client/src/multistorageclient/sync/producer.py
+++ b/multi-storage-client/src/multistorageclient/sync/producer.py
@@ -17,7 +17,7 @@ import logging
 import os
 import threading
 from enum import Enum
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Iterator, Optional
 
 from ..constants import DEFAULT_SYNC_BATCH_SIZE
 from ..types import ObjectMetadata, SymlinkHandling
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 
 MIN_BATCH_SIZE = 10
 MAX_BATCH_SIZE = 1000
+MSC_SYNC_DISABLE_PARALLEL_LISTING_ENV = "MSC_SYNC_DISABLE_PARALLEL_LISTING"
 
 # Size bucket thresholds for batching optimization
 SIZE_SMALL_THRESHOLD = 1 * 1024 * 1024  # 1 MB
@@ -195,6 +196,29 @@ class ProducerThread(threading.Thread):
         parts = path.split("/")
         return any(part.startswith(".") for part in parts)
 
+    def _create_listing_iterator(
+        self,
+        client: "AbstractStorageClient",
+        path: str,
+        *,
+        show_attributes: bool = False,
+    ) -> Iterator[ObjectMetadata]:
+        """Create a listing iterator, preferring recursive listing when compatible.
+
+        Falls back to ``list`` when attributes are required or parallel listing is disabled.
+        """
+        if show_attributes or os.getenv(MSC_SYNC_DISABLE_PARALLEL_LISTING_ENV) is not None:
+            return client.list(
+                path=path,
+                show_attributes=show_attributes,
+                symlink_handling=self.symlink_handling,
+            )
+
+        return client.list_recursive(
+            path=path,
+            symlink_handling=self.symlink_handling,
+        )
+
     def _create_source_iterator(self):
         """Create source iterator and enforce preserve_source_attributes policy."""
         if self.source_files is not None:
@@ -213,10 +237,10 @@ class ProducerThread(threading.Thread):
                     continue
             return
 
-        for source_metadata in self.source_client.list(
-            path=self.source_path,
+        for source_metadata in self._create_listing_iterator(
+            self.source_client,
+            self.source_path,
             show_attributes=self.preserve_source_attributes,
-            symlink_handling=self.symlink_handling,
         ):
             if not self.preserve_source_attributes:
                 source_metadata.metadata = None
@@ -230,10 +254,10 @@ class ProducerThread(threading.Thread):
                 self.preserve_source_attributes and getattr(self.target_client, "_metadata_provider", None)
             )
             target_iter = iter(
-                self.target_client.list(
-                    path=self.target_path,
+                self._create_listing_iterator(
+                    self.target_client,
+                    self.target_path,
                     show_attributes=target_show_attributes,
-                    symlink_handling=self.symlink_handling,
                 )
             )
 

--- a/multi-storage-client/src/multistorageclient/utils.py
+++ b/multi-storage-client/src/multistorageclient/utils.py
@@ -644,6 +644,9 @@ class NullStorageClient:
     def list(self, **kwargs: Any) -> Iterator[ObjectMetadata]:
         return iter([])
 
+    def list_recursive(self, **kwargs: Any) -> Iterator[ObjectMetadata]:
+        return iter([])
+
     def commit_metadata(self, prefix: Optional[str] = None) -> None:
         pass
 

--- a/multi-storage-client/tests/test_multistorageclient/unit/sync/test_manager.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/sync/test_manager.py
@@ -31,6 +31,9 @@ class MockStorageClient:
     def list(self, **kwargs):
         raise Exception("No Such Method")
 
+    def list_recursive(self, **kwargs):
+        return self.list(**kwargs)
+
     def commit_metadata(self, prefix: Optional[str] = None) -> None:
         pass
 

--- a/multi-storage-client/tests/test_multistorageclient/unit/sync/test_producer.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/sync/test_producer.py
@@ -23,7 +23,12 @@ import pytest
 
 import multistorageclient as msc
 from multistorageclient.client import StorageClient
-from multistorageclient.sync.producer import MAX_BATCH_SIZE, MIN_BATCH_SIZE, ProducerThread
+from multistorageclient.sync.producer import (
+    MAX_BATCH_SIZE,
+    MIN_BATCH_SIZE,
+    MSC_SYNC_DISABLE_PARALLEL_LISTING_ENV,
+    ProducerThread,
+)
 from multistorageclient.sync.progress_bar import ProgressBar
 from multistorageclient.sync.types import OperationType
 from multistorageclient.types import ObjectMetadata
@@ -52,6 +57,9 @@ class MockStorageClient:
 
     def list(self, **kwargs):
         raise Exception("No Such Method")
+
+    def list_recursive(self, **kwargs):
+        return self.list(**kwargs)
 
     def commit_metadata(self, prefix: Optional[str] = None) -> None:
         pass
@@ -199,7 +207,134 @@ def test_target_listing_requests_attributes_only_when_needed(
     producer_thread.join()
 
     assert producer_thread.error is None
-    assert list_kwargs.get("show_attributes") is expected_show_attributes
+    assert list_kwargs.get("show_attributes", False) is expected_show_attributes
+
+
+def test_listing_uses_list_recursive_by_default():
+    source_client = MockStorageClient()
+    target_client = MockStorageClient()
+
+    source_files = [ObjectMetadata(key="file1.txt", content_length=100, last_modified=datetime(2025, 1, 1, 0, 0, 0))]
+    target_files = [ObjectMetadata(key="file1.txt", content_length=100, last_modified=datetime(2025, 1, 1, 0, 0, 1))]
+    list_recursive_calls = []
+
+    def source_list_recursive(**kwargs):
+        list_recursive_calls.append(("source", kwargs))
+        return iter(source_files)
+
+    def target_list_recursive(**kwargs):
+        list_recursive_calls.append(("target", kwargs))
+        return iter(target_files)
+
+    source_client.list_recursive = source_list_recursive  # type: ignore[attr-defined]
+    target_client.list_recursive = target_list_recursive  # type: ignore[attr-defined]
+
+    producer = ProducerThread(
+        source_client=cast(StorageClient, source_client),
+        source_path="",
+        target_client=cast(StorageClient, target_client),
+        target_path="",
+        progress=ProgressBar(desc="", show_progress=False),
+        file_queue=queue.Queue(),
+        num_workers=1,
+        shutdown_event=threading.Event(),
+    )
+
+    assert list(producer._create_listing_iterator(cast(StorageClient, source_client), "source/")) == source_files
+    assert list(producer._create_listing_iterator(cast(StorageClient, target_client), "target/")) == target_files
+    assert list_recursive_calls == [
+        ("source", {"path": "source/", "symlink_handling": producer.symlink_handling}),
+        ("target", {"path": "target/", "symlink_handling": producer.symlink_handling}),
+    ]
+
+
+def test_listing_uses_list_when_parallel_listing_disabled(monkeypatch):
+    monkeypatch.setenv(MSC_SYNC_DISABLE_PARALLEL_LISTING_ENV, "true")
+    source_client = MockStorageClient()
+    target_client = MockStorageClient()
+
+    source_files = [ObjectMetadata(key="file1.txt", content_length=100, last_modified=datetime(2025, 1, 1, 0, 0, 0))]
+    target_files = [ObjectMetadata(key="file1.txt", content_length=100, last_modified=datetime(2025, 1, 1, 0, 0, 1))]
+    list_calls = []
+
+    def source_list(**kwargs):
+        list_calls.append(("source", kwargs))
+        return iter(source_files)
+
+    def target_list(**kwargs):
+        list_calls.append(("target", kwargs))
+        return iter(target_files)
+
+    def list_recursive(**kwargs):
+        raise AssertionError("list_recursive should not be called")
+
+    source_client.list = source_list  # type: ignore[method-assign]
+    target_client.list = target_list  # type: ignore[method-assign]
+    source_client.list_recursive = list_recursive  # type: ignore[attr-defined]
+    target_client.list_recursive = list_recursive  # type: ignore[attr-defined]
+
+    producer = ProducerThread(
+        source_client=cast(StorageClient, source_client),
+        source_path="",
+        target_client=cast(StorageClient, target_client),
+        target_path="",
+        progress=ProgressBar(desc="", show_progress=False),
+        file_queue=queue.Queue(),
+        num_workers=1,
+        shutdown_event=threading.Event(),
+    )
+
+    assert list(producer._create_listing_iterator(cast(StorageClient, source_client), "source/")) == source_files
+    assert list(producer._create_listing_iterator(cast(StorageClient, target_client), "target/")) == target_files
+    assert list_calls == [
+        ("source", {"path": "source/", "show_attributes": False, "symlink_handling": producer.symlink_handling}),
+        ("target", {"path": "target/", "show_attributes": False, "symlink_handling": producer.symlink_handling}),
+    ]
+
+
+def test_listing_falls_back_to_list_when_attributes_are_requested():
+    source_client = MockStorageClient()
+    target_client = MockStorageClient()
+
+    source_files = [
+        ObjectMetadata(
+            key="file1.txt",
+            content_length=100,
+            last_modified=datetime(2025, 1, 1, 0, 0, 0),
+            metadata={"version": "1"},
+        )
+    ]
+    target_files = [ObjectMetadata(key="file1.txt", content_length=100, last_modified=datetime(2025, 1, 1, 0, 0, 1))]
+    source_list_kwargs = {}
+
+    def source_list(**kwargs):
+        source_list_kwargs.update(kwargs)
+        return iter(source_files)
+
+    def list_recursive(**kwargs):
+        raise AssertionError("source list_recursive should not be called when attributes are requested")
+
+    source_client.list = source_list  # type: ignore[method-assign]
+    source_client.list_recursive = list_recursive  # type: ignore[attr-defined]
+    target_client.list = lambda **kwargs: iter(target_files)  # type: ignore[method-assign]
+
+    producer = ProducerThread(
+        source_client=cast(StorageClient, source_client),
+        source_path="",
+        target_client=cast(StorageClient, target_client),
+        target_path="",
+        progress=ProgressBar(desc="", show_progress=False),
+        file_queue=queue.Queue(),
+        num_workers=1,
+        shutdown_event=threading.Event(),
+        preserve_source_attributes=True,
+    )
+
+    assert (
+        list(producer._create_listing_iterator(cast(StorageClient, source_client), "", show_attributes=True))
+        == source_files
+    )
+    assert source_list_kwargs["show_attributes"] is True
 
 
 def test_batch_size_validation():


### PR DESCRIPTION
## Description

- Use `StorageClient.list_recursive` for sync source and target enumeration when supported.
- Fall back to `StorageClient.list` when attributes are requested or recursive listing is disabled.
- Add `MSC_SYNC_DISABLE_PARALLEL_LISTING` to disable parallel listing during sync.
- Document the new sync listing environment variable.

Closes NGCDP-8338

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MSC_SYNC_DISABLE_PARALLEL_LISTING environment variable to disable parallel listing during sync.

* **Documentation**
  * CLI docs updated with an example showing how to disable parallel listing for msc sync.

* **Behavior Changes**
  * Sync listing now centrally chooses listing mode; attribute-preservation requests force a non-parallel listing mode and the env var overrides parallelism.

* **Tests**
  * Expanded unit tests covering listing selection and parallelism control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->