### PR TITLE
fix: raise on broken symlink under SymlinkHandling.FOLLOW

### DIFF
--- a/multi-storage-client/src/multistorageclient/providers/posix_file.py
+++ b/multi-storage-client/src/multistorageclient/providers/posix_file.py
@@ -348,6 +348,17 @@ class PosixFileStorageProvider(BaseStorageProvider):
                         symlink_info[relative_path] = (relative_target, target_type)
                     continue
 
+                if is_link and symlink_handling == SymlinkHandling.FOLLOW:
+                    # Broken symlinks have no target to dereference: isfile/isdir both return
+                    # False, so the entry would be silently dropped. Fail fast instead.
+                    real_target = os.path.realpath(full_path)
+                    if not os.path.exists(real_target):
+                        relative_path = os.path.relpath(full_path, self._base_path)
+                        raise ValueError(
+                            f"Broken symlink '{relative_path}' points to a missing target "
+                            f"({full_path} -> {real_target}). Use symlink_handling=SKIP to ignore."
+                        )
+
                 relative_path = os.path.relpath(full_path, self._base_path)
 
                 if (start_after is None or start_after < relative_path) and (end_at is None or relative_path <= end_at):

--- a/multi-storage-client/src/multistorageclient/providers/posix_file.py
+++ b/multi-storage-client/src/multistorageclient/providers/posix_file.py
@@ -320,7 +320,7 @@ class PosixFileStorageProvider(BaseStorageProvider):
 
                     real_target = os.path.realpath(full_path)
                     if not os.path.exists(real_target):
