### PR TITLE
Fix rejection of unknown top-level config keys

### DIFF
--- a/multi-storage-client/src/multistorageclient/schema.py
+++ b/multi-storage-client/src/multistorageclient/schema.py
@@ -228,8 +228,8 @@ CONFIG_SCHEMA = {
         "opentelemetry": OTEL_SCHEMA,
         "path_mapping": PATH_MAPPING_SCHEMA,
         "posix": POSIX_SCHEMA,
-        "additionalProperties": False,
     },
+    "additionalProperties": False,
 }
 
 BENCHMARK_SCHEMA = {

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_schema.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_schema.py
@@ -534,3 +534,17 @@ def test_validate_include():
                 },
             }
         )
+
+
+def test_validate_unknown_top_level_key():
+    default_storage_provider = {"storage_provider": {"type": "s3", "options": {"base_path": "bucket/prefix"}}}
+
+    with pytest.raises(RuntimeError):
+        validate_config(
+            {
+                "profiles": {
+                    "default": default_storage_provider,
+                },
+                "typo": True,
+            }
+        )


### PR DESCRIPTION
## Summary

- move `additionalProperties: false` to the top level of `CONFIG_SCHEMA` so unknown top-level config keys are rejected
- add a regression test covering a config with valid `profiles` plus an unexpected `typo` key

## Why

The config schema had `additionalProperties` nested inside `properties`, which made it a normal property name instead of a schema constraint. As a result, configs with unknown top-level keys were accepted silently.

## Impact

This tightens config validation so misspelled top-level keys fail fast instead of being ignored.

## Checks

- `uv run --package multi-storage-client --group dev pytest multi-storage-client/tests/test_multistorageclient/unit/test_schema.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration validation to properly reject unknown top-level keys in config files.

* **Tests**
  * Added validation test for unknown configuration keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->