### PR TITLE
fix: refresh sync progress totals immediately

### DIFF
--- a/multi-storage-client/src/multistorageclient/sync/monitors.py
+++ b/multi-storage-client/src/multistorageclient/sync/monitors.py
@@ -15,6 +15,7 @@
 
 import contextlib
 import logging
+import queue
 import threading
 from typing import TYPE_CHECKING, Optional
 
@@ -60,7 +61,11 @@ class ResultMonitorThread(threading.Thread):
     def run(self):
         try:
             while True:
-                op, target_file_path, physical_metadata = self.result_queue.get()
+                try:
+                    op, target_file_path, physical_metadata = self.result_queue.get(timeout=1.0)
+                except queue.Empty:
+                    self.progress.refresh()
+                    continue
 
                 logger.debug(
                     f"ResultMonitorThread: {op}, target_file_path: {target_file_path}, physical_metadata: {physical_metadata}"

--- a/multi-storage-client/src/multistorageclient/sync/progress_bar.py
+++ b/multi-storage-client/src/multistorageclient/sync/progress_bar.py
@@ -65,6 +65,11 @@ class ProgressBar:
         self._last_total_update_time = time.time()
 
     def update_total(self, new_total: int) -> None:
+        """
+        Update the progress bar total.
+
+        :param new_total: Total item count to assign to the progress bar.
+        """
         if self.pbar is not None:
             self.pbar.total = new_total
             # Custom throttling for update_total since it doesn't go through update()
@@ -89,6 +94,13 @@ class ProgressBar:
     def set_postfix_str(self, s: str, refresh: bool = False) -> None:
         if self.pbar is not None:
             self.pbar.set_postfix_str(s, refresh)
+
+    def refresh(self) -> None:
+        """
+        Refresh the progress bar display without changing its counters.
+        """
+        if self.pbar is not None:
+            self.pbar.refresh()
 
     def close(self) -> None:
         if self.pbar is not None:

--- a/multi-storage-client/tests/test_multistorageclient/unit/sync/test_monitors.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/sync/test_monitors.py
@@ -16,17 +16,23 @@
 import queue
 import threading
 import time
+from datetime import datetime
 from typing import Optional, cast
 
 from multistorageclient.client import StorageClient
 from multistorageclient.sync.monitors import ErrorMonitorThread, ResultMonitorThread
+from multistorageclient.sync.producer import ProducerThread
 from multistorageclient.sync.progress_bar import ProgressBar
 from multistorageclient.sync.types import ErrorInfo, OperationType
+from multistorageclient.types import ObjectMetadata
 
 
 class MockStorageClient:
     def list(self, **kwargs):
         raise Exception("No Such Method")
+
+    def list_recursive(self, **kwargs):
+        return self.list(**kwargs)
 
     def commit_metadata(self, prefix: Optional[str] = None) -> None:
         pass
@@ -113,3 +119,71 @@ def test_error_consumer_thread_fail_fast():
     error_queue.put(None)
     error_consumer.join(timeout=1)
     assert not error_consumer.is_alive()
+
+
+def test_result_monitor_refreshes_progress_while_producer_listing_blocks():
+    source_client = MockStorageClient()
+    target_client = MockStorageClient()
+    file_queue = queue.Queue()
+    result_queue = queue.Queue()
+    shutdown_event = threading.Event()
+    sleep_started = threading.Event()
+    refresh_times = []
+
+    first = ObjectMetadata(key="file0.txt", content_length=100, last_modified=datetime(2025, 1, 1))
+    second = ObjectMetadata(key="file1.txt", content_length=100, last_modified=datetime(2025, 1, 1))
+
+    def slow_source_iter():
+        yield first
+        sleep_started.set()
+        time.sleep(10.0)
+        yield second
+
+    source_client.list = lambda **kwargs: slow_source_iter()  # type: ignore[method-assign]
+    target_client.list = lambda **kwargs: iter(())  # type: ignore[method-assign]
+
+    progress = ProgressBar(desc="Syncing", show_progress=True)
+    assert progress.pbar is not None
+
+    original_refresh = progress.pbar.refresh
+
+    def recording_refresh(*args, **kwargs):
+        refresh_times.append(time.monotonic())
+        return original_refresh(*args, **kwargs)
+
+    progress.pbar.refresh = recording_refresh
+
+    producer_thread = ProducerThread(
+        source_client=cast(StorageClient, source_client),
+        source_path="",
+        target_client=cast(StorageClient, target_client),
+        target_path="",
+        progress=progress,
+        file_queue=file_queue,
+        num_workers=1,
+        shutdown_event=shutdown_event,
+    )
+    result_monitor_thread = ResultMonitorThread(
+        target_client=cast(StorageClient, target_client),
+        target_path="",
+        progress=progress,
+        result_queue=result_queue,
+    )
+
+    result_monitor_thread.start()
+    producer_thread.start()
+    assert sleep_started.wait(timeout=2.0)
+
+    sleep_start = time.monotonic()
+    producer_thread.join(timeout=15.0)
+    sleep_end = time.monotonic()
+    result_queue.put((OperationType.STOP, None, None))
+    result_monitor_thread.join(timeout=2.0)
+    progress.close()
+
+    refreshes_during_sleep = [t for t in refresh_times if sleep_start <= t <= sleep_end]
+
+    assert producer_thread.error is None
+    assert not producer_thread.is_alive()
+    assert not result_monitor_thread.is_alive()
+    assert len(refreshes_during_sleep) >= 8

--- a/multi-storage-client/tests/test_multistorageclient/unit/sync/test_producer.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/sync/test_producer.py
@@ -71,6 +71,17 @@ class MockStorageClient:
         return False
 
 
+class RecordingProgress:
+    def __init__(self):
+        self.total_updates: list[int] = []
+
+    def update_total(self, new_total: int) -> None:
+        self.total_updates.append(new_total)
+
+    def update_progress(self, items_completed: int = 1) -> None:
+        pass
+
+
 def test_match_file_metadata_seconds_resolution():
     """_match_file_metadata compares last_modified at seconds resolution."""
     source_client = MockStorageClient()
@@ -397,6 +408,37 @@ def test_producer_thread_error():
 
     assert not producer_thread.is_alive()
     assert producer_thread.error is not None
+
+
+def test_producer_updates_final_total():
+    source_client = MockStorageClient()
+    target_client = MockStorageClient()
+
+    source_files = [
+        ObjectMetadata(key="file0.txt", content_length=100, last_modified=datetime(2025, 1, 1, 0, 0, 0)),
+        ObjectMetadata(key="file1.txt", content_length=100, last_modified=datetime(2025, 1, 1, 0, 0, 0)),
+    ]
+
+    source_client.list = lambda **kwargs: iter(source_files)  # type: ignore
+    target_client.list = lambda **kwargs: iter(())  # type: ignore
+
+    progress = RecordingProgress()
+    producer_thread = ProducerThread(
+        source_client=cast(StorageClient, source_client),
+        source_path="",
+        target_client=cast(StorageClient, target_client),
+        target_path="",
+        progress=cast(ProgressBar, progress),
+        file_queue=queue.Queue(),
+        num_workers=1,
+        shutdown_event=threading.Event(),
+    )
+
+    producer_thread.start()
+    producer_thread.join()
+
+    assert producer_thread.error is None
+    assert progress.total_updates[-1] == len(source_files)
 
 
 def test_progress_bar_update_in_producer_thread_without_deletion():

--- a/multi-storage-client/tests/test_multistorageclient/unit/sync/test_progress_bar.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/sync/test_progress_bar.py
@@ -27,6 +27,27 @@ def test_progress_bar_capped_percentage():
     assert "99.9%" in str(progress.pbar)
 
 
+def test_refresh_updates_display_without_changing_counters():
+    progress = ProgressBar(desc="Syncing", show_progress=True, total_items=0)
+    assert progress.pbar is not None
+
+    refresh_count = {"count": 0}
+    original_refresh = progress.pbar.refresh
+
+    def counting_refresh(*args, **kwargs):
+        refresh_count["count"] += 1
+        return original_refresh(*args, **kwargs)
+
+    progress.pbar.refresh = counting_refresh
+    progress.refresh()
+
+    assert progress.pbar.total == 0
+    assert progress.pbar.n == 0
+    assert refresh_count["count"] == 1
+
+    progress.close()
+
+
 def test_progress_update_interval():
     progress = ProgressBar(desc="Syncing", show_progress=True, total_items=2000)
     assert progress.pbar is not None


### PR DESCRIPTION
## Description

Fix sync progress visibility while object listing/data fetch is blocked.

Instead of forcing a one-time progress bar refresh from the producer, the existing `ResultMonitorThread` now wakes once per second while waiting on the result queue and refreshes the progress bar. This keeps elapsed time/status visibly updating even when the producer is blocked in source listing or metadata fetch.

## Changes

- Add `ProgressBar.refresh()` for display-only refreshes.
- Update `ResultMonitorThread` to call `result_queue.get(timeout=1.0)` and refresh progress on empty waits.
- Remove the earlier `update_total(..., refresh=True)` approach.
- Add a regression test where the producer listing sleeps for 10 seconds and verify the progress bar refreshes repeatedly during the sleep.

Closes NGCDP-8438

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Progress bar now includes a refresh capability to update the display without affecting progress counters.
  * Monitor thread now uses non-blocking timeout checks to refresh the progress display while waiting for items, improving responsiveness.

* **Tests**
  * Added comprehensive unit tests verifying progress refresh functionality and concurrent operation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->