### PR TITLE
fix: normalize duplicate slashes in MSC URLs

### DIFF
--- a/multi-storage-client-docs/src/user_guide/quickstart.rst
+++ b/multi-storage-client-docs/src/user_guide/quickstart.rst
@@ -197,6 +197,8 @@ They only support file-based configuration.
 
 Shortcuts use ``msc://{profile name}/{file/object path relative to the storage provider's base path}``
 URLs for file/object paths.
+Repeated slashes in the object path are normalized, so ``msc://profile/path//to/object.bin``
+is resolved as ``msc://profile/path/to/object.bin``.
 
 See :py:mod:`multistorageclient` for all shortcut methods.
 

--- a/multi-storage-client/src/multistorageclient/explorer/api/server.py
+++ b/multi-storage-client/src/multistorageclient/explorer/api/server.py
@@ -29,6 +29,7 @@ from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from multistorageclient import StorageClient, StorageClientConfig
+from multistorageclient.shortcuts import _resolve_msc_url
 
 from .models import (
     ConfigUploadResponse,
@@ -156,13 +157,10 @@ def get_msc_client_and_path(url: str) -> tuple[Any, str]:
             status_code=400, detail="MSC configuration not loaded. Please upload a configuration first."
         )
 
-    # Extract profile and path from URL (format: msc://profile/path)
     if not url.startswith("msc://"):
         raise HTTPException(status_code=400, detail="URL must start with msc://")
 
-    parts = url[6:].split("/", 1)  # Remove 'msc://' and split
-    profile = parts[0]
-    path = parts[1] if len(parts) > 1 else ""  # Extract path after profile
+    profile, path = _resolve_msc_url(url)
 
     if profile not in msc_config.get("profiles", {}):
         raise HTTPException(status_code=400, detail=f"Profile '{profile}' not found in configuration")

--- a/multi-storage-client/src/multistorageclient/shortcuts.py
+++ b/multi-storage-client/src/multistorageclient/shortcuts.py
@@ -15,6 +15,7 @@
 
 import logging
 import os
+import re
 import threading
 from collections.abc import Callable, Iterator
 from typing import Any, Optional, Union
@@ -132,6 +133,8 @@ def _resolve_msc_url(url: str) -> tuple[str, str]:
     """
     pr = urlparse(url)
     profile = pr.netloc
+    # Normalize only the object path so the msc:// scheme separator and profile stay intact.
+    pr = pr._replace(path=re.sub(r"/+", "/", pr.path))
     path = _build_full_path(url, pr)
     if path.startswith("/"):
         path = path[1:]

--- a/multi-storage-client/tests/test_multistorageclient/unit/explorer/test_api_endpoints.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/explorer/test_api_endpoints.py
@@ -96,6 +96,22 @@ def test_list_files_invalid_profile_returns_error(test_client):
     assert "not found" in response.json()["detail"].lower()
 
 
+def test_get_msc_client_and_path_normalizes_duplicate_slashes(mock_msc_config):
+    """Test that Explorer URL parsing uses normalized MSC paths."""
+    app_module.msc_config = mock_msc_config
+    cached_client = object()
+    app_module._client_cache["test-s3"] = cached_client
+
+    try:
+        client, path = app_module.get_msc_client_and_path("msc://test-s3/path//to///object.bin")
+    finally:
+        app_module.msc_config = None
+        app_module._client_cache.clear()
+
+    assert client is cached_client
+    assert path == "path/to/object.bin"
+
+
 # Tests for Pydantic models
 
 

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_shortcuts.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_shortcuts.py
@@ -67,8 +67,11 @@ def test_resolve_storage_client(file_storage_config):
     _, p6 = msc.resolve_storage_client("msc:/__filesystem__/etc/resolv.conf")
     assert p6 == "etc/resolv.conf"
 
-    _, p7 = msc.resolve_storage_client("./workspace/datasets")
-    assert p7 == os.path.realpath("workspace/datasets")
+    _, p7 = msc.resolve_storage_client("msc://__filesystem__/tmp//data///object.bin")
+    assert p7 == "tmp/data/object.bin"
+
+    _, p8 = msc.resolve_storage_client("./workspace/datasets")
+    assert p8 == os.path.realpath("workspace/datasets")
 
     # Multithreading test to verify the storage_client instance is the same
     tempdirs = []


### PR DESCRIPTION
## Description

- Normalize duplicate slashes in `msc://` URL object paths.
- Reuse the central MSC URL parser in Explorer API to keep behavior consistent.

Closes NGCDP-7789

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * MSC URLs with repeated slashes in object paths are now automatically normalized.

* **Documentation**
  * Updated quickstart guide to clarify slash normalization behavior in MSC URLs.

* **Tests**
  * Added and updated test coverage for MSC URL path normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->