### PR TITLE
chore: replace asserts with exception in non-test code

### DIFF
--- a/multi-storage-client-scripts/src/multistorageclient_scripts/utils/argparse_extensions/__init__.py
+++ b/multi-storage-client-scripts/src/multistorageclient_scripts/utils/argparse_extensions/__init__.py
@@ -128,9 +128,8 @@ def add_argument_partial(
     # {"a": int}
     # ```
     arguments_type_hints = get_type_hints(obj=arguments_type, include_extras=False)
-    assert hasattr(arguments_type, argument_key) or argument_key in arguments_type_hints, (
-        f"{arguments_type.__name__} doesn't contain {argument_key}!"
-    )
+    if not (hasattr(arguments_type, argument_key) or argument_key in arguments_type_hints):
+        raise ValueError(f"{arguments_type.__name__} doesn't contain {argument_key}!")
 
     # Default arguments without type hints to `Any`.
     argument_type_universe: set = {arguments_type_hints.get(argument_key, Any)}
@@ -298,7 +297,8 @@ def run_cli(parser: argparse.ArgumentParser) -> NoReturn:
     arguments = parser.parse_args(args=sys.argv[1:])
 
     # Check for a command function.
-    assert hasattr(arguments, _COMMAND_FUNCTION_ARGUMENT_KEY), "Command has no command function!"
+    if not hasattr(arguments, _COMMAND_FUNCTION_ARGUMENT_KEY):
+        raise RuntimeError("Command has no command function!")
 
     # Call command function.
     sys.exit(vars(arguments)[_COMMAND_FUNCTION_ARGUMENT_KEY](arguments=arguments))

--- a/multi-storage-client-scripts/src/multistorageclient_scripts/utils/wait/__init__.py
+++ b/multi-storage-client-scripts/src/multistorageclient_scripts/utils/wait/__init__.py
@@ -33,8 +33,10 @@ def wait(
 
     For handling storage services with eventually consistent operations.
     """
-    assert max_attempts >= 1
-    assert attempt_interval_seconds >= 0
+    if max_attempts < 1:
+        raise ValueError(f"max_attempts must be >= 1, got {max_attempts}")
+    if attempt_interval_seconds < 0:
+        raise ValueError(f"attempt_interval_seconds must be >= 0, got {attempt_interval_seconds}")
 
     for attempt in range(max_attempts):
         value = waitable()

--- a/multi-storage-client/src/multistorageclient/cache.py
+++ b/multi-storage-client/src/multistorageclient/cache.py
@@ -951,7 +951,8 @@ class CacheManager:
         configured_cache_line_size = (
             self._cache_line_size
         )  # Type checker knows this is not None due to range_cache_enabled check
-        assert configured_cache_line_size is not None  # For type checker
+        if configured_cache_line_size is None:
+            raise RuntimeError("Cache line size is not configured")
 
         # Calculate needed chunks
         start_chunk = byte_range.offset // configured_cache_line_size

--- a/multi-storage-client/src/multistorageclient/client/single.py
+++ b/multi-storage-client/src/multistorageclient/client/single.py
@@ -257,7 +257,8 @@ class SingleStorageClient(AbstractStorageClient):
         :return: The physical storage path.
         :raises FileNotFoundError: If the file does not exist in the metadata provider.
         """
-        assert self._metadata_provider is not None
+        if self._metadata_provider is None:
+            raise RuntimeError("Metadata provider is not configured")
         resolved = self._metadata_provider.realpath(logical_path)
         if not resolved.exists:
             raise FileNotFoundError(f"The file at path '{logical_path}' was not found by metadata provider.")
@@ -273,7 +274,8 @@ class SingleStorageClient(AbstractStorageClient):
         :return: The physical storage path to write to.
         :raises FileExistsError: If the file exists and overwrites are not allowed.
         """
-        assert self._metadata_provider is not None
+        if self._metadata_provider is None:
+            raise RuntimeError("Metadata provider is not configured")
         resolved = self._metadata_provider.realpath(logical_path)
         if resolved.state in (ResolvedPathState.EXISTS, ResolvedPathState.DELETED):
             if not self._metadata_provider.allow_overwrites():
@@ -298,7 +300,8 @@ class SingleStorageClient(AbstractStorageClient):
         .. note::
             TODO(NGCDP-3016): Handle eventual consistency of Swiftstack, without wait.
         """
-        assert self._metadata_provider is not None
+        if self._metadata_provider is None:
+            raise RuntimeError("Metadata provider is not configured")
         obj_metadata = self._storage_provider.get_object_metadata(physical_path)
         if attributes:
             obj_metadata.metadata = (obj_metadata.metadata or {}) | attributes

--- a/multi-storage-client/src/multistorageclient/explorer/api/server.py
+++ b/multi-storage-client/src/multistorageclient/explorer/api/server.py
@@ -215,7 +215,8 @@ async def upload_config(config_file: UploadFile = File(...)):
         content = await config_file.read()
 
         # Try to parse as JSON first
-        assert config_file.filename is not None
+        if config_file.filename is None:
+            raise HTTPException(status_code=400, detail="Uploaded file must have a filename")
 
         if config_file.filename.endswith(".json"):
             config = json.loads(content)

--- a/multi-storage-client/src/multistorageclient/instrumentation/auth.py
+++ b/multi-storage-client/src/multistorageclient/instrumentation/auth.py
@@ -238,7 +238,8 @@ class VaultCertificateProvider(CertificateProvider):
         :return: Vault client token
         :raises RuntimeError: If authentication fails
         """
-        assert hvac is not None
+        if hvac is None:
+            raise ImportError("hvac package is required for Vault authentication")
         client = hvac.Client(url=self._vault_endpoint, namespace=self._vault_namespace)
 
         retry_count = 0
@@ -274,7 +275,8 @@ class VaultCertificateProvider(CertificateProvider):
         :return: Dictionary containing certificate data
         :raises RuntimeError: If fetching certificates fails
         """
-        assert hvac is not None
+        if hvac is None:
+            raise ImportError("hvac package is required for Vault authentication")
         client = hvac.Client(url=self._vault_endpoint, namespace=self._vault_namespace, token=client_token)
 
         retry_count = 0

--- a/multi-storage-client/src/multistorageclient/mcp/server.py
+++ b/multi-storage-client/src/multistorageclient/mcp/server.py
@@ -75,7 +75,8 @@ def register_handlers():
     from . import prompts, tools
 
     # Ensure modules are loaded for their side effects of tool registration
-    assert prompts and tools
+    if not hasattr(prompts, "msc_help") or not hasattr(tools, "msc_list"):
+        raise RuntimeError("MCP handler modules (prompts, tools) failed to load")
 
 
 logger = logging.getLogger(__name__)

--- a/multi-storage-client/src/multistorageclient/providers/base.py
+++ b/multi-storage-client/src/multistorageclient/providers/base.py
@@ -416,7 +416,8 @@ class BaseStorageProvider(StorageProvider):
         :param error_type: The type of error that occurred
         :return: Attributes dictionary with status
         """
-        assert base_attributes is not None, "Base attributes must not be None"
+        if base_attributes is None:
+            raise ValueError("Base attributes must not be None")
         return {
             **base_attributes,
             BaseStorageProvider._AttributeName.STATUS.value: (
@@ -428,7 +429,8 @@ class BaseStorageProvider(StorageProvider):
 
     def _metrics_worker_loop(self) -> None:
         """Background thread that processes queued metrics."""
-        assert self._metrics_queue is not None, "Metrics queue must be initialized"
+        if self._metrics_queue is None:
+            raise RuntimeError("Metrics queue must be initialized")
         while not self._metrics_worker_shutdown.is_set():
             try:
                 metric_data = self._metrics_queue.get(timeout=1.0)

--- a/multi-storage-client/src/multistorageclient/providers/manifest_metadata.py
+++ b/multi-storage-client/src/multistorageclient/providers/manifest_metadata.py
@@ -438,7 +438,8 @@ class ManifestMetadataProvider(MetadataProvider):
             if not manifest_obj:
                 return ResolvedPath(physical_path=current, state=ResolvedPathState.UNTRACKED, profile=None)
             if not manifest_obj.symlink_target:
-                assert manifest_obj.physical_path is not None
+                if manifest_obj.physical_path is None:
+                    raise ValueError(f"Manifest entry for '{current}' has no physical path")
                 return ResolvedPath(
                     physical_path=manifest_obj.physical_path, state=ResolvedPathState.EXISTS, profile=None
                 )

--- a/multi-storage-client/src/multistorageclient/signers/cloudfront.py
+++ b/multi-storage-client/src/multistorageclient/signers/cloudfront.py
@@ -75,7 +75,8 @@ class CloudFrontURLSigner(URLSigner):
 
     def _get_private_key(self) -> Any:
         if self._private_key is None:
-            assert load_pem_private_key is not None
+            if load_pem_private_key is None:
+                raise ImportError("cryptography package is required for CloudFront signed URLs")
             with open(self._private_key_path, "rb") as f:
                 self._private_key = load_pem_private_key(f.read(), password=None)
         return self._private_key

--- a/multi-storage-client/src/multistorageclient/sync/worker.py
+++ b/multi-storage-client/src/multistorageclient/sync/worker.py
@@ -375,8 +375,10 @@ class PosixToPosixHandler(BatchSyncHandler):
         for file_metadata, target_file_path in transfer_items:
             source_physical_path = self.source_client.get_posix_path(file_metadata.key)
             target_physical_path = self.target_client.get_posix_path(target_file_path)
-            assert source_physical_path is not None
-            assert target_physical_path is not None
+            if source_physical_path is None:
+                raise ValueError(f"Source key '{file_metadata.key}' has no POSIX path")
+            if target_physical_path is None:
+                raise ValueError(f"Target path '{target_file_path}' has no POSIX path")
             self._copy_to_posix_target(source_physical_path, target_physical_path)
             update_posix_metadata(self.target_client, target_physical_path, target_file_path, file_metadata)
 
@@ -395,7 +397,8 @@ class PosixToRemoteHandler(BatchSyncHandler):
 
         for file_metadata, target_file_path in transfer_items:
             source_physical_path = self.source_client.get_posix_path(file_metadata.key)
-            assert source_physical_path is not None
+            if source_physical_path is None:
+                raise ValueError(f"Source key '{file_metadata.key}' has no POSIX path")
             source_local_paths.append(source_physical_path)
             target_remote_paths.append(target_file_path)
             attributes.append(file_metadata.metadata)
@@ -418,7 +421,8 @@ class RemoteToPosixHandler(BatchSyncHandler):
 
         for file_metadata, target_file_path in transfer_items:
             target_physical_path = self.target_client.get_posix_path(target_file_path)
-            assert target_physical_path is not None
+            if target_physical_path is None:
+                raise ValueError(f"Target path '{target_file_path}' has no POSIX path")
             safe_makedirs(os.path.dirname(target_physical_path))
             source_remote_paths.append(file_metadata.key)
             target_local_paths.append(target_physical_path)


### PR DESCRIPTION
Asserts can be silently disabled. Running Python with -O (optimize flag) strips all assert statements entirely, so checks vanish in production with no warning.

Exceptions also carry semantic meaning. ValueError, RuntimeError, ImportError etc. tell callers what kind of failure occurred, enabling targeted except handling. AssertionError is a generic "something went wrong" with no actionable signal to catch.

Related to NGCDP-000 ongoing maintenance

## Description

_Change description._

_{Relates to/Closes} {Task ID}._

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced debug-only assertions with explicit runtime validation across the app.
  * Users now see clear, descriptive errors when configuration, metadata providers, cache settings, authentication/dependency support, uploaded file names, handler modules, or manifest paths are missing or invalid.
  * Improved validation for retry/wait parameters and transfer path handling to prevent silent failures and provide actionable error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->