### PR TITLE
Reject unsafe cache delete paths

### DIFF
--- a/multi-storage-client/src/multistorageclient/cache.py
+++ b/multi-storage-client/src/multistorageclient/cache.py
@@ -116,18 +116,42 @@ class CacheManager:
 
     def delete_file(self, file_path: str) -> None:
         """
-        Delete a file from the cache directory.
+        Delete a file from the profile cache directory.
 
-        :param file_path: Path to the file relative to cache directory
+        :param file_path: Path to the file relative to the profile cache directory
         """
-        try:
-            # Construct absolute path using cache directory as base
-            abs_path = os.path.join(self._get_cache_dir(), file_path)
-            os.unlink(abs_path)
+        abs_path = self._resolve_profile_cache_delete_path(file_path)
+        self._delete_cache_file_at_path(abs_path)
 
-            # Handle lock file - keep it in same directory as the file
-            lock_name = f".{os.path.basename(file_path)}.lock"
-            lock_path = os.path.join(os.path.dirname(abs_path), lock_name)
+    def _resolve_profile_cache_delete_path(self, file_path: str) -> str:
+        """Resolve a profile-relative delete path and ensure it stays within the profile cache root."""
+        if os.path.isabs(file_path):
+            raise ValueError(f"Cache delete path must be relative to the profile cache root: {file_path}")
+
+        normalized_path = os.path.normpath(file_path)
+        if normalized_path in ("", "."):
+            raise ValueError("Cache delete path must reference a file under the profile cache root.")
+
+        cache_root = os.path.realpath(self._get_cache_dir())
+        abs_path = os.path.realpath(os.path.join(cache_root, normalized_path))
+        try:
+            if os.path.commonpath([cache_root, abs_path]) != cache_root or abs_path == cache_root:
+                raise ValueError(f"Cache delete path escapes the profile cache root: {file_path}")
+        except ValueError as exc:
+            raise ValueError(f"Cache delete path escapes the profile cache root: {file_path}") from exc
+
+        return abs_path
+
+    def _delete_cache_file_at_path(self, abs_path: str) -> None:
+        """Delete a cached file and its sibling lock file using an absolute cache path."""
+        try:
+            os.unlink(abs_path)
+        except OSError:
+            pass
+
+        lock_name = f".{os.path.basename(abs_path)}.lock"
+        lock_path = os.path.join(os.path.dirname(abs_path), lock_name)
+        try:
             os.unlink(lock_path)
         except OSError:
             pass
@@ -172,9 +196,7 @@ class CacheManager:
         cache = OrderedDict()
         cache_size = 0
         for item in cache_items:
-            # Use the relative path from cache directory
-            rel_path = os.path.relpath(item.file_path, self._cache_path)
-            cache[rel_path] = item.file_size
+            cache[item.file_path] = item.file_size
             cache_size += item.file_size
         logging.debug(f"Total cache size: {cache_size}, Max allowed: {self._max_cache_size}")
 
@@ -196,7 +218,7 @@ class CacheManager:
                 file_to_evict, file_size = cache.popitem(last=False)
                 cache_size -= file_size
                 logging.debug(f"Evicting file: {file_to_evict}, size: {file_size}, remaining: {cache_size}")
-                self.delete_file(file_to_evict)
+                self._delete_cache_file_at_path(file_to_evict)
 
         logging.debug("\nFinal cache contents:")
         for file_path in cache.keys():

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_cache.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_cache.py
@@ -247,6 +247,60 @@ def test_cache_manager_read_delete_file(profile_name, tmpdir, cache_manager):
     assert not os.path.exists(lock_path)
 
 
