### PR TITLE
chore: remove reference and warning for deprecated env variable

### DIFF
--- a/multi-storage-client/src/multistorageclient/sync/progress_bar.py
+++ b/multi-storage-client/src/multistorageclient/sync/progress_bar.py
@@ -1,12 +1,9 @@
-import logging
 import os
 import sys
 import time
 from typing import Any
 
 from tqdm import tqdm
-
-logger = logging.getLogger(__name__)
 
 
 class CappedProgressBar(tqdm):
@@ -33,17 +30,8 @@ class CappedProgressBar(tqdm):
 
 class ProgressBar:
     def __init__(self, desc: str, show_progress: bool, total_items: int = 0):
-        # If the env var is defined, always suppress the progress bar
-        legacy_msc_suppress = os.getenv("SUPPRESS_PROGRESS_BAR") is not None
-        msc_suppress = os.getenv("MSC_SUPPRESS_PROGRESS_BAR") is not None
-
-        if msc_suppress or legacy_msc_suppress:
+        if os.getenv("MSC_SUPPRESS_PROGRESS_BAR") is not None:
             show_progress = False
-
-        if legacy_msc_suppress:
-            logger.warning(
-                "Env var 'SUPPRESS_PROGRESS_BAR' is deprecated and will be removed; use 'MSC_SUPPRESS_PROGRESS_BAR'."
-            )
 
         if not show_progress:
             self.pbar = None


### PR DESCRIPTION
For part of 1.0 breaking changes, remove reference to this long-deprecated environment variable.

Related to NGCDP-8520

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed support for the deprecated `SUPPRESS_PROGRESS_BAR` environment variable. Use `MSC_SUPPRESS_PROGRESS_BAR` instead to suppress progress bar display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->