### PR TITLE
fix: make delete_many idempotent for missing keys

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+- Make `delete_many()` idempotent when missing keys are included.
+
 ## Multi-Storage File System (MSFS)
 
 ### Breaking Changes

--- a/multi-storage-client/src/multistorageclient/client/client.py
+++ b/multi-storage-client/src/multistorageclient/client/client.py
@@ -404,6 +404,7 @@ class StorageClient(AbstractStorageClient):
     def delete_many(self, paths: list[str]) -> None:
         """
         Delete multiple files at the specified paths. Only files are supported; directories are not deleted.
+        Paths that do not exist are treated as successful no-ops.
 
         :param paths: List of logical paths of the files to delete.
         :raises NotImplementedError: If delete operations are not supported (e.g., CompositeStorageClient).

--- a/multi-storage-client/src/multistorageclient/client/single.py
+++ b/multi-storage-client/src/multistorageclient/client/single.py
@@ -743,11 +743,13 @@ class SingleStorageClient(AbstractStorageClient):
         :param paths: List of logical paths of the files to delete.
         """
         physical_paths_to_delete: list[str] = []
+        metadata_paths_to_remove: set[str] = set()
         for path in paths:
             if self._metadata_provider:
                 resolved = self._metadata_provider.realpath(path)
                 if not resolved.exists:
-                    raise FileNotFoundError(f"The file at path '{path}' was not found.")
+                    continue
+                metadata_paths_to_remove.add(path)
                 if not self._metadata_provider.should_use_soft_delete():
                     physical_paths_to_delete.append(resolved.physical_path)
             else:
@@ -758,7 +760,7 @@ class SingleStorageClient(AbstractStorageClient):
 
         for path in paths:
             virtual_path = path
-            if self._metadata_provider:
+            if self._metadata_provider and virtual_path in metadata_paths_to_remove:
                 with self._metadata_provider_lock or contextlib.nullcontext():
                     self._metadata_provider.remove_file(virtual_path)
             if self._is_cache_enabled():

--- a/multi-storage-client/src/multistorageclient/client/types.py
+++ b/multi-storage-client/src/multistorageclient/client/types.py
@@ -303,6 +303,7 @@ class AbstractStorageClient(ABC):
     def delete_many(self, paths: list[str]) -> None:
         """
         Delete multiple files at the specified paths. Only files are supported; directories are not deleted.
+        Paths that do not exist are treated as successful no-ops.
 
         :param paths: List of logical paths of the files to delete.
         :raises NotImplementedError: If delete operations are not supported (e.g., CompositeStorageClient).

--- a/multi-storage-client/src/multistorageclient/providers/azure.py
+++ b/multi-storage-client/src/multistorageclient/providers/azure.py
@@ -24,8 +24,13 @@ from urllib.parse import urlparse
 from azure.core import MatchConditions
 from azure.core.exceptions import AzureError, HttpResponseError
 from azure.identity import DefaultAzureCredential
-from azure.storage.blob import BlobPrefix, BlobServiceClient, generate_blob_sas
-from azure.storage.blob._models import BlobSasPermissions
+from azure.storage.blob import (
+    BlobPrefix,
+    BlobSasPermissions,
+    BlobServiceClient,
+    PartialBatchErrorException,
+    generate_blob_sas,
+)
 
 from ..constants import DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT
 from ..signers.base import URLSigner
@@ -483,7 +488,17 @@ class AzureBlobStorageProvider(BaseStorageProvider):
                 container_client = self._blob_service_client.get_container_client(container=container_name)
                 for i in range(0, len(blob_names), AZURE_BATCH_LIMIT):
                     chunk = blob_names[i : i + AZURE_BATCH_LIMIT]
-                    container_client.delete_blobs(*chunk)
+                    try:
+                        responses = container_client.delete_blobs(*chunk, raise_on_any_failure=False)
+                    except PartialBatchErrorException as error:
+                        responses = error.parts
+                    for response in responses:
+                        status_code = response.status_code
+                        if 200 <= status_code < 300 or status_code == 404:
+                            continue
+                        raise RuntimeError(
+                            f"Azure batch delete failed with status_code: {status_code}, response: {response.text}"
+                        )
 
         container_desc = "(" + "|".join(by_container) + ")"
         blob_desc = "(" + "|".join(str(len(blob_names)) for blob_names in by_container.values()) + " keys)"

--- a/multi-storage-client/src/multistorageclient/providers/base.py
+++ b/multi-storage-client/src/multistorageclient/providers/base.py
@@ -713,6 +713,7 @@ class BaseStorageProvider(StorageProvider):
 
         Default implementation iterates through paths and deletes each object individually.
         Subclasses may override this to use bulk delete APIs for better performance.
+        Missing objects are ignored by bulk delete operations.
 
         :param paths: A list of paths of objects to delete.
         """