-                        raise ValueError(
+                        raise FileNotFoundError(
                             f"Broken symlink '{relative_path}' points to a missing target "
                             f"({full_path} -> {real_target}). Use symlink_handling=SKIP to ignore."
                         )
@@ -354,7 +354,7 @@ class PosixFileStorageProvider(BaseStorageProvider):
                     real_target = os.path.realpath(full_path)
                     if not os.path.exists(real_target):
                         relative_path = os.path.relpath(full_path, self._base_path)
-                        raise ValueError(
+                        raise FileNotFoundError(
                             f"Broken symlink '{relative_path}' points to a missing target "
                             f"({full_path} -> {real_target}). Use symlink_handling=SKIP to ignore."
                         )
@@ -412,6 +412,8 @@ class PosixFileStorageProvider(BaseStorageProvider):
                         symlink_target=relative_target,
                     )
 
+        except FileNotFoundError:
+            raise
         except (OSError, PermissionError) as e:
             logger.warning(f"Failed to list contents of {dir_path}, caused by: {e}")
             return

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_symlinks.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_symlinks.py
@@ -557,6 +557,58 @@ def test_list_recursive_symlinks_from_posix_with_preserve_raises_on_broken_targe
             list(storage_client.list_recursive(path="", symlink_handling=SymlinkHandling.PRESERVE))
 
 
+@pytest.mark.parametrize(
+    argnames=["temp_data_store_type"],
+    argvalues=[[tempdatastore.TemporaryPOSIXDirectory]],
+)
+def test_list_symlinks_from_posix_with_follow_raises_on_broken_target(
+    temp_data_store_type: type[tempdatastore.TemporaryDataStore],
+):
+    """
+    ``symlink_handling=SymlinkHandling.FOLLOW`` must raise ``ValueError``
+    when a symlink's target does not exist (broken / dangling symlink),
+    symmetric with :py:attr:`SymlinkHandling.PRESERVE`.
+
+    Under ``FOLLOW`` a symlink is dereferenced and classified as a regular
+    file or directory. A broken symlink is neither -- ``os.path.isfile`` and
+    ``os.path.isdir`` both follow the link to the missing target and return
+    ``False`` -- so without an explicit guard the entry is silently dropped
+    from the listing. That silent omission lets an upload/sync "succeed"
+    while quietly leaving out files the caller intended to include, so the
+    provider must fail fast instead, telling the caller to switch to
+    ``SKIP`` to ignore the symlink.
+
+    Layout created by this test::
+
+        base_dir/
+        ├── c.txt
+        └── dangling   -> missing.txt   (target does not exist)
+    """
+    with temp_data_store_type() as temp_data_store:
+        storage_client, base_path = _build_posix_storage_client_for_preserve_error(temp_data_store)
+
+        os.symlink(os.path.join(base_path, "missing.txt"), os.path.join(base_path, "dangling"))
+
+        with pytest.raises(ValueError, match="Broken symlink"):
+            list(storage_client.list(prefix="", symlink_handling=SymlinkHandling.FOLLOW))
+
+
+@pytest.mark.parametrize(
+    argnames=["temp_data_store_type"],
+    argvalues=[[tempdatastore.TemporaryPOSIXDirectory]],
+)
+def test_list_recursive_symlinks_from_posix_with_follow_raises_on_broken_target(
+    temp_data_store_type: type[tempdatastore.TemporaryDataStore],
+):
+    with temp_data_store_type() as temp_data_store:
+        storage_client, base_path = _build_posix_storage_client_for_preserve_error(temp_data_store)
+
+        os.symlink(os.path.join(base_path, "missing.txt"), os.path.join(base_path, "dangling"))
+
+        with pytest.raises(ValueError, match="Broken symlink"):
+            list(storage_client.list_recursive(path="", symlink_handling=SymlinkHandling.FOLLOW))
+
+
 @pytest.mark.serial
 def test_sync_from_posix_to_s3_to_posix_preserves_symlinks():
     """

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_symlinks.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_symlinks.py
@@ -537,7 +537,7 @@ def test_list_symlinks_from_posix_with_preserve_raises_on_broken_target(
 
         os.symlink(os.path.join(base_path, "missing.txt"), os.path.join(base_path, "dangling"))
 
-        with pytest.raises(ValueError, match="Broken symlink"):
+        with pytest.raises(FileNotFoundError, match="Broken symlink"):
             list(storage_client.list(prefix="", symlink_handling=SymlinkHandling.PRESERVE))
 
 
@@ -553,7 +553,7 @@ def test_list_recursive_symlinks_from_posix_with_preserve_raises_on_broken_targe
 
         os.symlink(os.path.join(base_path, "missing.txt"), os.path.join(base_path, "dangling"))
 
-        with pytest.raises(ValueError, match="Broken symlink"):
+        with pytest.raises(FileNotFoundError, match="Broken symlink"):
             list(storage_client.list_recursive(path="", symlink_handling=SymlinkHandling.PRESERVE))
 
 
@@ -565,7 +565,7 @@ def test_list_symlinks_from_posix_with_follow_raises_on_broken_target(
     temp_data_store_type: type[tempdatastore.TemporaryDataStore],
 ):
     """
-    ``symlink_handling=SymlinkHandling.FOLLOW`` must raise ``ValueError``
+    ``symlink_handling=SymlinkHandling.FOLLOW`` must raise ``FileNotFoundError``
     when a symlink's target does not exist (broken / dangling symlink),
     symmetric with :py:attr:`SymlinkHandling.PRESERVE`.
 
@@ -589,7 +589,7 @@ def test_list_symlinks_from_posix_with_follow_raises_on_broken_target(
 
         os.symlink(os.path.join(base_path, "missing.txt"), os.path.join(base_path, "dangling"))
 
-        with pytest.raises(ValueError, match="Broken symlink"):
+        with pytest.raises(FileNotFoundError, match="Broken symlink"):
             list(storage_client.list(prefix="", symlink_handling=SymlinkHandling.FOLLOW))
 
 
@@ -605,7 +605,7 @@ def test_list_recursive_symlinks_from_posix_with_follow_raises_on_broken_target(
 
         os.symlink(os.path.join(base_path, "missing.txt"), os.path.join(base_path, "dangling"))
 
-        with pytest.raises(ValueError, match="Broken symlink"):
+        with pytest.raises(FileNotFoundError, match="Broken symlink"):
             list(storage_client.list_recursive(path="", symlink_handling=SymlinkHandling.FOLLOW))
 
 


### PR DESCRIPTION
## Description

FOLLOW dereferences symlinks transparently and classifies them via os.path.isfile/os.path.isdir, both of which follow the link to the target. For a broken (dangling) symlink both return False, so the entry matched neither branch and was silently dropped from the listing -- an upload/sync could "succeed" while omitting files the caller intended to include.

Add a FOLLOW branch that raises ValueError for a broken target, symmetric with the existing PRESERVE check. FOLLOW still permits targets outside base_path (dereferencing them is its intended behavior), so only the broken-target case raises.

Adds list/list_recursive regression tests mirroring the PRESERVE broken-target tests.

Related to NGCDP-8829

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broken symlinks are now detected and reported as FileNotFoundError during directory listing when using FOLLOW mode (message indicates a broken symlink and suggests using SKIP to ignore them), preventing silent omission.

* **Tests**
  * Added tests asserting that listing and recursive listing in FOLLOW mode raise FileNotFoundError for dangling symlinks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->