### PR TITLE
chore: add pytest retry

### DIFF
--- a/multi-storage-client/pyproject.toml
+++ b/multi-storage-client/pyproject.toml
@@ -136,6 +136,7 @@ dev = [
     "pytest-asyncio>=1.3,<2",
     "pytest-cov>=7,<8",
     "pytest-forked>=1.6,<2",
+    "pytest-rerunfailures>=16.1,<17",
     "pytest-stress>=1.0.1,<2",
     "pytest-timeout>=2.4,<3",
     "pytest-xdist[psutil]>=3.8,<4",
@@ -199,6 +200,7 @@ markers = [
 pythonpath = [
     "tests"
 ]
+reruns = 3
 testpaths = [
     "tests/test_multistorageclient/unit",
     "tests/test_multistorageclient_rust/unit"

--- a/uv.lock
+++ b/uv.lock
@@ -1967,6 +1967,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-forked" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-stress" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist", extra = ["psutil"] },
@@ -2029,6 +2030,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3,<2" },
     { name = "pytest-cov", specifier = ">=7,<8" },
     { name = "pytest-forked", specifier = ">=1.6,<2" },
+    { name = "pytest-rerunfailures", specifier = ">=16.1,<17" },
     { name = "pytest-stress", specifier = ">=1.0.1,<2" },
     { name = "pytest-timeout", specifier = ">=2.4,<3" },
     { name = "pytest-xdist", extras = ["psutil"], specifier = ">=3.8,<4" },
@@ -3109,6 +3111,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8c/c9/93ad2ba2413057ee694884b88cf7467a46c50c438977720aeac26e73fdb7/pytest-forked-1.6.0.tar.gz", hash = "sha256:4dafd46a9a600f65d822b8f605133ecf5b3e1941ebb3588e943b4e3eb71a5a3f", size = 9977, upload-time = "2023-02-12T23:22:27.544Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/af/9c0bda43e486a3c9bf1e0f876d0f241bc3f229d7d65d09331a0868db9629/pytest_forked-1.6.0-py3-none-any.whl", hash = "sha256:810958f66a91afb1a1e2ae83089d8dc1cd2437ac96b12963042fbb9fb4d16af0", size = 4897, upload-time = "2023-02-12T23:22:26.022Z" },
+]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/04/71e9520551fc8fe2cf5c1a1842e4e600265b0815f2016b7c27ec85688682/pytest_rerunfailures-16.1.tar.gz", hash = "sha256:c38b266db8a808953ebd71ac25c381cb1981a78ff9340a14bcb9f1b9bff1899e", size = 30889 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/54/60eabb34445e3db3d3d874dc1dfa72751bfec3265bd611cb13c8b290adea/pytest_rerunfailures-16.1-py3-none-any.whl", hash = "sha256:5d11b12c0ca9a1665b5054052fcc1084f8deadd9328962745ef6b04e26382e86", size = 14093 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Retry the failed tests 3 times.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by enabling automatic retries for failed tests. Tests that fail will now be automatically rerun up to 3 times before being marked as failed, reducing flakiness and increasing overall test stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->