### PR TITLE
fix: add ordering support for multi-storage paths

### DIFF
--- a/multi-storage-client-docs/src/user_guide/libraries.rst
+++ b/multi-storage-client-docs/src/user_guide/libraries.rst
@@ -216,4 +216,7 @@ This module provides the ``Path`` class for working with paths in a way similar 
    for matched in msc.Path("msc://data-s3-iad/data").glob("*.txt"):
        print(matched)
 
+   # Sort paths for deterministic processing
+   paths = sorted(msc.Path("msc://data-s3-iad/data").glob("*.txt"))
+
 .. note:: The ``Path`` class implements much of the same interface as ``pathlib.Path``, making it familiar to use while working with remote storage.

--- a/multi-storage-client/src/multistorageclient/pathlib.py
+++ b/multi-storage-client/src/multistorageclient/pathlib.py
@@ -17,7 +17,9 @@ import codecs
 import logging
 import os
 import stat
-from pathlib import Path, PurePosixPath
+from functools import total_ordering
+from pathlib import Path, PurePath, PurePosixPath
+from types import NotImplementedType
 from typing import Union
 
 from .client import StorageClient
@@ -69,6 +71,7 @@ class StatResult:
         self.st_gid = os.getgid() if hasattr(os, "getgid") else 0  # Group ID
 
 
+@total_ordering
 class MultiStoragePath:
     """
     A path object similar to pathlib.Path that supports both local and remote file systems.
@@ -119,6 +122,35 @@ class MultiStoragePath:
             self._storage_client.profile == other._storage_client.profile
             and self._internal_path == other._internal_path
         )
+
+    def __lt__(self, other):
+        """
+        Return True if this path sorts before another path-like object.
+
+        Ordering is based on the normalized storage profile and internal path. ``pathlib`` paths are
+        compared as local filesystem paths; unsupported types return ``NotImplemented``.
+        """
+        other = self._coerce_path(other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._ordering_key() < other._ordering_key()
+
+    @staticmethod
+    def _coerce_path(other) -> "MultiStoragePath | NotImplementedType":
+        """
+        Convert supported path-like objects to ``MultiStoragePath`` for comparison.
+        """
+        if isinstance(other, MultiStoragePath):
+            return other
+        if isinstance(other, PurePath):
+            return MultiStoragePath(other)
+        return NotImplemented
+
+    def _ordering_key(self) -> tuple[str, PurePosixPath]:
+        """
+        Return the resolved profile and internal path used for equality-compatible ordering.
+        """
+        return (self._storage_client.profile, self._internal_path)
 
     def __hash__(self) -> int:
         """Return hash of the path."""

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_pathlib.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_pathlib.py
@@ -250,6 +250,51 @@ def test_hashable_path():
     assert len(paths) == 1
 
 
+def test_path_ordering():
+    config.setup_msc_config(
+        config_dict={
+            "profiles": {
+                "test": {
+                    "storage_provider": {
+                        "type": "file",
+                        "options": {"base_path": tempfile.gettempdir()},
+                    }
+                }
+            }
+        }
+    )
+
+    local_path = msc.Path("/tmp/testfile")
+    filesystem_path = msc.Path("msc://__filesystem__/tmp/testfile")
+
+    paths = [
+        msc.Path("msc://test/datasets/b.parquet"),
+        local_path,
+        msc.Path("msc://test/datasets/a.parquet"),
+        filesystem_path,
+    ]
+
+    assert sorted(paths) == [
+        local_path,
+        filesystem_path,
+        msc.Path("msc://test/datasets/a.parquet"),
+        msc.Path("msc://test/datasets/b.parquet"),
+    ]
+    assert min(paths) == local_path
+    assert max(paths) == msc.Path("msc://test/datasets/b.parquet")
+    assert local_path == filesystem_path
+    assert not (local_path < filesystem_path)
+    assert not (filesystem_path < local_path)
+    assert local_path != Path("/tmp/testfile")
+    assert [str(path) for path in sorted([Path("/tmp/z"), msc.Path("/tmp/a"), PurePosixPath("/tmp/m")])] == [
+        "/tmp/a",
+        "/tmp/m",
+        "/tmp/z",
+    ]
+    with pytest.raises(TypeError):
+        msc.Path("/tmp/testfile") < "/tmp/other"
+
+
 def test_pickable_path():
     local_path = msc.Path("/tmp/test/file.txt")
     pickled = pickle.dumps(local_path)


### PR DESCRIPTION
## Description

Adds ordering support to MultiStoragePath so deterministic ordering patterns work:

```
paths = sorted(msc.Path("msc://profile/data").glob("*.parquet"))
```

Closes #62 

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Path objects are now sortable and comparable, supporting `sorted()`, `min()`, and `max()` operations across different storage profiles.

* **Documentation**
  * Updated user guide example to sort glob results before iteration for deterministic file processing.

* **Tests**
  * Added unit tests validating path ordering and comparison functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/multi-storage-client/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->