@@ -763,11 +764,15 @@ class BaseStorageProvider(StorageProvider):
     def _delete_objects(self, paths: list[str]) -> None:
         """
         Deletes multiple objects from the storage provider.
+        Missing objects are ignored by bulk delete operations.
 
         :param paths: A list of paths of objects to delete.
         """
         for path in paths:
-            self._delete_object(path)
+            try:
+                self._delete_object(path)
+            except FileNotFoundError:
+                continue
 
     def get_object_metadata(self, path: str, strict: bool = True) -> ObjectMetadata:
         path = self._prepend_base_path(path)

--- a/multi-storage-client/src/multistorageclient/providers/gcs.py
+++ b/multi-storage-client/src/multistorageclient/providers/gcs.py
@@ -517,9 +517,18 @@ class GoogleStorageProvider(BaseStorageProvider):
                 bucket_obj = self._gcs_client.bucket(bucket)
                 for i in range(0, len(keys), GCS_BATCH_LIMIT):
                     chunk = keys[i : i + GCS_BATCH_LIMIT]
-                    with self._gcs_client.batch():
+                    with self._gcs_client.batch(raise_exception=False) as batch:
                         for k in chunk:
                             bucket_obj.blob(k).delete()
+                    if not hasattr(batch, "_responses"):
+                        raise RuntimeError("GCS batch delete did not expose responses.")
+                    for response in batch._responses:
+                        status_code = response.status_code
+                        if 200 <= status_code < 300 or status_code == 404:
+                            continue
+                        raise RuntimeError(
+                            f"GCS batch delete failed with status_code: {status_code}, response: {response.text}"
+                        )
 
         bucket_desc = "(" + "|".join(by_bucket) + ")"
         key_desc = "(" + "|".join(str(len(keys)) for keys in by_bucket.values()) + " keys)"

