### PR TITLE
fix: increase connection pool default for storage providers

### DIFF
--- a/multi-storage-client/src/multistorageclient/constants.py
+++ b/multi-storage-client/src/multistorageclient/constants.py
@@ -19,6 +19,7 @@ MEMORY_LOAD_LIMIT = 512 * 1024 * 1024
 # Default timeout values (in seconds) for storage provider connections
 DEFAULT_CONNECT_TIMEOUT = 60
 DEFAULT_READ_TIMEOUT = 60
+DEFAULT_MAX_POOL_CONNECTIONS = 128
 
 # Default host and port for the MSC Explorer application
 DEFAULT_EXPLORER_HOST = "127.0.0.1"

--- a/multi-storage-client/src/multistorageclient/providers/gcs.py
+++ b/multi-storage-client/src/multistorageclient/providers/gcs.py
@@ -34,6 +34,7 @@ from google.oauth2.credentials import Credentials as OAuth2Credentials
 
 from multistorageclient_rust import RustClient, RustClientError, RustRetryableError
 
+from ..constants import DEFAULT_MAX_POOL_CONNECTIONS
 from ..rust_utils import parse_retry_config, run_async_rust_client_method
 from ..telemetry import Telemetry
 from ..types import (
@@ -171,6 +172,7 @@ class GoogleStorageProvider(BaseStorageProvider):
         :param credentials_provider: The provider to retrieve GCS credentials.
         :param config_dict: Resolved MSC config.
         :param telemetry_provider: A function that provides a telemetry instance.
+        :param max_pool_connections: Maximum connection pool size for the Rust client.
         """
         super().__init__(
             base_path=base_path,
@@ -192,6 +194,8 @@ class GoogleStorageProvider(BaseStorageProvider):
         if "rust_client" in kwargs:
             # Inherit the rust client options from the kwargs
             rust_client_options = copy.deepcopy(kwargs["rust_client"])
+            if "max_pool_connections" in kwargs:
+                rust_client_options["max_pool_connections"] = kwargs["max_pool_connections"]
             if "max_concurrency" in kwargs:
                 rust_client_options["max_concurrency"] = kwargs["max_concurrency"]
             if "multipart_chunksize" in kwargs:
@@ -270,6 +274,9 @@ class GoogleStorageProvider(BaseStorageProvider):
         if "bucket" not in configs:
             bucket, _ = split_path(self._base_path)
             configs["bucket"] = bucket
+
+        if "max_pool_connections" not in configs:
+            configs["max_pool_connections"] = DEFAULT_MAX_POOL_CONNECTIONS
 
         if self._credentials_provider:
             if isinstance(self._credentials_provider, GoogleIdentityPoolCredentialsProvider):

--- a/multi-storage-client/src/multistorageclient/providers/s3.py
+++ b/multi-storage-client/src/multistorageclient/providers/s3.py
@@ -30,7 +30,7 @@ from dateutil.parser import parse as dateutil_parse
 
 from multistorageclient_rust import RustClient, RustClientError, RustRetryableError
 
-from ..constants import DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT
+from ..constants import DEFAULT_CONNECT_TIMEOUT, DEFAULT_MAX_POOL_CONNECTIONS, DEFAULT_READ_TIMEOUT
 from ..rust_utils import parse_retry_config, run_async_rust_client_method
 from ..signers import CloudFrontURLSigner, URLSigner
 from ..telemetry import Telemetry
@@ -46,7 +46,6 @@ from ..types import (
     SymlinkHandling,
 )
 from ..utils import (
-    get_available_cpu_count,
     safe_makedirs,
     split_path,
     validate_attributes,
@@ -55,13 +54,6 @@ from .base import BaseStorageProvider
 
 _T = TypeVar("_T")
 
-# Default connection pool size scales with CPU count or MSC Sync Threads count (minimum 64)
-MAX_POOL_CONNECTIONS = max(
-    64,
-    get_available_cpu_count(),
-    int(os.getenv("MSC_NUM_THREADS_PER_PROCESS", "0")),
-)
-
 MiB = 1024 * 1024
 
 # Python and Rust share the same multipart_threshold to keep the code simple.
@@ -69,6 +61,7 @@ MULTIPART_THRESHOLD = 64 * MiB
 MULTIPART_CHUNKSIZE = 32 * MiB
 IO_CHUNKSIZE = 32 * MiB
 PYTHON_MAX_CONCURRENCY = 8
+MAX_POOL_CONNECTIONS = DEFAULT_MAX_POOL_CONNECTIONS
 
 PROVIDER = "s3"
 


### PR DESCRIPTION
## Description

In the default `sync_from` operation, when the Rust client is enabled, the concurrency is 8 x 16 = 128. When the remote backend has high latency, the default connection pool (64) will be exhausted.

Closes NGCDP-8445

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable maximum pool connections in GCS storage provider.

* **Chores**
  * Standardized connection pool sizing across storage providers using a unified default configuration value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->