+def test_cache_manager_delete_rejects_absolute_path(profile_name, tmpdir, cache_manager):
+    """Test that CacheManager rejects absolute delete paths."""
+    outside_file = tmpdir.join("outside.txt")
+    outside_file.write("outside data")
+    absolute_key = str(outside_file)
+
+    cache_manager.set(absolute_key, b"cached data")
+    cached_path = cache_manager._get_cache_file_path(absolute_key)
+    assert os.path.exists(cached_path)
+
+    with pytest.raises(ValueError, match="relative to the profile cache root"):
+        cache_manager.delete(absolute_key)
+
+    assert outside_file.read() == "outside data"
+    assert os.path.exists(cached_path)
+
+
+def test_cache_manager_delete_rejects_path_outside_profile_root(profile_name, tmpdir, cache_manager):
+    """Test that CacheManager rejects delete paths that escape the profile cache root."""
+    sibling_dir = tmpdir.mkdir("other-profile")
+    sibling_file = sibling_dir.join("victim.txt")
+    sibling_file.write("victim data")
+
+    with pytest.raises(ValueError, match="escapes the profile cache root"):
+        cache_manager.delete_file(os.path.join("..", "other-profile", "victim.txt"))
+
+    assert sibling_file.read() == "victim data"
+
+
+def test_cache_manager_delete_rejects_symlink_escape(profile_name, tmpdir, cache_manager):
+    """Test that CacheManager rejects delete paths that escape through a symlinked directory."""
+    sibling_dir = tmpdir.mkdir("symlink-target")
+    sibling_file = sibling_dir.join("victim.txt")
+    sibling_file.write("victim data")
+
+    escape_link = os.path.join(str(tmpdir), profile_name, "escape-link")
+    os.symlink(str(sibling_dir), escape_link)
+
+    with pytest.raises(ValueError, match="escapes the profile cache root"):
+        cache_manager.delete_file(os.path.join("escape-link", "victim.txt"))
+
+    assert sibling_file.read() == "victim data"
+
+
+def test_cache_manager_delete_normalizes_safe_relative_path(profile_name, tmpdir, cache_manager):
+    """Test that CacheManager allows normalized relative delete paths that stay within the profile cache root."""
+    key = "bucket/test_file.txt"
+    cache_manager.set(key, b"cached data")
+
+    cache_manager.delete_file(os.path.join("bucket", "nested", "..", "test_file.txt"))
+
+    assert not os.path.exists(cache_manager._get_cache_file_path(key))
+
+
 def test_cache_manager_open_file(profile_name, tmpdir, cache_manager):
     """Test that CacheManager can open a file from the cache."""
     file = tmpdir.join(profile_name, "test_file.txt")


### PR DESCRIPTION
## Summary

- reject absolute cache delete paths with `ValueError` instead of letting `os.path.join` bypass the profile cache root
- normalize delete paths and verify the resolved target stays under the profile cache root before unlinking
- keep cache eviction working by routing internal eviction through an absolute-path helper instead of the stricter public delete path
- add regressions for absolute paths, `..` traversal, symlink escapes, and normalized in-root deletes

## Why

The cache delete path assumed its input was profile-relative, but `os.path.join(cache_root, absolute_path)` discards the cache root entirely. That made it possible to unlink arbitrary absolute paths. Path traversal through `..` or symlinked intermediate directories had the same class of problem.

## Impact

Unsafe delete inputs now fail fast with `ValueError` and do not remove anything outside the profile cache root.

## Checks

- `uv run --package multi-storage-client --group dev pytest multi-storage-client/tests/test_multistorageclient/unit/test_cache.py::test_cache_manager_read_delete_file_with_etag multi-storage-client/tests/test_multistorageclient/unit/test_cache.py::test_cache_manager_read_delete_file multi-storage-client/tests/test_multistorageclient/unit/test_cache.py::test_cache_manager_delete_rejects_absolute_path multi-storage-client/tests/test_multistorageclient/unit/test_cache.py::test_cache_manager_delete_rejects_path_outside_profile_root multi-storage-client/tests/test_multistorageclient/unit/test_cache.py::test_cache_manager_delete_rejects_symlink_escape multi-storage-client/tests/test_multistorageclient/unit/test_cache.py::test_cache_manager_delete_normalizes_safe_relative_path multi-storage-client/tests/test_multistorageclient/unit/test_cache.py::test_cache_manager_refresh_cache multi-storage-client/tests/test_multistorageclient/unit/test_cache.py::test_partial_chunk_write_triggers_background_eviction multi-storage-client/tests/test_multistorageclient/unit/test_cache.py::test_lru_eviction_policy multi-storage-client/tests/test_multistorageclient/unit/test_cache.py::test_mru_eviction_policy multi-storage-client/tests/test_multistorageclient/unit/test_cache.py::test_fifo_eviction_policy multi-storage-client/tests/test_multistorageclient/unit/test_cache.py::test_random_eviction_policy multi-storage-client/tests/test_multistorageclient/unit/test_cache.py::test_no_eviction_policy -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cache file deletion with stricter path validation and security checks
  * Improved protection to prevent unauthorized file access outside cache boundaries
  * Optimized cache eviction process with more reliable file handling

* **Tests**
  * Added comprehensive unit test coverage for cache deletion path validation and security scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->