### PR TITLE
chore: Upgrade AIStore Nix package to 1.4.5.

### DIFF
--- a/nix/overlays/development/multi-storage-client/packages/aistore/package.nix
+++ b/nix/overlays/development/multi-storage-client/packages/aistore/package.nix
@@ -7,20 +7,20 @@
 # https://nixos.org/manual/nixpkgs/unstable#ssec-language-go
 buildGoModule (finalAttrs: {
   pname = "aistore";
-  version = "1.4.4";
+  version = "1.4.5";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "aistore";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GAu+KKm5BeDBSpX4QY4CWdIMqIU+ESqvv0EGUGjwlWM=";
+    hash = "sha256-tHznq3QP/XX3Czh3JwFI0XmiIYo1xYwvZy+c1nTxBL8=";
   };
 
-  vendorHash = "sha256-ESXiEBtGtsQApoVPmmLMkDR17dKJzMcWxG49n5l9IjA=";
+  vendorHash = "sha256-sjO3Ktrb5H2efYv1C1O597C6XHw9Pzc692XC6oBzH6I=";
 
   # Exclude `cmd/cli` and `cmd/ishard` which are separate Go modules.
   #
-  # https://github.com/NVIDIA/aistore/tree/v1.4.4/cmd
+  # https://github.com/NVIDIA/aistore/tree/v1.4.5/cmd
   subPackages = [
     "cmd/aisinit"
     "cmd/aisloader"
@@ -32,7 +32,7 @@ buildGoModule (finalAttrs: {
 
   # Needed for version strings.
   #
-  # https://github.com/NVIDIA/aistore/blob/v1.4.4/Makefile#L86
+  # https://github.com/NVIDIA/aistore/blob/v1.4.5/Makefile#L86
   ldflags = [
     "-X main.build=v${finalAttrs.version}"
     "-X main.buildtime=1970-01-01T00:00:00-00:00"
@@ -41,7 +41,7 @@ buildGoModule (finalAttrs: {
   tags = [
     # Monotonic time.
     #
-    # https://github.com/NVIDIA/aistore/blob/v1.4.4/Makefile#L98
+    # https://github.com/NVIDIA/aistore/blob/v1.4.5/Makefile#L98
     "mono"
   ];
 


### PR DESCRIPTION
## Description

Upgrade AIStore Nix package to 1.4.5.

Updated hashes are found by:

1. Setting the `fetchFromGitHub.hash` and `vendorHash` to `lib.fakeHash`.
2. Running `nix build .#aistore` or starting the Nix shell (will build the `aistore` package).
3. Nix will complain the fake hashes don't match the calculated hashes. Substitute in the calculated hash.
   - This process is done twice: once for `fetchFromGitHub.hash` (hash of the cloned source code) and once for `vendorHash` (hash of the downloaded Go modules).

Closes NGCDP-8601.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded aistore package to version 1.4.5.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/multi-storage-client/pull/51)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->