### PR TITLE
fix: align manifest directory listings

### DIFF
--- a/multi-storage-client/src/multistorageclient/providers/manifest_metadata.py
+++ b/multi-storage-client/src/multistorageclient/providers/manifest_metadata.py
@@ -405,6 +405,7 @@ class ManifestMetadataProvider(MetadataProvider):
             key
             for key, obj_metadata in self._files.items()
             if key.startswith(path)
+            and obj_metadata.type != "directory"
             and (start_after is None or start_after < key)
             and (end_at is None or key <= end_at)
             and (

--- a/multi-storage-client/src/multistorageclient/providers/manifest_metadata.py
+++ b/multi-storage-client/src/multistorageclient/providers/manifest_metadata.py
@@ -380,7 +380,7 @@ class ManifestMetadataProvider(MetadataProvider):
                 existing_directory = directories.get(directory_key)
                 if existing_directory is None:
                     directories[directory_key] = ObjectMetadata(
-                        key=directory_name,
+                        key=directory_key,
                         type="directory",
                         last_modified=obj_metadata.last_modified,
                         content_length=0,

--- a/multi-storage-client/src/multistorageclient/providers/manifest_metadata.py
+++ b/multi-storage-client/src/multistorageclient/providers/manifest_metadata.py
@@ -335,6 +335,71 @@ class ManifestMetadataProvider(MetadataProvider):
             create_attribute_filter_evaluator(attribute_filter_expression) if attribute_filter_expression else None
         )
 
+        if include_directories:
+            # Match delimiter-style providers such as S3: list the immediate child
+            # directories first, then the immediate files. The manifest only stores
+            # object keys, so this view is built on demand for the requested path.
+            directories: dict[str, ObjectMetadata] = {}
+            synthetic_directories: set[str] = set()
+            files: list[ObjectMetadata] = []
+
+            for key, obj_metadata in sorted(self._files.items()):
+                if not key.startswith(path) or (
+                    evaluator is not None and not matches_attribute_filter_expression(obj_metadata, evaluator)
+                ):
+                    continue
+
+                relative = key[len(path) :].lstrip("/")
+
+                if "/" not in relative:
+                    if (start_after is not None and key <= start_after) or (end_at is not None and end_at < key):
+                        continue
+
+                    if obj_metadata.type == "directory":
+                        # Prefer explicit directory entries from the manifest when present.
+                        directory_key = obj_metadata.key.rstrip("/")
+                        directories[directory_key] = ObjectMetadata(
+                            key=directory_key,
+                            type="directory",
+                            last_modified=obj_metadata.last_modified,
+                            content_length=0,
+                            content_type=obj_metadata.content_type,
+                            etag=obj_metadata.etag,
+                            storage_class=obj_metadata.storage_class,
+                            metadata=obj_metadata.metadata,
+                            symlink_target=obj_metadata.symlink_target,
+                        )
+                        synthetic_directories.discard(directory_key)
+                    else:
+                        files.append(obj_metadata)
+                    continue
+
+                # Nested files imply an immediate child directory under the listed path.
+                directory_name = f"{path}{relative.split('/', 1)[0]}"
+                directory_key = directory_name.rstrip("/")
+                existing_directory = directories.get(directory_key)
+                if existing_directory is None:
+                    directories[directory_key] = ObjectMetadata(
+                        key=directory_name,
+                        type="directory",
+                        last_modified=obj_metadata.last_modified,
+                        content_length=0,
+                    )
+                    synthetic_directories.add(directory_key)
+                else:
+                    if directory_key in synthetic_directories:
+                        existing_directory.last_modified = max(
+                            existing_directory.last_modified, obj_metadata.last_modified
+                        )
+
+            yield from (
+                directories[key]
+                for key in sorted(directories)
+                if (start_after is None or start_after < key) and (end_at is None or key <= end_at)
+            )
+            yield from sorted(files, key=lambda obj: obj.key)
+            return
+
         # Note that this is a generator, not a tuple (there's no tuple comprehension).
         keys = (
             key
@@ -347,36 +412,8 @@ class ManifestMetadataProvider(MetadataProvider):
             )  # filter by evaluator if present
         )
 
-        pending_directory: Optional[ObjectMetadata] = None
         for key in sorted(keys):
-            if include_directories:
-                relative = key[len(path) :].lstrip("/")
-                subdirectory = relative.split("/", 1)[0] if "/" in relative else None
-
-                if subdirectory:
-                    directory_name = f"{path}{subdirectory}/"
-
-                    if pending_directory and pending_directory.key != directory_name:
-                        yield pending_directory
-
-                    obj_metadata = self.get_object_metadata(key)
-                    if not pending_directory or pending_directory.key != directory_name:
-                        pending_directory = ObjectMetadata(
-                            key=directory_name,
-                            type="directory",
-                            last_modified=obj_metadata.last_modified,
-                            content_length=0,
-                        )
-                    else:
-                        pending_directory.last_modified = max(
-                            pending_directory.last_modified, obj_metadata.last_modified
-                        )
-                    continue  # Skip yielding this key as it's part of a directory
-
             yield self._files[key]
-
-        if include_directories and pending_directory:
-            yield pending_directory
 
     def get_object_metadata(self, path: str, include_pending: bool = False) -> ObjectMetadata:
         if path in self._files:

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_manifest_metadata.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_manifest_metadata.py
@@ -1085,6 +1085,37 @@ def test_list_objects_filters_synthetic_directories_by_directory_key():
     assert [(obj.key, obj.type) for obj in objects] == [("dataset/b", "directory")]
 
 
