### PR TITLE
fix: cache path mapping in _resolve_non_msc_url

### DIFF
--- a/multi-storage-client/src/multistorageclient/shortcuts.py
+++ b/multi-storage-client/src/multistorageclient/shortcuts.py
@@ -21,7 +21,7 @@ from typing import Any, Optional, Union
 from urllib.parse import ParseResult, urlparse
 
 from .client import StorageClient
-from .config import RESERVED_POSIX_PROFILE_NAME, SUPPORTED_IMPLICIT_PROFILE_PROTOCOLS, StorageClientConfig
+from .config import RESERVED_POSIX_PROFILE_NAME, SUPPORTED_IMPLICIT_PROFILE_PROTOCOLS, PathMapping, StorageClientConfig
 from .file import ObjectFile, PosixFile
 from .telemetry import Telemetry
 from .types import MSC_PROTOCOL, ExecutionMode, ObjectMetadata, PatternList, SignerType, SymlinkHandling, SyncResult
@@ -30,6 +30,8 @@ _TELEMETRY_PROVIDER: Optional[Callable[[], Telemetry]] = None
 _TELEMETRY_PROVIDER_LOCK = threading.Lock()
 _STORAGE_CLIENT_CACHE: dict[str, StorageClient] = {}
 _STORAGE_CLIENT_CACHE_LOCK = threading.Lock()
+_PATH_MAPPING_CACHE: dict[Optional[str], PathMapping] = {}
+_PATH_MAPPING_CACHE_LOCK = threading.Lock()
 _PROCESS_ID = os.getpid()
 
 logger = logging.getLogger(__name__)
@@ -48,11 +50,14 @@ def _reinitialize_after_fork() -> None:
     only its lock is reinitialized.
     """
     global _STORAGE_CLIENT_CACHE, _STORAGE_CLIENT_CACHE_LOCK
+    global _PATH_MAPPING_CACHE, _PATH_MAPPING_CACHE_LOCK
     global _TELEMETRY_PROVIDER_LOCK
     global _PROCESS_ID
 
     _STORAGE_CLIENT_CACHE.clear()
     _STORAGE_CLIENT_CACHE_LOCK = threading.Lock()
+    _PATH_MAPPING_CACHE.clear()
+    _PATH_MAPPING_CACHE_LOCK = threading.Lock()
     # we don't need to reset telemetry provider as it is supposed to be a top-level Python function
     _TELEMETRY_PROVIDER_LOCK = threading.Lock()
     _PROCESS_ID = os.getpid()
@@ -133,6 +138,27 @@ def _resolve_msc_url(url: str) -> tuple[str, str]:
     return profile, path
 
 
+def _read_cached_path_mapping() -> PathMapping:
+    """
+    Read path mapping once per ``MSC_CONFIG`` value for shortcut URL resolution.
+
+    Path mapping checks happen on every non-MSC shortcut call, including POSIX paths. Caching here keeps that hot path
+    from repeatedly loading and validating the full MSC config while preserving ``StorageClientConfig.read_path_mapping``
+    behavior for direct callers.
+    """
+    cache_key = os.getenv("MSC_CONFIG", None)
+    if cache_key in _PATH_MAPPING_CACHE:
+        return _PATH_MAPPING_CACHE[cache_key]
+
+    with _PATH_MAPPING_CACHE_LOCK:
+        if cache_key in _PATH_MAPPING_CACHE:
+            return _PATH_MAPPING_CACHE[cache_key]
+
+        path_mapping = StorageClientConfig.read_path_mapping()
+        _PATH_MAPPING_CACHE[cache_key] = path_mapping
+        return path_mapping
+
+
 def _resolve_non_msc_url(url: str) -> tuple[str, str]:
     """
     Resolve a non-MSC URL to a profile name and path.
@@ -146,7 +172,7 @@ def _resolve_non_msc_url(url: str) -> tuple[str, str]:
     :return: A tuple of (profile_name, path)
     """
     # Check if we have a valid path mapping, if so check if there is a matching mapping
-    path_mapping = StorageClientConfig.read_path_mapping()
+    path_mapping = _read_cached_path_mapping()
     if path_mapping:
         # Look for a matching mapping
         possible_mapping = path_mapping.find_mapping(url)

--- a/multi-storage-client/tests/test_multistorageclient/unit/conftest.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/conftest.py
@@ -112,6 +112,8 @@ def reset_globals():
 
     with shortcuts._STORAGE_CLIENT_CACHE_LOCK:
         shortcuts._STORAGE_CLIENT_CACHE.clear()
+    with shortcuts._PATH_MAPPING_CACHE_LOCK:
+        shortcuts._PATH_MAPPING_CACHE.clear()
 
     # Preserve MSC environment variables for testing
     msc_num_processes = os.environ.get("MSC_NUM_PROCESSES")

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_shortcuts.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_shortcuts.py
@@ -24,6 +24,7 @@ import numpy as np
 import pytest
 
 import multistorageclient as msc
+import multistorageclient.config as msc_config
 from multistorageclient.client import StorageClient
 from multistorageclient.file import ObjectFile
 from multistorageclient.providers.manifest_metadata import (
@@ -711,6 +712,26 @@ def test_implicit_profiles_with_msc_config(file_storage_config_with_path_mapping
         for env_var in ["AWS_ENDPOINT_URL"]:
             if env_var in os.environ:
                 del os.environ[env_var]
+
+
+def test_path_mapping_is_cached_for_repeated_non_msc_resolution(file_storage_config_with_path_mapping, monkeypatch):
+    """Repeated POSIX resolution should not reload path mapping for an unchanged config."""
+    calls = 0
+    original_from_config = msc_config.PathMapping.from_config
+
+    def counting_from_config(config_dict=None):
+        nonlocal calls
+        calls += 1
+        return original_from_config(config_dict)
+
+    monkeypatch.setattr(msc_config.PathMapping, "from_config", counting_from_config)
+
+    for index in range(3):
+        client, path = msc.resolve_storage_client(f"/tmp/msc-cache-test-{index}.txt")
+        assert client.profile == "__filesystem__"
+        assert path == f"/tmp/msc-cache-test-{index}.txt"
+
+    assert calls == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Fix the performance issue of `msc.open` when MSC_CONFIG is provided by caching the path mapping.

**Before**
```
Iterations: 1000
case                            total(s)    mean(us)  median(us)     p95(us)     p99(us)
----------------------------------------------------------------------------------------
baseline: no MSC_CONFIG         0.063855       63.68       61.13       75.83      137.13
target: S3/cache MSC_CONFIG    14.364555    14363.80    14209.98    15079.33    17883.42

Delta total: 14.300701s (224.96x)
Delta mean:  14300.13us/open
```

**After**
```
Iterations: 1000
case                            total(s)    mean(us)  median(us)     p95(us)     p99(us)
----------------------------------------------------------------------------------------
baseline: no MSC_CONFIG         0.029590       29.43       27.25       36.21       69.46
target: S3/cache MSC_CONFIG     0.027984       27.80       25.58       33.92       69.29

Delta total: -0.001606s (0.95x)
Delta mean:  -1.63us/open
```

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Non-MSC path resolution is faster through improved caching of path mappings.

* **Reliability**
  * Cache handling now reinitializes safely across process forks to avoid stale state.

* **Tests**
  * Added tests verifying path-mapping caching behavior and reset between tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/multi-storage-client/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->