### PR TITLE
fix: add per-item MSC retry for batch transfers

### DIFF
--- a/multi-storage-client-docs/src/references/configuration.rst
+++ b/multi-storage-client-docs/src/references/configuration.rst
@@ -922,6 +922,8 @@ Retry
 
 MSC will retry on errors classified as ``RetryableError`` (see :py:class:`multistorageclient.types.RetryableError`) in addition to the retry logic of the underlying CSP native SDKs.
 
+For batch APIs such as ``StorageClient.upload_files`` and ``StorageClient.download_files``, MSC preserves the storage provider batch operation. If the provider reports item-level failures, MSC retries only the failed items instead of repeating the entire batch.
+
 Options: See parameters in :py:class:`multistorageclient.types.RetryConfig`.
 
 The retry strategy uses exponential backoff: the delay is multiplied by the backoff multiplier raised to the power of the attempt number for each subsequent attempt, and a random jitter of 0 to 1 second is added to the delay.

--- a/multi-storage-client/src/multistorageclient/client/single.py
+++ b/multi-storage-client/src/multistorageclient/client/single.py
@@ -30,7 +30,7 @@ from ..constants import DEFAULT_SYNC_BATCH_SIZE, MEMORY_LOAD_LIMIT
 from ..file import ObjectFile, PosixFile
 from ..providers.posix_file import PosixFileStorageProvider
 from ..replica_manager import ReplicaManager
