### PR TITLE
chore: Upgrade AIStore Nix package to 1.4.7.

### DIFF
--- a/nix/overlays/development/multi-storage-client/packages/aistore/package.nix
+++ b/nix/overlays/development/multi-storage-client/packages/aistore/package.nix
@@ -7,20 +7,20 @@
 # https://nixos.org/manual/nixpkgs/unstable#ssec-language-go
 buildGoModule (finalAttrs: {
   pname = "aistore";
-  version = "1.4.6";
+  version = "1.4.7";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "aistore";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GEO8+r9gPqLXPcsQ19SMT3qMq5Y2KaTvkFJP1pDphvo=";
+    hash = "sha256-wYHAN7h4tvRhUITk7Z5CUmf510tHddk8dsOKEBCp33w=";
   };
 
-  vendorHash = "sha256-sjO3Ktrb5H2efYv1C1O597C6XHw9Pzc692XC6oBzH6I=";
+  vendorHash = "sha256-df7xiuAqbX7XAKVQyX/KWktnK+0ToNw0gJe8vroZe8Q=";
 
   # Exclude `cmd/cli` and `cmd/ishard` which are separate Go modules.
   #
-  # https://github.com/NVIDIA/aistore/tree/v1.4.6/cmd
+  # https://github.com/NVIDIA/aistore/tree/v1.4.7/cmd
   subPackages = [
     "cmd/aisinit"
     "cmd/aisloader"
@@ -32,7 +32,7 @@ buildGoModule (finalAttrs: {
 
   # Needed for version strings.
   #
-  # https://github.com/NVIDIA/aistore/blob/v1.4.6/Makefile#L86
+  # https://github.com/NVIDIA/aistore/blob/v1.4.7/Makefile#L86
   ldflags = [
     "-X main.build=v${finalAttrs.version}"
     "-X main.buildtime=1970-01-01T00:00:00-00:00"
@@ -41,7 +41,7 @@ buildGoModule (finalAttrs: {
   tags = [
     # Monotonic time.
     #
-    # https://github.com/NVIDIA/aistore/blob/v1.4.6/Makefile#L98
+    # https://github.com/NVIDIA/aistore/blob/v1.4.7/Makefile#L98
     "mono"
   ];
 


### PR DESCRIPTION
## Description

Upgrade AIStore Nix package to 1.4.7.

Closes NGCDP-8983.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated aistore package to version 1.4.7 with corresponding hash updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->