### PR TITLE
fix: Document boto3 S3 transfer manager pass-through options on S3 storage provider.

### DIFF
--- a/multi-storage-client-docs/src/references/configuration.rst
+++ b/multi-storage-client-docs/src/references/configuration.rst
@@ -544,7 +544,6 @@ Options: See parameters in :py:class:`multistorageclient.providers.ais_s3.AIStor
            password: ${AIS_PASSWORD}
            authn_endpoint: https://authn.example.com:52001
            ca_cert: /path/to/authn-ca.crt  # CA certificate for AuthN server (often same as above)
-.. _rust-client-reference:
 
 ``huggingface``
 ---------------
@@ -587,6 +586,8 @@ Options: See parameters in :py:class:`multistorageclient.providers.huggingface.H
    operations.
 
    For detailed configuration instructions, see the `HuggingFace documentation <https://huggingface.co/docs/huggingface_hub/en/guides/download#faster-downloads>`_.
+
+.. _rust-client-reference:
 
 ``rust_client`` (experimental)
 ------------------------------
@@ -1354,9 +1355,9 @@ When a profile is configured with multiple backends, MSC automatically uses a :p
 
 .. important::
    **Metadata Provider Requirement**
-   
+
    Multi-backend configuration requires a custom metadata provider that returns routing information. The metadata provider must implement ``realpath()`` to return a :py:class:`~multistorageclient.types.ResolvedPath` object with the ``profile`` field set to match one of your configured backend profile names.
-   
+
    The standard ``manifest`` metadata provider does not support multi-backend routing and cannot be used with this feature.
 
 Configuration Using storage_provider_profiles
@@ -1380,7 +1381,7 @@ The recommended approach is to define individual backend profiles, then referenc
          options:
            access_key: ${AWS_ACCESS_KEY_US}
            secret_key: ${AWS_SECRET_KEY_US}
-     
+
      # Backend 2: EU West region
      eu-west-backend:
        storage_provider:
@@ -1393,7 +1394,7 @@ The recommended approach is to define individual backend profiles, then referenc
          options:
            access_key: ${AWS_ACCESS_KEY_EU}
            secret_key: ${AWS_SECRET_KEY_EU}
-     
+
      # Multi-backend profile (read-only)
      global-dataset:
        storage_provider_profiles:

--- a/multi-storage-client/src/multistorageclient/providers/s3.py
+++ b/multi-storage-client/src/multistorageclient/providers/s3.py
@@ -171,10 +171,8 @@ class S3StorageProvider(BaseStorageProvider):
             Can be ``True`` (verify using system CA bundle, default), ``False`` (skip verification), or a string path to a custom CA certificate bundle.
         :param request_checksum_calculation: For :py:class:`botocore.config.Config`.
             When the underlying S3 client should calculate request checksums.
-            See the equivalent option in the `AWS configuration file <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-a-configuration-file>`_.
         :param response_checksum_validation: For :py:class:`botocore.config.Config`.
             When the underlying S3 client should validate response checksums.
-            See the equivalent option in the `AWS configuration file <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-a-configuration-file>`_.
         :param max_pool_connections: For :py:class:`botocore.config.Config`.
             The maximum number of connections to keep in a connection pool.
         :param connect_timeout: For :py:class:`botocore.config.Config`.
@@ -188,6 +186,16 @@ class S3StorageProvider(BaseStorageProvider):
         :param checksum_algorithm: Upload-only object integrity algorithm.
             One of ``"CRC32"``, ``"CRC32C"``, ``"SHA1"``, ``"SHA256"``, ``"CRC64NVME"`` (case-insensitive).
             When ``rust_client`` is enabled, only ``"SHA256"`` is accepted.
+        :param multipart_threshold: For :py:class:`boto3.s3.transfer.TransferConfig`.
+            The transfer size threshold for which multipart uploads, downloads, and copies will automatically be triggered.
+        :param max_concurrency: For :py:class:`boto3.s3.transfer.TransferConfig`.
+            The maximum number of threads that will be making requests to perform a transfer.
+            If ``use_threads`` is set to ``False``, the value provided is ignored as the transfer will only ever use the current thread.
+        :param multipart_chunksize: For :py:class:`boto3.s3.transfer.TransferConfig`.
+            The partition size of each part for a multipart transfer.
+        :param io_chunksize: For :py:class:`boto3.s3.transfer.TransferConfig`.
+            The max size of each chunk in the ``io`` queue. Currently, this is the size used when read is called on the downloaded stream as well.
+            Note: This value is ignored when resolved transfer manager type is CRTTransferManager.
         """
         super().__init__(
             base_path=base_path,


### PR DESCRIPTION
## Description

We're missing docstrings for the boto3 S3 transfer manager constructor args we pass-through from the S3 storage provider constructor args.

Closes NGCDP-8670.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified S3 storage configuration guidance: improved description of checksum validation and expanded guidance for transfer-related options (multipart threshold, concurrency, chunk sizes), including a note that some transfer managers ignore I/O chunk-size.
  * Reorganized and reformatted reference content: adjusted section labeling, important-note placement, and example spacing for clearer multi-backend configuration documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/multi-storage-client/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->