-from ..retry import retry
+from ..retry import batch_retry, retry
 from ..sync import SyncManager
 from ..types import (
     AWARE_DATETIME_MIN,
@@ -329,6 +329,70 @@ class SingleStorageClient(AbstractStorageClient):
             for future in as_completed(future_to_virtual_path):
                 future.result()
 
+    @batch_retry(operation_name="download_files")
+    def _download_files_batch(
+        self,
+        indices: list[int],
+        remote_paths: Sequence[str],
+        local_paths: list[str],
+        metadata: Optional[Sequence[Optional[ObjectMetadata]]],
+        max_workers: int,
+    ) -> None:
+        """
+        Execute one provider batch download attempt for the selected item indices.
+
+        The ``@batch_retry`` decorator retries this method with only failed
+        indices when the provider reports item-level retryable failures.
+
+        :param indices: Original batch indices to include in this attempt.
+        :param remote_paths: Remote paths for the full original batch.
+        :param local_paths: Local destination paths for the full original batch.
+        :param metadata: Optional per-file metadata for the full original batch.
+        :param max_workers: Maximum provider workers for this attempt.
+        """
+        provider_remote_paths = [remote_paths[index] for index in indices]
+        provider_local_paths = [local_paths[index] for index in indices]
+        provider_metadata = [metadata[index] for index in indices] if metadata is not None else None
+
+        self._storage_provider.download_files(
+            provider_remote_paths,
+            provider_local_paths,
+            provider_metadata,
+            max_workers,
+        )
+
+    @batch_retry(operation_name="upload_files")
+    def _upload_files_batch(
+        self,
+        indices: list[int],
+        local_paths: list[str],
+        remote_paths: Sequence[str],
+        attributes: Optional[Sequence[Optional[dict[str, Any]]]],
+        max_workers: int,
+    ) -> None:
+        """
+        Execute one provider batch upload attempt for the selected item indices.
+
+        The ``@batch_retry`` decorator retries this method with only failed
+        indices when the provider reports item-level retryable failures.
+
+        :param indices: Original batch indices to include in this attempt.
+        :param local_paths: Local source paths for the full original batch.
+        :param remote_paths: Provider destination paths for the full original batch.
+        :param attributes: Optional per-file attributes for the full original batch.
+        :param max_workers: Maximum provider workers for this attempt.
+        """
+        provider_local_paths = [local_paths[index] for index in indices]
+        provider_remote_paths = [remote_paths[index] for index in indices]
+        provider_attributes = [attributes[index] for index in indices] if attributes is not None else None
+
+        self._storage_provider.upload_files(
+            provider_local_paths,
+            provider_remote_paths,
+            provider_attributes,
+            max_workers,
+        )
+
     @retry
     def read(
         self,
@@ -472,14 +536,19 @@ class SingleStorageClient(AbstractStorageClient):
         if len(remote_paths) != len(local_paths):
             raise ValueError("remote_paths and local_paths must have the same length")
 
+        if metadata is not None and len(metadata) != len(remote_paths):
+            raise ValueError("metadata must have the same length as remote_paths and local_paths")
+
         if self._metadata_provider:
             physical_paths = [self._resolve_read_path(rp) for rp in remote_paths]
-            self._storage_provider.download_files(physical_paths, local_paths, metadata, max_workers)
+            self._download_files_batch(
+                list(range(len(remote_paths))), physical_paths, local_paths, metadata, max_workers
+            )
         elif self._replica_manager:
             for remote_path, local_path in zip(remote_paths, local_paths):
                 self.download_file(remote_path, local_path)
         else:
-            self._storage_provider.download_files(remote_paths, local_paths, metadata, max_workers)
+            self._download_files_batch(list(range(len(remote_paths))), remote_paths, local_paths, metadata, max_workers)
 
     @retry
     def upload_file(
@@ -521,15 +590,24 @@ class SingleStorageClient(AbstractStorageClient):
         """
         if len(remote_paths) != len(local_paths):
             raise ValueError("remote_paths and local_paths must have the same length")
+
         if attributes is not None and len(attributes) != len(remote_paths):
             raise ValueError("attributes must have the same length as remote_paths and local_paths")
 
         if self._metadata_provider:
             physical_paths = [self._resolve_write_path(rp) for rp in remote_paths]
-            self._storage_provider.upload_files(local_paths, physical_paths, attributes, max_workers)
+
+            self._upload_files_batch(
+                list(range(len(remote_paths))),
+                local_paths,
+                physical_paths,
+                attributes,
+                max_workers,
+            )
+
             self._register_written_files(remote_paths, physical_paths, attributes, max_workers)
         else:
-            self._storage_provider.upload_files(local_paths, remote_paths, attributes, max_workers)
+            self._upload_files_batch(list(range(len(remote_paths))), local_paths, remote_paths, attributes, max_workers)
 
     @retry
     def write(self, path: str, body: bytes, attributes: Optional[dict[str, Any]] = None) -> None:

--- a/multi-storage-client/src/multistorageclient/providers/base.py
+++ b/multi-storage-client/src/multistorageclient/providers/base.py
@@ -26,7 +26,7 @@ from abc import abstractmethod
 from collections.abc import Callable, Iterator, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from enum import Enum
-from typing import IO, Any, Optional, TypeVar, Union, cast
+from typing import IO, Any, NamedTuple, Optional, TypeVar, Union, cast
 
 import opentelemetry.metrics as api_metrics
 import opentelemetry.util.types as api_types
@@ -34,7 +34,16 @@ import opentelemetry.util.types as api_types
 from ..rust_utils import run_coroutine_sync
 from ..telemetry import Telemetry
 from ..telemetry.attributes.base import AttributesProvider, collect_attributes
-from ..types import MAX_SYMLINK_DEPTH, ObjectMetadata, Range, SignerType, StorageProvider, SymlinkHandling
+from ..types import (
+    MAX_SYMLINK_DEPTH,
+    BatchTransferError,
+    BatchTransferFailure,
+    ObjectMetadata,
+    Range,
+    SignerType,
+    StorageProvider,
+    SymlinkHandling,
+)
 from ..utils import (
     create_attribute_filter_evaluator,
     extract_prefix_from_glob,
@@ -49,6 +58,14 @@ from ..utils import (
 logger = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
+
+
+class _AsyncTransferItem(NamedTuple):
+    item_index: int
+    local_path: str
+    remote_path: str
+    key: str
+    use_multipart: bool
 
 
 _ShallowListResult = tuple[list[str], list[ObjectMetadata]]
@@ -1027,6 +1044,20 @@ class BaseStorageProvider(StorageProvider):
         metadata: Optional[Sequence[Optional[ObjectMetadata]]] = None,
         max_workers: int = 16,
     ) -> None:
+        """
+        Download multiple remote objects to local paths.
+
+        Missing metadata entries are resolved before transfer. When a Rust
+        client is available, downloads run through the async Rust batch path;
+        otherwise each item is downloaded through the threaded Python helper.
+
+        :param remote_paths: Remote object paths to download.
+        :param local_paths: Local destination paths for each remote object.
+        :param metadata: Optional per-object metadata used for multipart decisions.
+        :param max_workers: Maximum number of concurrent download workers.
+        :raises ValueError: If path or metadata lengths differ, or if max_workers is less than 1.
+        :raises BatchTransferError: If one or more item downloads fail.
+        """
         if len(remote_paths) != len(local_paths):
             raise ValueError("remote_paths and local_paths must have the same length")
 
@@ -1084,12 +1115,26 @@ class BaseStorageProvider(StorageProvider):
         max_workers: int,
     ) -> None:
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = [
-                executor.submit(self.download_file, rp, lp, metadata[i])
+            future_to_index = {
+                executor.submit(self.download_file, rp, lp, metadata[i]): i
                 for i, (rp, lp) in enumerate(zip(remote_paths, local_paths))
-            ]
-            for future in as_completed(futures):
-                future.result()
+            }
+            failures: list[BatchTransferFailure] = []
+            for future in as_completed(future_to_index):
+                i = future_to_index[future]
+                try:
+                    future.result()
+                except Exception as e:
+                    failures.append(
+                        BatchTransferFailure(
+                            index=i,
+                            source_path=remote_paths[i],
+                            destination_path=local_paths[i],
+                            error=e,
+                        )
+                    )
+            if failures:
+                raise BatchTransferError(failures)
 
     def _download_files_async(
         self,
@@ -1104,14 +1149,33 @@ class BaseStorageProvider(StorageProvider):
 
         multipart_threshold = self._multipart_threshold
 
-        items: list[tuple[str, str, bool]] = []
+        items: list[_AsyncTransferItem] = []
+        failures: list[BatchTransferFailure] = []
         for i, (remote_path, local_path) in enumerate(zip(remote_paths, local_paths)):
-            full_path = self._prepend_base_path(remote_path)
-            _, key = split_path(full_path)
-            if os.path.dirname(local_path):
-                safe_makedirs(os.path.dirname(local_path))
-            use_multipart = metadata[i].content_length > multipart_threshold
-            items.append((key, local_path, use_multipart))
+            try:
+                full_path = self._prepend_base_path(remote_path)
+                _, key = split_path(full_path)
+                if os.path.dirname(local_path):
+                    safe_makedirs(os.path.dirname(local_path))
+                use_multipart = metadata[i].content_length > multipart_threshold
+                items.append(
+                    _AsyncTransferItem(
+                        item_index=i,
+                        local_path=local_path,
+                        remote_path=remote_path,
+                        key=key,
+                        use_multipart=use_multipart,
+                    )
+                )
+            except Exception as e:
+                failures.append(
+                    BatchTransferFailure(
+                        index=i,
+                        source_path=remote_path,
+                        destination_path=local_path,
+                        error=e,
+                    )
+                )
 
         semaphore = asyncio.Semaphore(max_workers)
 
@@ -1139,13 +1203,22 @@ class BaseStorageProvider(StorageProvider):
 
         async def _download_all() -> None:
             results = await asyncio.gather(
-                *[_download_one(key, lp, mp) for key, lp, mp in items],
+                *[_download_one(item.key, item.local_path, item.use_multipart) for item in items],
                 return_exceptions=True,
             )
-            errors = [r for r in results if isinstance(r, Exception)]
-            if errors:
-                logger.error("download_files: %d/%d downloads failed", len(errors), len(items))
-                raise errors[0]
+            failures.extend(
+                BatchTransferFailure(
+                    index=item.item_index,
+                    source_path=item.remote_path,
+                    destination_path=item.local_path,
+                    error=result,
+                )
+                for result, item in zip(results, items)
+                if isinstance(result, Exception)
+            )
+            if failures:
+                logger.error("download_files: %d/%d downloads failed", len(failures), len(remote_paths))
+                raise BatchTransferError(failures)
 
         run_coroutine_sync(_download_all)
 
@@ -1156,6 +1229,21 @@ class BaseStorageProvider(StorageProvider):
         attributes: Optional[Sequence[Optional[dict[str, Any]]]] = None,
         max_workers: int = 16,
     ) -> None:
+        """
+        Upload multiple local files to remote object paths.
+
+        Uploads use the async Rust batch path when available and no per-file
+        attributes are provided; otherwise each item is uploaded through the
+        threaded Python helper.
+
+        :param local_paths: Local source file paths to upload.
+        :param remote_paths: Remote destination object paths for each local file.
+        :param attributes: Optional per-file attributes to attach on upload.
+        :param max_workers: Maximum number of concurrent upload workers.
+        :return: None.
+        :raises ValueError: If path or attributes lengths differ, or if max_workers is less than 1.
+        :raises BatchTransferError: If one or more item uploads fail.
+        """
         if len(local_paths) != len(remote_paths):
             raise ValueError("local_paths and remote_paths must have the same length")
 
@@ -1183,12 +1271,26 @@ class BaseStorageProvider(StorageProvider):
         max_workers: int = 16,
     ) -> None:
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = [
-                executor.submit(self.upload_file, rp, lp, attributes[i] if attributes is not None else None)
+            future_to_index = {
+                executor.submit(self.upload_file, rp, lp, attributes[i] if attributes is not None else None): i
                 for i, (lp, rp) in enumerate(zip(local_paths, remote_paths))
-            ]
-            for future in as_completed(futures):
-                future.result()
+            }
+            failures: list[BatchTransferFailure] = []
+            for future in as_completed(future_to_index):
+                i = future_to_index[future]
+                try:
+                    future.result()
+                except Exception as e:
+                    failures.append(
+                        BatchTransferFailure(
+                            index=i,
+                            source_path=local_paths[i],
+                            destination_path=remote_paths[i],
+                            error=e,
+                        )
+                    )
+            if failures:
+                raise BatchTransferError(failures)
 
     def _upload_files_async(
         self, rust_client: Any, local_paths: list[str], remote_paths: list[str], max_workers: int
@@ -1198,14 +1300,31 @@ class BaseStorageProvider(StorageProvider):
 
         multipart_threshold = self._multipart_threshold
 
-        # Build (local_path, object_key, use_multipart) tuples so each upload
-        # knows its resolved key and whether it exceeds the multipart threshold.
-        items: list[tuple[str, str, bool]] = []
-        for local_path, remote_path in zip(local_paths, remote_paths):
-            full_path = self._prepend_base_path(remote_path)
-            _, key = split_path(full_path)
-            file_size = os.path.getsize(local_path)
-            items.append((local_path, key, file_size > multipart_threshold))
+        items: list[_AsyncTransferItem] = []
+        failures: list[BatchTransferFailure] = []
+        for i, (local_path, remote_path) in enumerate(zip(local_paths, remote_paths)):
+            try:
+                full_path = self._prepend_base_path(remote_path)
+                _, key = split_path(full_path)
+                file_size = os.path.getsize(local_path)
+                items.append(
+                    _AsyncTransferItem(
+                        item_index=i,
+                        local_path=local_path,
+                        remote_path=remote_path,
+                        key=key,
+                        use_multipart=file_size > multipart_threshold,
+                    )
+                )
+            except Exception as e:
+                failures.append(
+                    BatchTransferFailure(
+                        index=i,
+                        source_path=local_path,
+                        destination_path=remote_path,
+                        error=e,
+                    )
+                )
 
         semaphore = asyncio.Semaphore(max_workers)
 
@@ -1233,13 +1352,22 @@ class BaseStorageProvider(StorageProvider):
 
         async def _upload_all() -> None:
             results = await asyncio.gather(
-                *[_upload_one(lp, key, mp) for lp, key, mp in items],
+                *[_upload_one(item.local_path, item.key, item.use_multipart) for item in items],
                 return_exceptions=True,
             )
-            errors = [r for r in results if isinstance(r, Exception)]
-            if errors:
-                logger.error("upload_files: %d/%d uploads failed", len(errors), len(items))
-                raise errors[0]
+            failures.extend(
+                BatchTransferFailure(
+                    index=item.item_index,
+                    source_path=item.local_path,
+                    destination_path=item.remote_path,
+                    error=result,
+                )
+                for result, item in zip(results, items)
+                if isinstance(result, Exception)
+            )
+            if failures:
+                logger.error("upload_files: %d/%d uploads failed", len(failures), len(local_paths))
+                raise BatchTransferError(failures)
 
         run_coroutine_sync(_upload_all)
 

--- a/multi-storage-client/src/multistorageclient/retry.py
+++ b/multi-storage-client/src/multistorageclient/retry.py
@@ -16,45 +16,200 @@
 import logging
 import random
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from functools import wraps
 from typing import Any
 
-from .types import RetryableError
+from .types import BatchTransferError, BatchTransferFailure, RetryableError
+
+
+@dataclass
+class _RetryDecision:
+    """
+    Result of classifying an exception raised by a retried operation.
+    """
+
+    retryable: bool
+    error: Exception
+    message: str
+    log_non_retryable: bool = True
+
+
+def sleep_before_retry(retry_config: Any, attempt: int) -> None:
+    """
+    Sleep before the next retry attempt using MSC exponential backoff and jitter.
+
+    :param retry_config: Retry configuration with delay and backoff multiplier fields.
+    :param attempt: Zero-based retry attempt that just failed.
+    """
+    delay = retry_config.delay * (retry_config.backoff_multiplier**attempt)
+    delay += random.uniform(0, 1)
+    time.sleep(delay)
+
+
+def _run_with_retry(
+    operation_name: str,
+    retry_config: Any,
+    call: Callable[[], Any],
+    classify_error: Callable[[Exception], _RetryDecision],
+) -> Any:
+    """
+    Run an operation with the common MSC retry loop.
+
+    :param operation_name: Name used in retry log messages.
+    :param retry_config: Retry configuration. If ``None``, the operation is called once.
+    :param call: Callable that performs one operation attempt.
+    :param classify_error: Callable that maps a raised exception to a retry decision.
+    :return: The value returned by ``call``.
+    :raises Exception: The final classified exception when the operation is not retryable or attempts are exhausted.
+    """
+    attempts = retry_config.attempts if retry_config is not None else 1
+    for attempt in range(attempts):
+        try:
+            return call()
+        except Exception as e:
+            decision = classify_error(e)
+            if not decision.retryable:
+                if decision.log_non_retryable:
+                    logging.error("Non-retryable error occurred for %s: %s", operation_name, decision.error)
+                raise decision.error
+
+            if retry_config is None:
+                raise decision.error
+
+            logging.warning("Attempt %d failed for %s: %s", attempt + 1, operation_name, decision.message)
+            if attempt < attempts - 1:
+                sleep_before_retry(retry_config, attempt)
+            else:
+                logging.error("All retry attempts failed for %s", operation_name)
+                raise decision.error
 
 
 def retry(func: Callable) -> Callable:
     """
     Decorator to retry a function call if a retryable error is raised.
+
+    The decorated method must be on an object with an optional ``_retry_config``
+    attribute. Only :py:class:`multistorageclient.types.RetryableError` is
+    retried; other exceptions are raised immediately.
     """
 
+    @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         storage_client_instance = args[0]
         retry_config = getattr(storage_client_instance, "_retry_config", None)
-        # If retry_config is None, just run the function without retrying
-        if retry_config is None:
-            return func(*args, **kwargs)
 
-        for attempt in range(retry_config.attempts):
-            try:
-                return func(*args, **kwargs)
-            except RetryableError as e:
-                logging.warning("Attempt %d failed for %s: %s", attempt + 1, func.__name__, e)
-                if attempt < retry_config.attempts - 1:
-                    # Calculate exponential backoff with multiplier
-                    delay = retry_config.delay * (retry_config.backoff_multiplier**attempt)
-                    # Add random jitter
-                    delay += random.uniform(0, 1)
-                    time.sleep(delay)
-                else:
-                    logging.error("All retry attempts failed for %s", func.__name__)
-                    raise
-            except FileNotFoundError as e:
+        def _classify_error(error: Exception) -> _RetryDecision:
+            if isinstance(error, RetryableError):
+                return _RetryDecision(retryable=True, error=error, message=str(error))
+            if isinstance(error, FileNotFoundError):
                 # FileNotFoundError is expected in many scenarios (e.g., zarr probing for metadata files)
                 # Log at debug level to avoid cluttering logs with expected 404s
-                logging.debug("File not found for %s: %s", func.__name__, e)
-                raise
-            except Exception as e:
-                logging.error("Non-retryable error occurred for %s: %s", func.__name__, e)
-                raise
+                logging.debug("File not found for %s: %s", func.__name__, error)
+                return _RetryDecision(
+                    retryable=False,
+                    error=error,
+                    message=str(error),
+                    log_non_retryable=False,
+                )
+            return _RetryDecision(retryable=False, error=error, message=str(error))
+
+        return _run_with_retry(
+            operation_name=func.__name__,
+            retry_config=retry_config,
+            call=lambda: func(*args, **kwargs),
+            classify_error=_classify_error,
+        )
 
     return wrapper
+
+
+def batch_retry(func: Callable | None = None, *, operation_name: str | None = None) -> Callable:
+    """
+    Decorator to retry batch operations that raise BatchTransferError with item-level failures.
+
+    The decorated method must accept an ``indices`` argument that identifies the
+    original item indices to attempt. On retry, only indices associated with
+    retryable item failures are attempted again.
+
+    :param func: Decorated batch method when used as ``@batch_retry``.
+    :param operation_name: Optional operation name to use in retry log messages.
+    :return: Decorated batch method.
+    """
+
+    def decorator(batch_func: Callable) -> Callable:
+        @wraps(batch_func)
+        def wrapper(
+            storage_client_instance: Any,
+            indices: Sequence[int],
+            *args: Any,
+            **kwargs: Any,
+        ) -> Any:
+            retry_config = getattr(storage_client_instance, "_retry_config", None)
+            pending_indices = list(indices)
+            name = operation_name or batch_func.__name__
+
+            def _call_batch() -> Any:
+                return batch_func(storage_client_instance, pending_indices, *args, **kwargs)
+
+            def _classify_error(error: Exception) -> _RetryDecision:
+                nonlocal pending_indices
+                if isinstance(error, BatchTransferError):
+                    batch_error, failed_indices = _remap_batch_transfer_error(error, pending_indices)
+
+                    if any(not isinstance(failure.error, RetryableError) for failure in batch_error.failures):
+                        return _RetryDecision(
+                            retryable=False,
+                            error=batch_error,
+                            message=str(batch_error),
+                        )
+
+                    pending_indices = failed_indices
+                    return _RetryDecision(
+                        retryable=True,
+                        error=batch_error,
+                        message=f"{len(batch_error.failures)} item(s) failed",
+                    )
+                if isinstance(error, RetryableError):
+                    return _RetryDecision(retryable=True, error=error, message=str(error))
+                return _RetryDecision(retryable=False, error=error, message=str(error))
+
+            return _run_with_retry(
+                operation_name=name,
+                retry_config=retry_config,
+                call=_call_batch,
+                classify_error=_classify_error,
+            )
+
+        return wrapper
+
+    if func is not None:
+        return decorator(func)
+    return decorator
+
+
+def _remap_batch_transfer_error(
+    error: BatchTransferError, pending_indices: Sequence[int]
+) -> tuple[BatchTransferError, list[int]]:
+    """
+    Convert failed subset-relative indices back to the original batch indices.
+
+    :param error: Batch error raised by a provider call for the current pending subset.
+    :param pending_indices: Original batch indices included in the provider call.
+    :return: A remapped batch error and the original indices that failed.
+    """
+    remapped_failures: list[BatchTransferFailure] = []
+    failed_indices: list[int] = []
+    for failure in error.failures:
+        original_index = pending_indices[failure.index]
+        failed_indices.append(original_index)
+        remapped_failures.append(
+            BatchTransferFailure(
+                index=original_index,
+                source_path=failure.source_path,
+                destination_path=failure.destination_path,
+                error=failure.error,
+            )
+        )
+    return BatchTransferError(remapped_failures), failed_indices

--- a/multi-storage-client/src/multistorageclient/types.py
+++ b/multi-storage-client/src/multistorageclient/types.py
@@ -814,6 +814,42 @@ class RetryableError(Exception):
     pass
 
 
+@dataclass(frozen=True)
+class BatchTransferFailure:
+    """
+    A failed item from a batch upload or download operation.
+    """
+
+    #: The item index in the batch request that failed.
+    index: int
+    #: The source path for the failed transfer.
+    source_path: str
+    #: The destination path for the failed transfer.
+    destination_path: str
+    #: The underlying exception raised for this item.
+    error: Exception
+
+
+class BatchTransferError(Exception):
+    """
+    Exception raised when one or more items fail in a batch transfer operation.
+    """
+
+    def __init__(self, failures: Sequence[BatchTransferFailure]):
+        if not failures:
+            raise ValueError("BatchTransferError requires at least one failure.")
+        self.failures = list(failures)
+        super().__init__(self._format_message())
+
+    def _format_message(self) -> str:
+        details = ", ".join(
+            f"index {failure.index} ({type(failure.error).__name__}: {failure.error})" for failure in self.failures[:3]
+        )
+        if len(self.failures) > 3:
+            details += f", and {len(self.failures) - 3} more"
+        return f"{len(self.failures)} batch transfer item(s) failed: {details}"
+
+
 class PreconditionFailedError(Exception):
     """
     Exception raised when a precondition fails. e.g. if-match, if-none-match, etc.

--- a/multi-storage-client/tests/test_multistorageclient/unit/client/test_client.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/client/test_client.py
@@ -23,7 +23,15 @@ import pytest
 from multistorageclient import StorageClient, StorageClientConfig
 from multistorageclient.client.composite import CompositeStorageClient
 from multistorageclient.client.single import SingleStorageClient
-from multistorageclient.types import ObjectMetadata, ResolvedPath, ResolvedPathState, SymlinkHandling
+from multistorageclient.types import (
+    BatchTransferError,
+    BatchTransferFailure,
+    ObjectMetadata,
+    ResolvedPath,
+    ResolvedPathState,
+    RetryableError,
+    SymlinkHandling,
+)
 
 
 @pytest.fixture
@@ -394,6 +402,16 @@ def test_download_files_rejects_mismatched_lengths_single(single_backend_config)
         client.download_files(["/a", "/b"], ["/local_a"])
 
 
+def test_single_download_files_rejects_mismatched_metadata_length_with_replica_manager(single_backend_config):
+    client = StorageClient(single_backend_config)
+    single = client._delegate
+    assert isinstance(single, SingleStorageClient)
+    single._replica_manager = MagicMock()
+
+    with pytest.raises(ValueError, match="metadata must have the same length"):
+        client.download_files(["/a"], ["/local_a"], metadata=[])
+
+
 def test_download_files_rejects_mismatched_lengths_composite(multi_backend_config):
     client = StorageClient(multi_backend_config)
     with pytest.raises(ValueError, match="same length"):
@@ -487,7 +505,7 @@ def test_single_download_files_with_metadata_resolves_paths(single_backend_confi
     )
 
 
-def test_single_download_files_with_metadata_raises_on_missing_file(single_backend_config):
+def test_single_download_files_with_metadata_reports_missing_file_without_data_transfer(single_backend_config):
     client = StorageClient(single_backend_config)
     single = client._delegate
     assert isinstance(single, SingleStorageClient)
@@ -498,9 +516,58 @@ def test_single_download_files_with_metadata_raises_on_missing_file(single_backe
         ResolvedPath(physical_path="logical/missing", state=ResolvedPathState.UNTRACKED),
     ]
     single._metadata_provider = metadata_provider
+    single._storage_provider.download_files = MagicMock()
 
-    with pytest.raises(FileNotFoundError, match="logical/missing"):
+    with pytest.raises(FileNotFoundError):
         client.download_files(["logical/a", "logical/missing"], ["/la", "/lb"])
+
+    single._storage_provider.download_files.assert_not_called()
+
+
+def test_single_download_files_with_metadata_does_not_retry_metadata_provider_failures(single_backend_config):
+    client = StorageClient(single_backend_config)
+    single = client._delegate
+    assert isinstance(single, SingleStorageClient)
+
+    metadata_provider = MagicMock()
+    metadata_provider.realpath.side_effect = RetryableError("metadata provider unavailable")
+    single._metadata_provider = metadata_provider
+    single._storage_provider.download_files = MagicMock()
+
+    with pytest.raises(RetryableError):
+        client.download_files(["logical/a"], ["/la"])
+
+    assert metadata_provider.realpath.call_count == 1
+    single._storage_provider.download_files.assert_not_called()
+
+
+def test_single_download_files_with_metadata_reports_provider_failures_for_physical_paths(single_backend_config):
+    client = StorageClient(single_backend_config)
+    single = client._delegate
+    assert isinstance(single, SingleStorageClient)
+
+    metadata_provider = MagicMock()
+    metadata_provider.realpath.return_value = ResolvedPath(physical_path="physical/a", state=ResolvedPathState.EXISTS)
+    single._metadata_provider = metadata_provider
+    single._storage_provider.download_files = MagicMock(
+        side_effect=BatchTransferError(
+            [
+                BatchTransferFailure(
+                    index=0,
+                    source_path="physical/a",
+                    destination_path="/la",
+                    error=FileNotFoundError("missing"),
+                )
+            ]
+        )
+    )
+
+    with pytest.raises(BatchTransferError) as exc_info:
+        client.download_files(["logical/a"], ["/la"])
+
+    assert exc_info.value.failures[0].index == 0
+    assert exc_info.value.failures[0].source_path == "physical/a"
+    assert exc_info.value.failures[0].destination_path == "/la"
 
 
 def test_single_download_files_empty_lists(single_backend_config):
@@ -670,9 +737,130 @@ def test_single_upload_files_with_metadata_rejects_overwrite(single_backend_conf
     metadata_provider.realpath.return_value = ResolvedPath(physical_path="existing", state=ResolvedPathState.EXISTS)
     metadata_provider.allow_overwrites.return_value = False
     single._metadata_provider = metadata_provider
+    single._storage_provider.upload_files = MagicMock()
 
-    with pytest.raises(FileExistsError, match="already exists"):
+    with pytest.raises(FileExistsError):
         client.upload_files(["existing"], ["/la"])
+
+    single._storage_provider.upload_files.assert_not_called()
+
+
+def test_single_upload_files_with_metadata_does_not_upload_when_overwrite_fails(single_backend_config):
+    client = StorageClient(single_backend_config)
+    single = client._delegate
+    assert isinstance(single, SingleStorageClient)
+
+    metadata_provider = MagicMock()
+    metadata_provider.realpath.side_effect = [
+        ResolvedPath(physical_path="logical/a", state=ResolvedPathState.UNTRACKED),
+        ResolvedPath(physical_path="existing", state=ResolvedPathState.EXISTS),
+    ]
+    metadata_provider.generate_physical_path.return_value = ResolvedPath(
+        physical_path="physical/a", state=ResolvedPathState.UNTRACKED
+    )
+    metadata_provider.allow_overwrites.return_value = False
+    obj_meta = ObjectMetadata(key="physical/a", content_length=100, last_modified=datetime.now(tz=timezone.utc))
+    single._storage_provider.get_object_metadata = MagicMock(return_value=obj_meta)
+    single._storage_provider.upload_files = MagicMock()
+    single._metadata_provider = metadata_provider
+    single._metadata_provider_lock = None
+
+    with pytest.raises(FileExistsError):
+        client.upload_files(["logical/a", "existing"], ["/la", "/lb"])
+
+    single._storage_provider.upload_files.assert_not_called()
+    metadata_provider.add_file.assert_not_called()
+
+
+def test_single_upload_files_with_metadata_does_not_register_partial_provider_success(single_backend_config):
+    client = StorageClient(single_backend_config)
+    single = client._delegate
+    assert isinstance(single, SingleStorageClient)
+
+    metadata_provider = MagicMock()
+    metadata_provider.realpath.side_effect = [
+        ResolvedPath(physical_path="logical/a", state=ResolvedPathState.UNTRACKED),
+        ResolvedPath(physical_path="logical/b", state=ResolvedPathState.UNTRACKED),
+    ]
+    metadata_provider.generate_physical_path.side_effect = [
+        ResolvedPath(physical_path="physical/a", state=ResolvedPathState.UNTRACKED),
+        ResolvedPath(physical_path="physical/b", state=ResolvedPathState.UNTRACKED),
+    ]
+    metadata_provider.allow_overwrites.return_value = False
+    single._metadata_provider = metadata_provider
+    single._metadata_provider_lock = None
+    single._storage_provider.get_object_metadata = MagicMock(
+        return_value=ObjectMetadata(key="physical/a", content_length=100, last_modified=datetime.now(tz=timezone.utc))
+    )
+    single._storage_provider.upload_files = MagicMock(
+        side_effect=BatchTransferError(
+            [
+                BatchTransferFailure(
+                    index=1,
+                    source_path="/lb",
+                    destination_path="physical/b",
+                    error=RuntimeError("permanent upload failure"),
+                )
+            ]
+        )
+    )
+
+    with pytest.raises(BatchTransferError):
+        client.upload_files(["logical/a", "logical/b"], ["/la", "/lb"])
+
+    metadata_provider.add_file.assert_not_called()
+
+
+def test_single_upload_files_with_metadata_does_not_retry_metadata_provider_failures(single_backend_config):
+    client = StorageClient(single_backend_config)
+    single = client._delegate
+    assert isinstance(single, SingleStorageClient)
+
+    metadata_provider = MagicMock()
+    metadata_provider.realpath.side_effect = RetryableError("metadata provider unavailable")
+    single._metadata_provider = metadata_provider
+    single._metadata_provider_lock = None
+    single._storage_provider.upload_files = MagicMock()
+
+    with pytest.raises(RetryableError):
+        client.upload_files(["logical/a"], ["/la"])
+
+    assert metadata_provider.realpath.call_count == 1
+    single._storage_provider.upload_files.assert_not_called()
+
+
+def test_single_upload_files_with_metadata_reports_provider_failures_for_physical_paths(single_backend_config):
+    client = StorageClient(single_backend_config)
+    single = client._delegate
+    assert isinstance(single, SingleStorageClient)
+
+    metadata_provider = MagicMock()
+    metadata_provider.realpath.return_value = ResolvedPath(physical_path="logical/a", state=ResolvedPathState.UNTRACKED)
+    metadata_provider.generate_physical_path.return_value = ResolvedPath(
+        physical_path="physical/a", state=ResolvedPathState.UNTRACKED
+    )
+    metadata_provider.allow_overwrites.return_value = False
+    single._metadata_provider = metadata_provider
+    single._metadata_provider_lock = None
+    single._storage_provider.upload_files = MagicMock(
+        side_effect=BatchTransferError(
+            [
+                BatchTransferFailure(
+                    index=0,
+                    source_path="/la",
+                    destination_path="physical/a",
+                    error=FileNotFoundError("missing local"),
+                )
+            ]
+        )
+    )
+
+    with pytest.raises(BatchTransferError) as exc_info:
+        client.upload_files(["logical/a"], ["/la"])
+
+    assert exc_info.value.failures[0].index == 0
+    assert exc_info.value.failures[0].source_path == "/la"
+    assert exc_info.value.failures[0].destination_path == "physical/a"
 
 
 def test_single_upload_files_with_metadata_allows_overwrite(single_backend_config):

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_base_storage_provider.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_base_storage_provider.py
@@ -25,22 +25,29 @@ import pytest
 
 from multistorageclient.providers.base import BaseStorageProvider
 from multistorageclient.telemetry import Telemetry
-from multistorageclient.types import ObjectMetadata, Range, SymlinkHandling
+from multistorageclient.types import BatchTransferError, ObjectMetadata, Range, RetryableError, SymlinkHandling
 
 
 class MockBaseStorageProvider(BaseStorageProvider):
     _rust_client: Any = None
 
-    def _put_object(self, path: str, body: bytes) -> None:
-        pass
+    def _put_object(
+        self,
+        path: str,
+        body: bytes,
+        if_match: Optional[str] = None,
+        if_none_match: Optional[str] = None,
+        attributes: Optional[dict[str, str]] = None,
+    ) -> int:
+        return len(body)
 
     def _get_object(self, path: str, byte_range: Optional[Range] = None) -> bytes:
         return b""
 
-    def _copy_object(self, src_path: str, dest_path: str) -> None:
-        pass
+    def _copy_object(self, src_path: str, dest_path: str) -> int:
+        return 0
 
-    def _delete_object(self, path: str, etag: Optional[str] = None) -> None:
+    def _delete_object(self, path: str, if_match: Optional[str] = None) -> None:
         pass
 
     def _make_symlink(self, path: str, target: str) -> None:
@@ -62,8 +69,8 @@ class MockBaseStorageProvider(BaseStorageProvider):
     ) -> Iterator[ObjectMetadata]:
         return iter([])
 
-    def _upload_file(self, remote_path: str, f: Union[str, IO]) -> None:
-        pass
+    def _upload_file(self, remote_path: str, f: Union[str, IO], attributes: Optional[dict[str, str]] = None) -> int:
+        return 0
 
     def _download_file(self, remote_path: str, f: Union[str, IO], metadata: Optional[ObjectMetadata] = None) -> int:
         return 0
@@ -161,6 +168,194 @@ def test_upload_file_converts_provider_attributes_to_strings():
     provider.upload_file("file.txt", "/tmp/file.txt", attributes={"count": 1})
 
     provider._upload_file.assert_called_once_with("bucket/file.txt", "/tmp/file.txt", {"count": "1"})
+
+
+def test_upload_files_threaded_reports_all_failed_indices():
+    provider = MockBaseStorageProvider(base_path="bucket", provider_name="mock")
+
+    def _upload_file(remote_path: str, f: Union[str, IO], attributes: Optional[dict[str, Any]] = None) -> None:
+        if remote_path.endswith(("remote-b", "remote-c")):
+            raise RetryableError(f"failed {remote_path}")
+
+    provider._upload_file = Mock(side_effect=_upload_file)
+
+    with pytest.raises(BatchTransferError) as exc_info:
+        provider.upload_files(
+            local_paths=["local-a", "local-b", "local-c"],
+            remote_paths=["remote-a", "remote-b", "remote-c"],
+        )
+
+    assert {failure.index for failure in exc_info.value.failures} == {1, 2}
+    assert {failure.source_path for failure in exc_info.value.failures} == {"local-b", "local-c"}
+    assert {failure.destination_path for failure in exc_info.value.failures} == {"remote-b", "remote-c"}
+
+
+def test_upload_files_async_reports_failed_indices(tmp_path):
+    provider = MockBaseStorageProvider(base_path="bucket", provider_name="mock")
+
+    class FakeRustClient:
+        def __init__(self):
+            self.uploaded_keys: list[str] = []
+
+        async def upload(self, local_path: str, key: str) -> int:
+            self.uploaded_keys.append(key)
+            if key.endswith("remote-b"):
+                raise RetryableError(f"failed {key}")
+            return 1
+
+        async def upload_multipart_from_file(self, local_path: str, key: str) -> int:
+            return await self.upload(local_path, key)
+
+    local_paths = []
+    for name in ["local-a", "local-b", "local-c"]:
+        path = tmp_path / name
+        path.write_bytes(b"x")
+        local_paths.append(str(path))
+    rust_client = FakeRustClient()
+    provider._rust_client = rust_client
+
+    with pytest.raises(BatchTransferError) as exc_info:
+        provider.upload_files(
+            local_paths=local_paths,
+            remote_paths=["remote-a", "remote-b", "remote-c"],
+        )
+
+    assert rust_client.uploaded_keys == ["remote-a", "remote-b", "remote-c"]
+    assert [failure.index for failure in exc_info.value.failures] == [1]
+    assert exc_info.value.failures[0].source_path == local_paths[1]
+    assert exc_info.value.failures[0].destination_path == "remote-b"
+
+
+def test_download_files_threaded_reports_all_failed_indices():
+    provider = MockBaseStorageProvider(base_path="bucket", provider_name="mock")
+
+    def download_file(remote_path: str, f: Union[str, IO], metadata: Optional[ObjectMetadata] = None) -> None:
+        if remote_path.endswith(("remote-b", "remote-c")):
+            raise RetryableError(f"failed {remote_path}")
+
+    provider.download_file = Mock(side_effect=download_file)
+    metadata = [ObjectMetadata(key=path, content_length=1, last_modified=datetime.now()) for path in ["a", "b", "c"]]
+
+    with pytest.raises(BatchTransferError) as exc_info:
+        provider.download_files(
+            remote_paths=["remote-a", "remote-b", "remote-c"],
+            local_paths=["local-a", "local-b", "local-c"],
+            metadata=metadata,
+        )
+
+    assert {failure.index for failure in exc_info.value.failures} == {1, 2}
+    assert {failure.source_path for failure in exc_info.value.failures} == {"remote-b", "remote-c"}
+    assert {failure.destination_path for failure in exc_info.value.failures} == {"local-b", "local-c"}
+
+
+def test_download_files_async_reports_failed_indices():
+    provider = MockBaseStorageProvider(base_path="bucket", provider_name="mock")
+
+    class FakeRustClient:
+        def __init__(self):
+            self.downloaded_keys: list[str] = []
+
+        async def download(self, key: str, local_path: str) -> int:
+            self.downloaded_keys.append(key)
+            if key.endswith("remote-b"):
+                raise RetryableError(f"failed {key}")
+            return 1
+
+        async def download_multipart_to_file(self, key: str, local_path: str) -> int:
+            return await self.download(key, local_path)
+
+    rust_client = FakeRustClient()
+    provider._rust_client = rust_client
+    metadata = [
+        ObjectMetadata(key="remote-a", content_length=1, last_modified=datetime.now()),
+        ObjectMetadata(key="remote-b", content_length=1, last_modified=datetime.now()),
+        ObjectMetadata(key="remote-c", content_length=1, last_modified=datetime.now()),
+    ]
+
+    with pytest.raises(BatchTransferError) as exc_info:
+        provider.download_files(
+            remote_paths=["remote-a", "remote-b", "remote-c"],
+            local_paths=["local-a", "local-b", "local-c"],
+            metadata=metadata,
+        )
+
+    assert rust_client.downloaded_keys == ["remote-a", "remote-b", "remote-c"]
+    assert [failure.index for failure in exc_info.value.failures] == [1]
+    assert exc_info.value.failures[0].source_path == "remote-b"
+    assert exc_info.value.failures[0].destination_path == "local-b"
+
+
+def test_download_files_async_reports_preflight_failures():
+    provider = MockBaseStorageProvider(base_path="bucket", provider_name="mock")
+
+    class FakeRustClient:
+        def __init__(self):
+            self.downloaded_keys: list[str] = []
+
+        async def download(self, key: str, local_path: str) -> int:
+            self.downloaded_keys.append(key)
+            return 1
+
+        async def download_multipart_to_file(self, key: str, local_path: str) -> int:
+            return await self.download(key, local_path)
+
+    rust_client = FakeRustClient()
+    provider._rust_client = rust_client
+    metadata = [
+        ObjectMetadata(key="remote-a", content_length=1, last_modified=datetime.now()),
+        ObjectMetadata(key="remote-b", content_length=1, last_modified=datetime.now()),
+    ]
+
+    def fail_for_second_dir(path: str) -> None:
+        if path.endswith("blocked"):
+            raise PermissionError("cannot create directory")
+
+    with patch("multistorageclient.providers.base.safe_makedirs", side_effect=fail_for_second_dir):
+        with pytest.raises(BatchTransferError) as exc_info:
+            provider.download_files(
+                remote_paths=["remote-a", "remote-b"],
+                local_paths=["ok/local-a", "blocked/local-b"],
+                metadata=metadata,
+            )
+
+    assert rust_client.downloaded_keys == ["remote-a"]
+    assert [failure.index for failure in exc_info.value.failures] == [1]
+    assert exc_info.value.failures[0].source_path == "remote-b"
+    assert exc_info.value.failures[0].destination_path == "blocked/local-b"
+    assert isinstance(exc_info.value.failures[0].error, PermissionError)
+
+
+def test_upload_files_async_reports_preflight_failures(tmp_path):
+    provider = MockBaseStorageProvider(base_path="bucket", provider_name="mock")
+
+    class FakeRustClient:
+        def __init__(self):
+            self.uploaded_keys: list[str] = []
+
+        async def upload(self, local_path: str, key: str) -> int:
+            self.uploaded_keys.append(key)
+            return 1
+
+        async def upload_multipart_from_file(self, local_path: str, key: str) -> int:
+            return await self.upload(local_path, key)
+
+    rust_client = FakeRustClient()
+    provider._rust_client = rust_client
+    good_path = tmp_path / "local-a"
+    good_path.write_bytes(b"x")
+    missing_path = tmp_path / "missing"
+
+    with pytest.raises(BatchTransferError) as exc_info:
+        provider.upload_files(
+            local_paths=[str(good_path), str(missing_path)],
+            remote_paths=["remote-a", "remote-b"],
+        )
+
+    assert rust_client.uploaded_keys == ["remote-a"]
+    assert [failure.index for failure in exc_info.value.failures] == [1]
+    assert exc_info.value.failures[0].source_path == str(missing_path)
+    assert exc_info.value.failures[0].destination_path == "remote-b"
+    assert isinstance(exc_info.value.failures[0].error, FileNotFoundError)
 
 
 def test_provider_attribute_conversion_leaves_validation_to_provider_hook():

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_retry.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_retry.py
@@ -19,8 +19,8 @@ from unittest.mock import patch
 import pytest
 
 from multistorageclient import StorageClient, StorageClientConfig
-from multistorageclient.retry import retry
-from multistorageclient.types import Range, RetryableError, StorageProvider
+from multistorageclient.retry import batch_retry, retry
+from multistorageclient.types import BatchTransferError, BatchTransferFailure, Range, RetryableError, StorageProvider
 
 
 class FakeStorageProvider:
@@ -187,3 +187,195 @@ def test_file_not_found_error_logging(caplog):
 
     debug_logs = [record for record in caplog.records if record.levelname == "DEBUG" and "not found" in record.message]
     assert len(debug_logs) > 0, "FileNotFoundError should be logged at DEBUG level"
+
+
+class FakeBatchStorageProvider:
+    def __init__(self, failing_indices_by_call: list[set[int]], error: Exception):
+        self.calls: list[dict[str, object]] = []
+        self._failing_indices_by_call = failing_indices_by_call
+        self._error = error
+
+    def upload_files(self, local_paths, remote_paths, attributes=None, max_workers=16):
+        self.calls.append(
+            {
+                "local_paths": list(local_paths),
+                "remote_paths": list(remote_paths),
+                "attributes": list(attributes) if attributes is not None else None,
+            }
+        )
+        self._raise_batch_error_for_call(local_paths, remote_paths)
+
+    def download_files(self, remote_paths, local_paths, metadata=None, max_workers=16):
+        self.calls.append(
+            {
+                "remote_paths": list(remote_paths),
+                "local_paths": list(local_paths),
+                "metadata": list(metadata) if metadata is not None else None,
+            }
+        )
+        self._raise_batch_error_for_call(remote_paths, local_paths)
+
+    def _raise_batch_error_for_call(self, source_paths, destination_paths):
+        call_index = len(self.calls) - 1
+        failing_indices = (
+            self._failing_indices_by_call[call_index] if call_index < len(self._failing_indices_by_call) else set()
+        )
+        if failing_indices:
+            raise BatchTransferError(
+                [
+                    BatchTransferFailure(
+                        index=i,
+                        source_path=source_paths[i],
+                        destination_path=destination_paths[i],
+                        error=self._error,
+                    )
+                    for i in sorted(failing_indices)
+                ]
+            )
+
+
+def test_upload_files_retries_only_failed_files():
+    config = StorageClientConfig.from_json(
+        """{
+        "profiles": {
+            "default": {
+                "storage_provider": {
+                    "type": "file",
+                    "options": {
+                        "base_path": "/"
+                    }
+                }
+            }
+        }
+    }"""
+    )
+    storage_client = StorageClient(config)
+    storage_provider = FakeBatchStorageProvider(
+        failing_indices_by_call=[{1}, set()],
+        error=RetryableError("temporary upload failure"),
+    )
+    storage_client._storage_provider = cast(StorageProvider, storage_provider)
+
+    with patch("time.sleep"):
+        storage_client.upload_files(
+            remote_paths=["remote-a", "remote-b", "remote-c"],
+            local_paths=["local-a", "local-b", "local-c"],
+            attributes=[{"name": "a"}, {"name": "b"}, {"name": "c"}],
+        )
+
+    assert storage_provider.calls == [
+        {
+            "local_paths": ["local-a", "local-b", "local-c"],
+            "remote_paths": ["remote-a", "remote-b", "remote-c"],
+            "attributes": [{"name": "a"}, {"name": "b"}, {"name": "c"}],
+        },
+        {
+            "local_paths": ["local-b"],
+            "remote_paths": ["remote-b"],
+            "attributes": [{"name": "b"}],
+        },
+    ]
+
+
+def test_download_files_retries_only_failed_files():
+    config = StorageClientConfig.from_json(
+        """{
+        "profiles": {
+            "default": {
+                "storage_provider": {
+                    "type": "file",
+                    "options": {
+                        "base_path": "/"
+                    }
+                }
+            }
+        }
+    }"""
+    )
+    storage_client = StorageClient(config)
+    storage_provider = FakeBatchStorageProvider(
+        failing_indices_by_call=[{0, 2}, set()],
+        error=RetryableError("temporary download failure"),
+    )
+    storage_client._storage_provider = cast(StorageProvider, storage_provider)
+
+    with patch("time.sleep"):
+        storage_client.download_files(
+            remote_paths=["remote-a", "remote-b", "remote-c"],
+            local_paths=["local-a", "local-b", "local-c"],
+        )
+
+    assert storage_provider.calls == [
+        {
+            "remote_paths": ["remote-a", "remote-b", "remote-c"],
+            "local_paths": ["local-a", "local-b", "local-c"],
+            "metadata": None,
+        },
+        {
+            "remote_paths": ["remote-a", "remote-c"],
+            "local_paths": ["local-a", "local-c"],
+            "metadata": None,
+        },
+    ]
+
+
+def test_upload_files_does_not_retry_non_retryable_batch_failures():
+    config = StorageClientConfig.from_json(
+        """{
+        "profiles": {
+            "default": {
+                "storage_provider": {
+                    "type": "file",
+                    "options": {
+                        "base_path": "/"
+                    }
+                }
+            }
+        }
+    }"""
+    )
+    storage_client = StorageClient(config)
+    storage_provider = FakeBatchStorageProvider(
+        failing_indices_by_call=[{1}],
+        error=RuntimeError("permanent upload failure"),
+    )
+    storage_client._storage_provider = cast(StorageProvider, storage_provider)
+
+    with pytest.raises(BatchTransferError) as exc_info:
+        storage_client.upload_files(
+            remote_paths=["remote-a", "remote-b"],
+            local_paths=["local-a", "local-b"],
+        )
+
+    assert storage_provider.calls == [
+        {
+            "local_paths": ["local-a", "local-b"],
+            "remote_paths": ["remote-a", "remote-b"],
+            "attributes": None,
+        }
+    ]
+    assert len(exc_info.value.failures) == 1
+    assert isinstance(exc_info.value.failures[0].error, RuntimeError)
+
+
+def test_batch_retry_remaps_failures_without_retry_config():
+    class BatchOperation:
+        _retry_config = None
+
+        @batch_retry(operation_name="batch_operation")
+        def run(self, indices: list[int]) -> None:
+            raise BatchTransferError(
+                [
+                    BatchTransferFailure(
+                        index=1,
+                        source_path="source-b",
+                        destination_path="destination-b",
+                        error=RuntimeError("permanent failure"),
+                    )
+                ]
+            )
+
+    with pytest.raises(BatchTransferError) as exc_info:
+        BatchOperation().run([0, 1, 2])
+
+    assert [failure.index for failure in exc_info.value.failures] == [1]


### PR DESCRIPTION
## Description

Adds MSC-level retry support for `StorageClient.upload_files` and `StorageClient.download_files` while preserving provider-level batch execution.

Instead of retrying an entire batch when one item fails, providers now report structured item-level failures and `SingleStorageClient` retries only the failed subset.

## Changes

### Types
- Added `BatchTransferFailure` to capture item-level batch transfer failures with index, source path, destination path, and underlying error.
- Added `BatchTransferError` to aggregate one or more `BatchTransferFailure` instances and produce concise failure messages.

### StorageClient
- Updated `SingleStorageClient.upload_files` and `download_files` to preserve provider batch operations.
- Added batch retry wrappers for upload/download that retry only failed item indices.
- Kept metadata provider operations outside batch retry so metadata resolution and registration are not retried.
- Ensured provider failures are surfaced with provider transfer paths after metadata resolution.

### BaseStorageProvider
- Updated batch upload/download implementations to raise `BatchTransferError` with item-level failures.
- Added async Rust batch failure handling for upload/download operations.
- Added preflight failure reporting for local file checks, metadata resolution, path preparation, and directory creation.
- Refactored async transfer item bookkeeping into a named `_AsyncTransferItem` structure using `local_path` and `remote_path`.

### Retry
- Added shared retry-loop helper used by both single-operation and batch-operation retries.
- Added `batch_retry` decorator for retrying `BatchTransferError` failures.
- Implemented failed-index remapping so retries operate only on failed batch items.
- Preserved existing retry behavior for `RetryableError` and non-retryable errors.


Closes NGCDP-8140

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch upload/download now retries only failed items within a batch and supports callbacks to register completed items after batch success.
  * Added item-level batch error types that report index, source and destination paths for failures.

* **Improvements**
  * More granular concurrency and per-item error reporting for bulk transfers; non-retryable errors propagate immediately.

* **Documentation**
  * Clarified configuration guide about batch API retry behavior.

* **Tests**
  * Added unit tests for batch retry, failure aggregation, remapping, and concurrency scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->