### PR TITLE
fix: release BytesIO buffer after Rust retry

### DIFF
--- a/multi-storage-client/src/multistorageclient/providers/s3.py
+++ b/multi-storage-client/src/multistorageclient/providers/s3.py
@@ -971,7 +971,10 @@ class S3StorageProvider(BaseStorageProvider):
 
                 if self._rust_client and isinstance(f, io.BytesIO) and not extra_args:
                     data = f.getbuffer()
-                    run_async_rust_client_method(self._rust_client, "upload_multipart_from_bytes", key, data)
+                    try:
+                        run_async_rust_client_method(self._rust_client, "upload_multipart_from_bytes", key, data)
+                    finally:
+                        data.release()
                 else:
                     if self._checksum_algorithm:
                         extra_args["ChecksumAlgorithm"] = self._checksum_algorithm

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_s3_error_translation.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_s3_error_translation.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -20,7 +22,12 @@ from botocore.exceptions import ClientError, IncompleteReadError, ReadTimeoutErr
 
 from multistorageclient.providers.s3 import S3StorageProvider, StaticS3CredentialsProvider
 from multistorageclient.types import PreconditionFailedError, RetryableError
-from multistorageclient_rust import RustClientError, RustRetryableError
+from multistorageclient_rust import RustClient, RustClientError, RustRetryableError
+
+
+class _FailingRustClient:
+    async def upload_multipart_from_bytes(self, key, data):
+        raise RustRetryableError("Connection reset by peer")
 
 
 def _create_s3_provider() -> S3StorageProvider:
@@ -358,6 +365,20 @@ def test_translate_errors_rust_retryable_error():
     assert "retryable error from Rust" in str(exc_info.value)
     assert "test-bucket/test-key" in str(exc_info.value)
     assert "RustRetryableError" in str(exc_info.value)
+
+
+def test_large_bytesio_upload_releases_buffer_after_rust_retryable_error():
+    provider = _create_s3_provider()
+    provider._rust_client = cast(RustClient, _FailingRustClient())
+    provider._multipart_threshold = 1
+    provider._checksum_algorithm = None
+
+    stream = io.BytesIO(b"large enough for multipart")
+
+    with pytest.raises(RetryableError):
+        provider._upload_file("test-bucket/test-key", stream)
+
+    stream.close()
 
 
 def test_translate_errors_generic_exception():


### PR DESCRIPTION
## Description

When uploading a large `BytesIO` through the Rust client, MSC uses `BytesIO.getbuffer()` to pass data into Rust without copying. If the Rust upload hits a retryable error, the exported buffer can remain alive long enough for `ObjectFile.close()` to later close the underlying `BytesIO`, which raises:

```
BufferError: Existing exports of data: object cannot be re-sized
```

This makes the failure appear to come from ObjectFile.close() / fp.close(), while the root cause is the unreleased exported buffer from the Rust upload bridge.

This PR releases the exported buffer in a finally block so both success and error paths clean up correctly.

Add a regression test for the Rust retryable error path.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multipart upload reliability by ensuring in-memory upload buffers are always released even when upload attempts fail.
* **Tests**
  * Added a unit test to verify buffers are cleaned up after simulated upload errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/multi-storage-client/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->