+def test_list_objects_excludes_existing_directories_when_not_requested():
+    now = datetime.now(tz=timezone.utc)
+    provider = _make_manifest_provider(
+        {
+            "dataset/images": ManifestObjectMetadata(
+                key="dataset/images",
+                content_length=0,
+                last_modified=now,
+                type="directory",
+            ),
+            "dataset/images/0001.jpg": ManifestObjectMetadata(
+                key="dataset/images/0001.jpg",
+                content_length=100,
+                last_modified=now,
+            ),
+            "dataset/readme.txt": ManifestObjectMetadata(
+                key="dataset/readme.txt",
+                content_length=10,
+                last_modified=now,
+            ),
+        }
+    )
+
+    objects = list(provider.list_objects("dataset", include_directories=False))
+
+    assert [(obj.key, obj.type) for obj in objects] == [
+        ("dataset/images/0001.jpg", "file"),
+        ("dataset/readme.txt", "file"),
+    ]
+
+
 def test_realpath_follows_symlink_chain():
     now = datetime.now(tz=timezone.utc)
     files = {

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_manifest_metadata.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_manifest_metadata.py
@@ -193,7 +193,7 @@ def test_manifest_metadata(temp_data_store_type: type[tempdatastore.TemporaryDat
         # Test listing with directories
         with_dirs = list(data_with_manifest_storage_client.list(path=base_path, include_directories=True))
         assert len(with_dirs) == 1
-        assert with_dirs[0].key == file_directory + "/"
+        assert with_dirs[0].key == file_directory
 
 
 def test_nonexistent_and_read_only():
@@ -993,6 +993,96 @@ def _make_manifest_provider(files: dict[str, ManifestObjectMetadata]) -> Manifes
     )
     provider._files = files
     return provider
+
+
+def test_list_objects_includes_directory_without_trailing_slash():
+    now = datetime.now(tz=timezone.utc)
+    provider = _make_manifest_provider(
+        {
+            "dataset/images/0001.jpg": ManifestObjectMetadata(
+                key="dataset/images/0001.jpg",
+                content_length=100,
+                last_modified=now,
+            )
+        }
+    )
+
+    objects = list(provider.list_objects("dataset", include_directories=True))
+
+    assert len(objects) == 1
+    assert objects[0].key == "dataset/images"
+    assert objects[0].type == "directory"
+
+
+def test_list_objects_uses_existing_directory_metadata_without_duplicate():
+    now = datetime.now(tz=timezone.utc)
+    provider = _make_manifest_provider(
+        {
+            "dataset/images": ManifestObjectMetadata(
+                key="dataset/images",
+                content_length=0,
+                last_modified=now,
+                type="directory",
+            ),
+            "dataset/images/0001.jpg": ManifestObjectMetadata(
+                key="dataset/images/0001.jpg",
+                content_length=100,
+                last_modified=now,
+            ),
+            "dataset/labels/0001.txt": ManifestObjectMetadata(
+                key="dataset/labels/0001.txt",
+                content_length=20,
+                last_modified=now,
+            ),
+            "dataset/a.txt": ManifestObjectMetadata(
+                key="dataset/a.txt",
+                content_length=10,
+                last_modified=now,
+            ),
+            "dataset/b/0001.txt": ManifestObjectMetadata(
+                key="dataset/b/0001.txt",
+                content_length=30,
+                last_modified=now,
+            ),
+            "dataset/readme.txt": ManifestObjectMetadata(
+                key="dataset/readme.txt",
+                content_length=10,
+                last_modified=now,
+            ),
+        }
+    )
+
+    objects = list(provider.list_objects("dataset", include_directories=True))
+
+    assert [(obj.key, obj.type) for obj in objects] == [
+        ("dataset/b", "directory"),
+        ("dataset/images", "directory"),
+        ("dataset/labels", "directory"),
+        ("dataset/a.txt", "file"),
+        ("dataset/readme.txt", "file"),
+    ]
+
+
+def test_list_objects_filters_synthetic_directories_by_directory_key():
+    now = datetime.now(tz=timezone.utc)
+    provider = _make_manifest_provider(
+        {
+            "dataset/b/0001.txt": ManifestObjectMetadata(
+                key="dataset/b/0001.txt",
+                content_length=30,
+                last_modified=now,
+            ),
+            "dataset/c/0001.txt": ManifestObjectMetadata(
+                key="dataset/c/0001.txt",
+                content_length=40,
+                last_modified=now,
+            ),
+        }
+    )
+
+    objects = list(provider.list_objects("dataset", end_at="dataset/b", include_directories=True))
+
+    assert [(obj.key, obj.type) for obj in objects] == [("dataset/b", "directory")]
 
 
 def test_realpath_follows_symlink_chain():


### PR DESCRIPTION
## Description

- Align `ManifestMetadataProvider` directory listings with delimiter-style providers by returning immediate directories before files.
- Stop adding trailing `/` to returned directory keys.
- Preserve explicit manifest directory entries without duplicating synthetic directory entries.

## Changes
- Reworked `ManifestMetadataProvider.list_objects(..., include_directories=True)` to build an on-demand immediate-child view from manifest keys.
- Apply range filtering to synthetic directory keys instead of accidentally filtering them by nested child object keys.
- Added focused unit coverage for no trailing slash, explicit directory de-duplication, S3-style ordering, and `end_at` filtering for synthetic directories.

Closes NGCDP-6990

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Directory names in listings no longer include trailing slashes when directories are included.
  * Duplicate directory entries are prevented when existing directory metadata exists.
  * Directory generation respects listing key-range boundaries.
  * Listings emit directories (sorted) before files (sorted).
  * When directories are not requested, listings return only file objects.

* **Tests**
  * Added unit tests validating directory listing behavior and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->