### PR TITLE
fix: keep metadata attributes out of physical writes

### DIFF
--- a/multi-storage-client/src/multistorageclient/client/single.py
+++ b/multi-storage-client/src/multistorageclient/client/single.py
@@ -565,6 +565,7 @@ class SingleStorageClient(AbstractStorageClient):
         virtual_path = remote_path
         if self._metadata_provider:
             physical_path = self._resolve_write_path(remote_path)
+            # Attributes belong to logical metadata, so physical writes get none and registration stores them.
             self._storage_provider.upload_file(physical_path, local_path, attributes=None)
             self._register_written_file(virtual_path, physical_path, attributes)
         else:
@@ -597,6 +598,7 @@ class SingleStorageClient(AbstractStorageClient):
         if self._metadata_provider:
             physical_paths = [self._resolve_write_path(rp) for rp in remote_paths]
 
+            # Attributes belong to logical metadata, so physical writes get none and registration stores them.
             self._upload_files_batch(
                 list(range(len(remote_paths))),
                 local_paths,
@@ -621,6 +623,7 @@ class SingleStorageClient(AbstractStorageClient):
         virtual_path = path
         if self._metadata_provider:
             physical_path = self._resolve_write_path(path)
+            # Attributes belong to logical metadata, so physical writes get none and registration stores them.
             self._storage_provider.put_object(physical_path, body, attributes=None)
             self._register_written_file(virtual_path, physical_path, attributes)
         else:

--- a/multi-storage-client/src/multistorageclient/client/single.py
+++ b/multi-storage-client/src/multistorageclient/client/single.py
@@ -565,7 +565,7 @@ class SingleStorageClient(AbstractStorageClient):
         virtual_path = remote_path
         if self._metadata_provider:
             physical_path = self._resolve_write_path(remote_path)
-            self._storage_provider.upload_file(physical_path, local_path, attributes)
+            self._storage_provider.upload_file(physical_path, local_path, attributes=None)
             self._register_written_file(virtual_path, physical_path, attributes)
         else:
             self._storage_provider.upload_file(remote_path, local_path, attributes)
@@ -601,7 +601,7 @@ class SingleStorageClient(AbstractStorageClient):
                 list(range(len(remote_paths))),
                 local_paths,
                 physical_paths,
-                attributes,
+                None,
                 max_workers,
             )
 
@@ -621,7 +621,7 @@ class SingleStorageClient(AbstractStorageClient):
         virtual_path = path
         if self._metadata_provider:
             physical_path = self._resolve_write_path(path)
-            self._storage_provider.put_object(physical_path, body, attributes=attributes)
+            self._storage_provider.put_object(physical_path, body, attributes=None)
             self._register_written_file(virtual_path, physical_path, attributes)
         else:
             self._storage_provider.put_object(path, body, attributes=attributes)

--- a/multi-storage-client/tests/test_multistorageclient/unit/client/test_client.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/client/test_client.py
@@ -386,7 +386,7 @@ def test_single_write_with_metadata_provider_accepts_non_string_attributes(singl
 
     client.write("logical/file.bin", b"data", attributes=attributes)
 
-    single._storage_provider.put_object.assert_called_once_with("physical/file.bin", b"data", attributes=attributes)
+    single._storage_provider.put_object.assert_called_once_with("physical/file.bin", b"data", attributes=None)
     metadata_provider.add_file.assert_called_once()
     add_file_path, add_file_metadata = metadata_provider.add_file.call_args.args
     assert add_file_path == "logical/file.bin"
@@ -670,9 +670,7 @@ def test_single_upload_files_with_metadata_and_attributes(single_backend_config)
     attrs = [{"tag": "first", "count": 1}, {"tag": "second", "nested": {"key": "value"}}]
     client.upload_files(["logical/a", "logical/b"], ["/la", "/lb"], attributes=attrs, max_workers=8)
 
-    single._storage_provider.upload_files.assert_called_once_with(
-        ["/la", "/lb"], ["physical/a", "physical/b"], attrs, 8
-    )
+    single._storage_provider.upload_files.assert_called_once_with(["/la", "/lb"], ["physical/a", "physical/b"], None, 8)
     assert metadata_provider.add_file.call_count == 2
     added_meta_a = metadata_provider.add_file.call_args_list[0][0][1]
     assert added_meta_a.metadata == {"tag": "first", "count": 1}


### PR DESCRIPTION
## Description

Avoid forwarding user attributes to physical storage writes when a metadata provider is active.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed attribute handling for write and upload flows when using a metadata provider: user-supplied attributes are now applied only to metadata registration and are not forwarded to underlying storage provider write/upload calls, preventing unintended attribute propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/multi-storage-client/pull/50)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->