--- a/multi-storage-client/src/multistorageclient/providers/gcs_s3.py
+++ b/multi-storage-client/src/multistorageclient/providers/gcs_s3.py
@@ -41,4 +41,7 @@ class GoogleS3StorageProvider(S3StorageProvider):
         GCS S3 does not support bulk deletion, so we delete one object at a time.
         """
         for path in paths:
-            self._delete_object(path)
+            try:
+                self._delete_object(path)
+            except FileNotFoundError:
+                continue

--- a/multi-storage-client/tests/test_multistorageclient/e2e/common.py
+++ b/multi-storage-client/tests/test_multistorageclient/e2e/common.py
@@ -331,11 +331,13 @@ def verify_storage_provider(storage_client: msc.StorageClient, prefix: str) -> N
             with open(local_path, "rb") as f:
                 assert f.read() == b"x"
 
-    storage_client.delete_many(remote_paths)
+    missing_remote_paths = [f"{batch_prefix}/missing_{i:04d}" for i in range(2)]
+    storage_client.delete_many([missing_remote_paths[0], *remote_paths, missing_remote_paths[1]])
     wait(
         waitable=lambda: storage_client.list(batch_prefix),
         should_wait=len_should_wait(expected_len=0),
     )
+    storage_client.delete_many([missing_remote_paths[0], *remote_paths, missing_remote_paths[1]])
 
     # Test symlinks
     symlink_prefix = f"{prefix}/symlinks"

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_manifest_metadata.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_manifest_metadata.py
@@ -17,6 +17,7 @@ import copy
 import os
 import tempfile
 import time
+import uuid
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
@@ -265,6 +266,42 @@ def test_nonexistent_and_read_only():
         # Attempt a delete.
         with pytest.raises(RuntimeError):
             data_with_read_only_manifest_storage_client.delete(path=file_path)
+
+
+def test_manifest_delete_many_missing_objects_is_idempotent():
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
+        profile = "data_with_manifest"
+        profile_config_dict = temp_data_store.profile_config_dict() | {
+            "metadata_provider": {
+                "type": "manifest",
+                "options": {
+                    "manifest_path": DEFAULT_MANIFEST_BASE_DIR,
+                    "writable": True,
+                },
+            }
+        }
+        storage_client = StorageClient(
+            config=StorageClientConfig.from_dict(
+                config_dict={"profiles": {profile: profile_config_dict}},
+                profile=profile,
+            )
+        )
+
+        prefix = uuid.uuid4().hex
+        existing_path = f"{prefix}/existing.txt"
+        missing_path = f"{prefix}/missing.txt"
+        another_missing_path = f"{prefix}/another-missing.txt"
+
+        storage_client.write(path=existing_path, body=b"payload")
+        storage_client.commit_metadata()
+        assert len(storage_client.glob(pattern=existing_path)) == 1
+
+        storage_client.delete_many([missing_path, existing_path, another_missing_path])
+        storage_client.commit_metadata()
+
+        assert len(storage_client.glob(pattern=existing_path)) == 0
+        assert len(storage_client.glob(pattern=missing_path)) == 0
+        storage_client.delete_many([missing_path, existing_path, another_missing_path])
 
 
 @pytest.mark.parametrize(

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_storage_providers.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_storage_providers.py
@@ -41,6 +41,18 @@ from multistorageclient.types import PreconditionFailedError, Range
 from test_multistorageclient.unit.utils.telemetry.metrics.export import InMemoryMetricExporter
 from test_multistorageclient.utils.wait import wait_for_is_file
 
+DELETE_MANY_IDEMPOTENCY_DATA_STORES = [
+    tempdatastore.TemporaryPOSIXDirectory,
+    tempdatastore.TemporaryAWSS3Bucket,
+    tempdatastore.TemporaryAzureBlobStorageContainer,
+    # Native GCS uses the batch delete API, which fake-gcs-server does not support.
+    # Real GCS coverage comes from the shared e2e storage client test.
+    tempdatastore.TemporaryGoogleCloudStorageS3Bucket,
+    tempdatastore.TemporarySwiftStackBucket,
+    tempdatastore.TemporaryAIStoreBucket,
+    tempdatastore.TemporaryAIStoreS3Bucket,
+]
+
 
 @pytest.mark.parametrize(
     argnames=["temp_data_store_type", "with_cache"],
@@ -321,6 +333,34 @@ def test_storage_providers(temp_data_store_type: type[tempdatastore.TemporaryDat
 
         if with_cache:
             shutil.rmtree(cache_location, ignore_errors=True)
+
+
+@pytest.mark.parametrize("temp_data_store_type", DELETE_MANY_IDEMPOTENCY_DATA_STORES)
+def test_delete_many_missing_objects_is_idempotent(temp_data_store_type: type[tempdatastore.TemporaryDataStore]):
+    with temp_data_store_type() as temp_data_store:
+        profile = "data"
+        storage_client = StorageClient(
+            config=StorageClientConfig.from_dict(
+                config_dict={"profiles": {profile: temp_data_store.profile_config_dict()}},
+                profile=profile,
+            )
+        )
+
+        prefix = uuid.uuid4().hex
+        existing_path = f"{prefix}/existing.txt"
+        missing_path = f"{prefix}/missing.txt"
+        another_missing_path = f"{prefix}/another-missing.txt"
+
+        storage_client.write(path=existing_path, body=b"payload")
+        wait_for_is_file(storage_client=storage_client, path=existing_path, is_file=True)
+
+        storage_client.delete_many([missing_path, existing_path, another_missing_path])
+        wait_for_is_file(storage_client=storage_client, path=existing_path, is_file=False)
+        wait_for_is_file(storage_client=storage_client, path=missing_path, is_file=False)
+        assert not storage_client.is_file(path=existing_path)
+        assert not storage_client.is_file(path=missing_path)
+
+        storage_client.delete_many([missing_path, existing_path, another_missing_path])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

- Make `delete_many()` idempotent when paths are missing.
- Skip missing logical paths for metadata-backed clients.
- Ignore missing physical objects in provider bulk-delete paths.
- Preserve GCS batching while ignoring only `404` subresponses.
- Add unit and e2e coverage for mixed existing/missing `delete_many()` calls.

Closes NGCDP-8971

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved `delete_many` behavior to gracefully handle non-existent paths. Missing objects are now treated as successful no-ops, making `delete_many` idempotent when the input includes a mix of existing and absent paths.
  * Enhanced provider-side bulk deletion handling so partial or per-item failures no longer surface as errors when the target objects are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->