### PR TITLE
fix: stream dry-run sync output before joining producer

### DIFF
--- a/multi-storage-client/src/multistorageclient/sync/manager.py
+++ b/multi-storage-client/src/multistorageclient/sync/manager.py
@@ -418,7 +418,6 @@ class SyncManager:
             batch_size,
         )
         producer_thread.start()
-        producer_thread.join()
 
         if output_path:
             dryrun_dir = output_path
@@ -433,6 +432,7 @@ class SyncManager:
         total_bytes_added = 0
         total_bytes_deleted = 0
 
+        # Stream the producer output to JSONL files.
         with open(add_path, "w") as add_file, open(delete_path, "w") as delete_file:
             while True:
                 batch = file_queue.get()
@@ -448,6 +448,9 @@ class SyncManager:
                         delete_file.write(json.dumps(item.to_dict()) + "\n")
                         total_files_deleted += 1
                         total_bytes_deleted += item.content_length
+
+        # Wait for the producer thread to finish.
+        producer_thread.join()
 
         progress.close()
         logger.debug(f"Completed dryrun sync operation {description}")


### PR DESCRIPTION
## Description

Fix dry-run sync to consume producer batches while the producer is running, then join the producer after the queue has been drained. This reduces memory consumption for large datasets by streaming generated metadata batches to disk instead of waiting for all producer output before processing.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dryrun synchronization to ensure queued batch operations are streamed to output files before processing completes, preventing potential data loss during dryrun operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/multi-storage-client/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->