### PR TITLE
fix: handle buffer-protocol read results in data size metrics

### DIFF
--- a/multi-storage-client/src/multistorageclient/providers/base.py
+++ b/multi-storage-client/src/multistorageclient/providers/base.py
@@ -387,7 +387,8 @@ class BaseStorageProvider(StorageProvider):
                 data_size = sum(len(item) if item.isascii() else len(item.encode()) for item in result)
         else:
             try:
-                data_size = memoryview(cast(Union[bytes, bytearray, memoryview], result)).nbytes
+                buffer_result: Any = result
+                data_size = memoryview(buffer_result).nbytes
             except TypeError:
                 pass
 

--- a/multi-storage-client/src/multistorageclient/providers/base.py
+++ b/multi-storage-client/src/multistorageclient/providers/base.py
@@ -380,15 +380,15 @@ class BaseStorageProvider(StorageProvider):
             data_size = len(result) if result.isascii() else len(result.encode())
         elif isinstance(result, int):
             data_size = result
-        elif isinstance(result, list) and len(result) > 0:
-            if isinstance(result[0], bytes):
-                data_size = sum(len(item) for item in result)
-            elif isinstance(result[0], str):
-                data_size = sum(len(item) if item.isascii() else len(item.encode()) for item in result)
+        elif isinstance(result, list):
+            if len(result) > 0:
+                if isinstance(result[0], bytes):
+                    data_size = sum(len(item) for item in result)
+                elif isinstance(result[0], str):
+                    data_size = sum(len(item) if item.isascii() else len(item.encode()) for item in result)
         else:
             try:
-                buffer_result: Any = result
-                data_size = memoryview(buffer_result).nbytes
+                data_size = memoryview(result).nbytes
             except TypeError:
                 pass
 

--- a/multi-storage-client/src/multistorageclient/providers/base.py
+++ b/multi-storage-client/src/multistorageclient/providers/base.py
@@ -385,6 +385,11 @@ class BaseStorageProvider(StorageProvider):
                 data_size = sum(len(item) for item in result)
             elif isinstance(result[0], str):
                 data_size = sum(len(item) if item.isascii() else len(item.encode()) for item in result)
+        else:
+            try:
+                data_size = memoryview(result).nbytes
+            except TypeError:
+                pass
 
         return data_size
 

--- a/multi-storage-client/src/multistorageclient/providers/base.py
+++ b/multi-storage-client/src/multistorageclient/providers/base.py
@@ -387,7 +387,7 @@ class BaseStorageProvider(StorageProvider):
                 data_size = sum(len(item) if item.isascii() else len(item.encode()) for item in result)
         else:
             try:
-                data_size = memoryview(result).nbytes
+                data_size = memoryview(cast(Union[bytes, bytearray, memoryview], result)).nbytes
             except TypeError:
                 pass
 

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_base_storage_provider.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_base_storage_provider.py
@@ -375,6 +375,29 @@ def test_list_objects_with_empty_base_path():
         list(provider.list_objects(path=""))
 
 
+def test_calculate_data_size_supports_buffer_protocol_result():
+    provider = MockBaseStorageProvider(base_path="bucket", provider_name="mock")
+
+    cases = [
+        (b"abcd", 4),
+        ("abcd", 4),
+        ("é", 2),
+        (4, 4),
+        ([b"ab", b"cd"], 4),
+        (["ab", "é"], 4),
+        (bytearray(b"abcd"), 4),
+        (memoryview(b"abcd"), 4),
+    ]
+    for result, expected_size in cases:
+        assert provider._calculate_data_size(result, BaseStorageProvider._Operation.READ, None) == expected_size
+
+    assert provider._calculate_data_size(object(), BaseStorageProvider._Operation.READ, None) is None
+    assert (
+        provider._calculate_data_size(bytearray(b"abcd"), BaseStorageProvider._Operation.READ, "RuntimeError") is None
+    )
+    assert provider._calculate_data_size(bytearray(b"abcd"), BaseStorageProvider._Operation.INFO, None) is None
+
+
 def test_async_metrics_disabled_by_default():
     """Test that async metrics are disabled when not specified in config."""
     config = {


### PR DESCRIPTION
## Description

- Add buffer-protocol fallback sizing in `BaseStorageProvider._calculate_data_size`
- Covers Rust client read results such as `builtins.Bytes`, `bytearray`, and `memoryview`
- Add focused unit coverage for existing scalar/list behavior plus buffer-protocol results

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced data-size calculation to support additional buffer-like inputs (e.g., bytes/memoryview/bytearray and similar) and to leave size unspecified for unsupported types or empty collections.
* **Tests**
  * Added unit tests verifying size computation across buffer-supported inputs and confirming unsupported inputs return no size metric.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->