### PR TITLE
feat: release 0.48.0

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -6,8 +6,6 @@
 
 ### New Features
 
-- Added `cache.prefetch_file` to let `open()` use partial file caching by default when configured.
-
 ### Bug Fixes
 
 ## Multi-Storage File System (MSFS)

--- a/.release_notes/0.48.0.md
+++ b/.release_notes/0.48.0.md
@@ -1,0 +1,19 @@
+## Multi-Storage Client (MSC)
+
+### New Features
+
+- Added `cache.prefetch_file` to let `open()` use partial file caching by default when configured.
+- Use recursive listing in the sync producer to improve sync planning performance.
+- Enable parallel recursive listing for the POSIX storage provider.
+
+### Bug Fixes
+
+- Allow custom object attributes to use `dict[str, Any]` values across MSC APIs and providers.
+
+## Multi-Storage File System (MSFS)
+
+### New Features
+
+- Adopt `/dev/fuse` multi-reader support for improved FUSE request handling.
+
+### Bug Fixes

--- a/multi-storage-client/pyproject.toml
+++ b/multi-storage-client/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 
 [project]
 name = "multi-storage-client"
-version = "0.47.1"
+version = "0.48.0"
 description = "Unified high-performance Python client for object and file stores."
 authors = [
     { name = "NVIDIA Multi-Storage Client Team" }

--- a/uv.lock
+++ b/uv.lock
@@ -1871,7 +1871,7 @@ wheels = [
 
 [[package]]
 name = "multi-storage-client"
-version = "0.47.1"
+version = "0.48.0"
 source = { editable = "multi-storage-client" }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Description

Release MSC 0.48.0.

## Checklist

- Release PR
  - CI/CD
    - [x] The Beta stage is passing in GitLab CI/CD.
  - `multi-storage-client/pyproject.toml`
    - [x] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [x] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.
