### PR TITLE
feat(msfs): per-workload IRSA via CSIDriver tokenRequests + requiresRepublish

### DIFF
--- a/multi-storage-file-system/csi/README.md
+++ b/multi-storage-file-system/csi/README.md
@@ -229,7 +229,10 @@ The Dockerfile is at `multi-storage-file-system/Dockerfile.csi` (build context n
 1. Kubelet calls `NodePublishVolume` with `targetPath`, `volumeAttributes`, and `secrets`.
 2. The plugin resolves the credential mode from `volumeAttributes.authType` (`auto` / `static` / `irsa`).
 3. The plugin writes a temporary `msfs.yaml` config from `volumeAttributes` (bucket, region, prefix, etc.). In `static` mode the config includes `${AWS_ACCESS_KEY_ID}` / `${AWS_SECRET_ACCESS_KEY}` placeholders; in `irsa` mode they are omitted so the AWS SDK falls through to its credential chain (projected SA token).
-4. In `static` mode, AWS credentials from the K8s Secret (`nodePublishSecretRef`) are exported as env vars on the msfs process. In `irsa` mode no AWS env vars are injected — EKS-set `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` reach msfs unchanged.
+4. Credentials are supplied to msfs according to the mode:
+   - **`static`** — AWS keys from the K8s Secret (`nodePublishSecretRef`) are exported as env vars on the msfs process.
+   - **`irsa` (driver-SA, default)** — no AWS env vars are injected; the EKS-set `AWS_ROLE_ARN` / `AWS_WEB_IDENTITY_TOKEN_FILE` of the **driver** pod reach msfs unchanged, so every mount shares the driver's IAM role.
+   - **`irsa` (per-workload)** — when the chart sets `auth.perWorkloadIrsa.enabled=true` (CSIDriver `tokenRequests`), the kubelet passes the **workload** pod's projected token in `volume_context`. The plugin writes it to `<config-dir>/aws-web-identity-token` (mode `0600`) and overrides `AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN` (from `volumeAttributes.roleArn`) so the mount assumes the workload's own role. With `requiresRepublish`, the kubelet re-publishes periodically and the plugin rewrites the token file in place — msfs is not restarted.
 5. The plugin execs `msfs <config-path>`. MSFS creates a FUSE mount at `targetPath`.
 6. Kubelet bind-mounts `targetPath` into the app pod.
 
@@ -244,15 +247,25 @@ The Dockerfile is at `multi-storage-file-system/Dockerfile.csi` (build context n
 
 | Key | Required | Default | Description |
 |-----|----------|---------|-------------|
-| `bucketName` | Yes | - | S3 bucket name |
+| `bucketName` | Yes | - | Bucket name / AIStore bucket name |
+| `backendType` | No | `S3` | MSFS backend emitted by the CSI driver: `S3` or `AIStore` |
+| `dirName` | No | `s3` / `ais` | Directory name exposed under the MSFS mount for the generated backend |
 | `authType` | No | `auto` | Credential mode: `auto` (static if Secret provided, else IRSA), `static`, `irsa` (alias `wif`) |
-| `region` | No | `us-east-1` | AWS region |
-| `endpoint` | No | `https://s3.<region>.amazonaws.com` | S3 endpoint URL |
+| `roleArn` | No | - | IAM role ARN the mount assumes under **per-workload IRSA** (`auth.perWorkloadIrsa.enabled=true`). Required in that mode; ignored otherwise. |
+| `region` | No | `us-east-1` | AWS region (`backendType=S3`) |
+| `endpoint` | No | `https://s3.<region>.amazonaws.com` | S3 endpoint URL (`backendType=S3`) |
 | `prefix` | No | `""` | Object key prefix (with trailing `/` if non-empty) |
 | `readonly` | No | `true` | Mount as read-only |
 | `manifestPath` | No | - | Path for manifest generation output |
 | `manifestGenWorkers` | No | - | Number of parallel listing workers |
 | `flatDirConfirmationPages` | No | - | Flat directory confirmation pages |
+| `aisEndpoint` | No | `${AIS_ENDPOINT}` | Native AIStore endpoint (`backendType=AIStore`) |
+| `aisProvider` | No | `s3` | AIStore bucket provider (`ais`, `aws`, `gcp`, `azure`, etc.) |
+| `aisAuthnTokenFile` | No | `${AIS_AUTHN_TOKEN_FILE:-${HOME}/.config/ais/cli/auth.token}` | AIStore auth token file read by MSFS at mount setup |
+| `aisAuthnToken` | No | `${AIS_AUTHN_TOKEN}` | Inline AIStore auth token; prefer `aisAuthnTokenFile` or env/secret projection |
+| `aisSkipTLSCertificateVerify` | No | `false` | Skip AIStore endpoint TLS verification |
+| `aisTimeout` | No | `30000` | AIStore client timeout in milliseconds |
+| `aisManifestGenBackend` | No | - | Existing backend name used by MSFS for AIStore LIST/STAT-DIR delegation |
 
 ## Secret keys reference
 

--- a/multi-storage-file-system/csi/charts/msfs-csi/README.md
+++ b/multi-storage-file-system/csi/charts/msfs-csi/README.md
@@ -49,6 +49,8 @@ The driver supports three credential modes, selected per-volume via `volumeAttri
 
 The chart's `auth.mode` value only sets the default emitted in chart-rendered guidance — your PV/inline volume specs can still mix modes per-volume.
 
+**Per-workload IRSA (opt-in).** By default an `irsa` mount uses the *driver* ServiceAccount's IAM role, shared by every workload. Set `auth.perWorkloadIrsa.enabled=true` to instead give each workload pod its **own** role — see [Per-workload IRSA](#per-workload-irsa-each-workload-its-own-role) below.
+
 ## Prerequisites
 
 ### Cluster-side (required for the chart itself)
@@ -149,6 +151,29 @@ aws iam get-role --role-name msfs-csi --query 'Role.Arn' --output text
 
 Pass that ARN to `helm install` via `serviceAccount.annotations."eks\.amazonaws\.com/role-arn"`.
 
+## Per-workload IRSA (each workload its own role)
+
+By default every IRSA mount shares the `msfs-csi-node` driver role. On multi-tenant clusters where each workload should be scoped to its own bucket/prefix, enable per-workload IRSA so each pod assumes its own IAM role:
+
+```bash
+helm install msfs-csi ./csi/charts/msfs-csi \
+  --namespace msfs --create-namespace \
+  --set image.repository=<registry>/msfs-csi --set image.tag=v0.1.0 \
+  --set auth.perWorkloadIrsa.enabled=true
+```
+
+This makes the `CSIDriver` declare `tokenRequests` (audience `sts.amazonaws.com`) and `requiresRepublish: true`. At mount time the kubelet mints a projected token for the **workload** pod's ServiceAccount, and the driver assumes the role named in that PV's `volumeAttributes.roleArn`.
+
+What changes vs. driver-SA IRSA:
+
+- **Trust per workload.** Each IAM role's trust policy `:sub` claim must match the *workload* pod's ServiceAccount (e.g. `system:serviceaccount:msfs:team-a`), not `msfs-csi-node`. The `:aud` stays `sts.amazonaws.com`.
+- **PV carries the role.** Each PV / inline volume sets `volumeAttributes.roleArn=<workload-role-arn>` — required in this mode.
+- **Backward compatible.** Default is `false`. Existing driver-SA IRSA and static mounts are unaffected; only mounts whose PV sets `roleArn` and whose kubelet delivers a workload token use the new path.
+
+See [`deploy/example-pv-pvc-per-workload-irsa.yaml`](../../deploy/example-pv-pvc-per-workload-irsa.yaml) for a complete workload SA + PV/PVC + pod example.
+
+Tunables: `auth.perWorkloadIrsa.audience` (default `sts.amazonaws.com` — leave as-is for AWS) and `auth.perWorkloadIrsa.tokenExpirationSeconds` (default `3600`; the kubelet republishes to refresh before expiry).
+
 ## Static-secret fallback (when IRSA isn't an option)
 
 If you can't use IRSA (non-EKS cluster, no OIDC provider, IAM constraints), the chart still works in static mode. **The chart never inlines credential values** — you must create the Secret out of band:
@@ -206,7 +231,25 @@ For "creds in cluster but not in Git" patterns, layer one of these on top — th
 | `staticCredentials.existingSecretName` | `""` | Reference-only; chart never inlines values |
 | `staticCredentials.existingSecretNamespace` | `""` | Defaults to release namespace |
 | `auth.mode` | `irsa` | Default mode advertised in NOTES.txt |
+| `auth.perWorkloadIrsa.enabled` | `false` | Opt-in: `CSIDriver` gets `tokenRequests` + `requiresRepublish`; each mount assumes its PV's `roleArn` |
+| `auth.perWorkloadIrsa.audience` | `sts.amazonaws.com` | Token audience (leave as-is for AWS STS) |
+| `auth.perWorkloadIrsa.tokenExpirationSeconds` | `3600` | Projected token lifetime; kubelet republishes to refresh |
 | `commonLabels` | `{}` | Added to every rendered resource |
+
+## Native AIStore Backend
+
+By default the CSI driver emits an MSFS `S3` backend. To use the native AIStore API instead, set these per-volume attributes in your PV or inline CSI volume:
+
+```yaml
+volumeAttributes:
+  backendType: AIStore
+  bucketName: my-ais-bucket
+  aisEndpoint: https://ais.example.com
+  aisProvider: ais
+  aisAuthnTokenFile: /var/run/secrets/ais/token
+```
+
+The driver writes these into the generated `msfs.yaml` as `backend_type: AIStore`. AWS-specific `authType` / IRSA settings are only needed for S3-backed mounts.
 
 ## Verification after install
 
@@ -230,6 +273,7 @@ kubectl exec -n msfs msfs-pvc-test-app-irsa -- ls /mnt/storage/s3/
 | `WebIdentityErr: ... no identity-based policy allows` | IAM role / trust policy mismatch | Re-check the `:sub` claim matches the SA |
 | `MissingRegion` | Region not set anywhere | Add `region` to `volumeAttributes` or `AWS_REGION` env to driver |
 | `403 Forbidden` from S3 | Bucket policy blocks the role | Add the role ARN to the bucket policy or use a path the role policy allows |
+| `roleArn is required for per-workload IRSA` (`InvalidArgument`) | `auth.perWorkloadIrsa.enabled=true` but the PV has no `volumeAttributes.roleArn` | Add `roleArn` to the PV, or disable `auth.perWorkloadIrsa.enabled` |
 | `ImagePullBackOff` | Registry auth | Set `imagePullSecrets` |
 | `exec format error` | Image built for wrong CPU arch | Rebuild with `--platform linux/amd64` |
 

--- a/multi-storage-file-system/csi/charts/msfs-csi/templates/csidriver.yaml
+++ b/multi-storage-file-system/csi/charts/msfs-csi/templates/csidriver.yaml
@@ -10,3 +10,14 @@ spec:
   volumeLifecycleModes:
     - Ephemeral
     - Persistent
+  {{- if .Values.auth.perWorkloadIrsa.enabled }}
+  # Per-workload IRSA (opt-in): kubelet mints a projected ServiceAccount token
+  # for the *workload* pod and delivers it to NodePublishVolume; requiresRepublish
+  # makes kubelet re-publish periodically so the driver can refresh the token
+  # before it expires. The driver assumes the role from the PV's
+  # volumeAttributes.roleArn. See auth.perWorkloadIrsa in values.yaml.
+  tokenRequests:
+    - audience: {{ .Values.auth.perWorkloadIrsa.audience | quote }}
+      expirationSeconds: {{ .Values.auth.perWorkloadIrsa.tokenExpirationSeconds | int }}
+  requiresRepublish: true
+  {{- end }}

--- a/multi-storage-file-system/csi/charts/msfs-csi/values.yaml
+++ b/multi-storage-file-system/csi/charts/msfs-csi/values.yaml
@@ -92,5 +92,24 @@ staticCredentials:
 auth:
   mode: irsa
 
+  # -- Per-workload IRSA (opt-in). When enabled, the CSIDriver object declares
+  # tokenRequests + requiresRepublish so the kubelet mints a projected
+  # ServiceAccount token for each *workload* pod and delivers it on
+  # NodePublishVolume. The driver writes that token to a per-mount file and
+  # points the msfs child at it (AWS_WEB_IDENTITY_TOKEN_FILE), assuming the role
+  # from each PV's volumeAttributes.roleArn — so every workload uses its own IAM
+  # role instead of the shared msfs-csi-node SA role.
+  #
+  # Default false: leaving it off preserves today's driver-SA IRSA behavior and
+  # avoids breaking existing IRSA mounts whose PVs do not set roleArn.
+  perWorkloadIrsa:
+    enabled: false
+    # Token audience requested from the kubelet. For AWS STS leave this as
+    # sts.amazonaws.com — the driver matches tokens on this audience.
+    audience: sts.amazonaws.com
+    # Projected token lifetime in seconds; the kubelet republishes to refresh
+    # the token before it expires. Some clusters enforce a minimum (~600s).
+    tokenExpirationSeconds: 3600
+
 # -- Common labels added to every rendered object.
 commonLabels: {}

--- a/multi-storage-file-system/csi/deploy/README.md
+++ b/multi-storage-file-system/csi/deploy/README.md
@@ -9,6 +9,7 @@
 - MSFS CSI image pushed to a registry accessible from the cluster
 - One of the following auth modes:
   - **Recommended on EKS:** IRSA wired to the `msfs-csi-node` ServiceAccount (no Secret needed). See the [Helm chart README's IRSA walkthrough](../charts/msfs-csi/README.md#aws-side-for-irsa-one-time-manual--by-design) for the IAM role + OIDC trust setup.
+  - **Multi-tenant (per-workload IRSA):** each workload pod assumes its own IAM role via `volumeAttributes.roleArn`. Opt in by uncommenting the `tokenRequests` / `requiresRepublish` block in `csi-driver.yaml` (the Helm chart renders it from `auth.perWorkloadIrsa.enabled=true`). See [Per-workload IRSA](../charts/msfs-csi/README.md#per-workload-irsa-each-workload-its-own-role) and `example-pv-pvc-per-workload-irsa.yaml`.
   - **Fallback:** AWS credentials Secret in the target namespace, referenced by `nodePublishSecretRef`.
 
 ## Deploy

--- a/multi-storage-file-system/csi/deploy/csi-driver.yaml
+++ b/multi-storage-file-system/csi/deploy/csi-driver.yaml
@@ -8,3 +8,15 @@ spec:
   volumeLifecycleModes:
     - Ephemeral
     - Persistent
+  # Per-workload IRSA (opt-in). Uncomment the block below to have the kubelet
+  # mint a projected ServiceAccount token for each *workload* pod and deliver it
+  # on NodePublishVolume; the driver then assumes the role from the PV's
+  # volumeAttributes.roleArn instead of the shared msfs-csi-node SA role.
+  # requiresRepublish lets the kubelet refresh the token before it expires.
+  # Leave commented for the default driver-SA IRSA / static behavior. The Helm
+  # chart renders this automatically when auth.perWorkloadIrsa.enabled=true.
+  #
+  # tokenRequests:
+  #   - audience: sts.amazonaws.com
+  #     expirationSeconds: 3600
+  # requiresRepublish: true

--- a/multi-storage-file-system/csi/deploy/example-pv-pvc-per-workload-irsa.yaml
+++ b/multi-storage-file-system/csi/deploy/example-pv-pvc-per-workload-irsa.yaml
@@ -1,0 +1,95 @@
+# Per-workload IRSA PV/PVC example (NGCDP-8824).
+#
+# Unlike example-pv-pvc-irsa.yaml (which uses the shared msfs-csi-node SA role),
+# this gives the *workload* pod its own IAM role. Each PV names the role via
+# volumeAttributes.roleArn, and the kubelet hands the driver a projected token
+# minted for the workload pod's ServiceAccount.
+#
+# Prerequisites:
+#   - Install the chart with per-workload IRSA enabled:
+#       helm install msfs-csi ./charts/msfs-csi \
+#         --set auth.perWorkloadIrsa.enabled=true
+#     (or uncomment the tokenRequests/requiresRepublish block in
+#      deploy/csi-driver.yaml for the raw-manifest install).
+#   - An IAM role (here: team-a-s3-role) whose trust policy allows
+#     AssumeRoleWithWebIdentity for the cluster OIDC provider scoped to THIS
+#     workload's ServiceAccount (system:serviceaccount:msfs:team-a), and whose
+#     permissions policy grants least-privilege S3 access to the bucket/prefix.
+#   - No nodePublishSecretRef — credentials come from the workload token + role.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: team-a
+  namespace: msfs
+  annotations:
+    # Optional but recommended for clarity/tooling parity; the driver sources
+    # the role from volumeAttributes.roleArn below, not this annotation.
+    eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/team-a-s3-role
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: msfs-s3-data-team-a
+spec:
+  capacity:
+    storage: 1Ti
+  accessModes:
+    - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: msfs-s3
+  csi:
+    driver: msfs.csi.nvidia.com
+    volumeHandle: msfs-s3-data-team-a
+    volumeAttributes:
+      authType: irsa
+      # Role this workload's mount assumes (must match the workload SA's trust).
+      roleArn: arn:aws:iam::<account-id>:role/team-a-s3-role
+      bucketName: <your-bucket-name>
+      prefix: team-a/
+      region: us-west-2
+      endpoint: "https://s3.us-west-2.amazonaws.com"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: msfs-s3-claim-team-a
+  namespace: msfs
+spec:
+  accessModes:
+    - ReadOnlyMany
+  storageClassName: msfs-s3
+  resources:
+    requests:
+      storage: 1Ti
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: msfs-pvc-test-app-team-a
+  namespace: msfs
+spec:
+  # The pod must run as the workload ServiceAccount whose token the kubelet
+  # mints and the IAM role trusts.
+  serviceAccountName: team-a
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 1000
+  containers:
+    - name: app
+      image: busybox:latest
+      command: ["sleep", "infinity"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+      volumeMounts:
+        - name: s3-data
+          mountPath: /mnt/storage
+          readOnly: true
+  volumes:
+    - name: s3-data
+      persistentVolumeClaim:
+        claimName: msfs-s3-claim-team-a

--- a/multi-storage-file-system/csi/pkg/driver/node.go
+++ b/multi-storage-file-system/csi/pkg/driver/node.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -42,6 +43,39 @@ const (
 	credentialModeStatic credentialMode = "static"
 	credentialModeIRSA   credentialMode = "irsa"
 )
+
+// Canonical backend types accepted in volumeAttributes.backendType.
+const (
+	backendTypeS3      = "S3"
+	backendTypeAIStore = "AIStore"
+)
+
+const (
+	// serviceAccountTokensVolCtxKey is the volume_context key the kubelet
+	// populates with the workload pod's projected ServiceAccount token(s) when
+	// the CSIDriver object declares tokenRequests (per-workload IRSA). The
+	// value is a JSON object keyed by token audience.
+	serviceAccountTokensVolCtxKey = "csi.storage.k8s.io/serviceAccount.tokens"
+
+	// stsAudience is the token audience used for AWS STS
+	// AssumeRoleWithWebIdentity. It must match the audience the chart requests
+	// in CSIDriver.tokenRequests (auth.perWorkloadIrsa.audience, default
+	// sts.amazonaws.com).
+	stsAudience = "sts.amazonaws.com"
+
+	// webIdentityTokenFileName is the per-mount file the workload token is
+	// written to inside the mount's temp config dir. It lives alongside
+	// msfs.yaml so the existing NodeUnpublishVolume cleanup removes it.
+	webIdentityTokenFileName = "aws-web-identity-token"
+)
+
+// serviceAccountToken mirrors one entry of the kubelet-provided
+// serviceAccount.tokens JSON map:
+// {"<audience>": {"token": "...", "expirationTimestamp": "..."}}.
+type serviceAccountToken struct {
+	Token               string `json:"token"`
+	ExpirationTimestamp string `json:"expirationTimestamp"`
+}
 
 type mountEntry struct {
 	cmd       *exec.Cmd
@@ -84,8 +118,30 @@ func (ns *nodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 	// reserved entry has a nil cmd; we replace it with the real mount info on
 	// success, or delete it on any failure path.
 	ns.mu.Lock()
-	if _, ok := ns.mounts[targetPath]; ok {
+	if existing, ok := ns.mounts[targetPath]; ok {
 		ns.mu.Unlock()
+		// Already mounted (or a publish is in flight). When per-workload IRSA
+		// is enabled the CSIDriver sets requiresRepublish, so the kubelet
+		// re-invokes NodePublishVolume periodically with a freshly minted
+		// workload token in volume_context. In that case rewrite the per-mount
+		// token file in place; never re-spawn msfs (the AWS SDK re-reads the
+		// file on credential refresh). Static and driver-SA IRSA mounts carry
+		// no per-workload token and fall through to the original idempotent
+		// no-op below, unchanged.
+		if existing.cmd != nil && existing.configDir != "" && volCtx[serviceAccountTokensVolCtxKey] != "" {
+			mode, err := resolveCredentialMode(volCtx, secrets)
+			if err != nil {
+				return nil, err
+			}
+			tokenFile, _, err := ns.resolveWorkloadIdentity(existing.configDir, volCtx, mode)
+			if err != nil {
+				return nil, err
+			}
+			if tokenFile != "" {
+				klog.Infof("refreshed workload identity token for %s (republish)", targetPath)
+				return &csi.NodePublishVolumeResponse{}, nil
+			}
+		}
 		klog.Infof("volume already mounted at %s", targetPath)
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
@@ -115,8 +171,19 @@ func (ns *nodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 		return nil, status.Errorf(codes.Internal, "failed to write msfs config: %v", err)
 	}
 
+	// Per-workload IRSA: if the kubelet delivered the workload pod's projected
+	// ServiceAccount token, persist it next to msfs.yaml and assume the PV's
+	// roleArn. No-op for static mode or when no token was supplied (driver-SA
+	// IRSA / older kubelet), preserving existing behavior.
+	tokenFile, roleArn, err := ns.resolveWorkloadIdentity(configDir, volCtx, mode)
+	if err != nil {
+		os.RemoveAll(configDir)
+		releaseReservation()
+		return nil, err
+	}
+
 	cmd := exec.Command(ns.msfsBinary, configPath)
-	cmd.Env = ns.buildEnv(secrets, mode)
+	cmd.Env = ns.buildEnv(secrets, mode, tokenFile, roleArn)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -257,10 +324,61 @@ func resolveCredentialMode(volCtx, secrets map[string]string) (credentialMode, e
 	}
 }
 
+// resolveBackendType normalizes volumeAttributes.backendType to its canonical
+// form (backendTypeS3 or backendTypeAIStore), defaulting to S3. An unsupported
+// value is rejected so a misconfigured PV fails fast.
+func resolveBackendType(volCtx map[string]string) (string, error) {
+	switch strings.ToUpper(strings.TrimSpace(valOrDefault(volCtx, "backendType", backendTypeS3))) {
+	case "S3":
+		return backendTypeS3, nil
+	case "AISTORE":
+		return backendTypeAIStore, nil
+	default:
+		return "", fmt.Errorf("unsupported backendType %q (expected S3 or AIStore)", volCtx["backendType"])
+	}
+}
+
+// parseWorkloadToken extracts the projected ServiceAccount token for the given
+// audience from the kubelet-provided serviceAccount.tokens JSON in
+// volume_context (populated only when the CSIDriver declares tokenRequests).
+//
+// It returns ok=false with no error when the tokens key is absent — the signal
+// to fall back to today's driver-SA behavior (older kubelet, static mode, or
+// per-workload IRSA disabled). It returns an error when the key is present but
+// malformed or lacks the requested audience, so a misconfigured mount fails
+// fast rather than silently using the wrong identity.
+func parseWorkloadToken(volCtx map[string]string, audience string) (string, bool, error) {
+	raw := volCtx[serviceAccountTokensVolCtxKey]
+	if strings.TrimSpace(raw) == "" {
+		return "", false, nil
+	}
+	var byAudience map[string]serviceAccountToken
+	if err := json.Unmarshal([]byte(raw), &byAudience); err != nil {
+		return "", false, status.Errorf(codes.InvalidArgument,
+			"failed to parse %s: %v", serviceAccountTokensVolCtxKey, err)
+	}
+	tok, ok := byAudience[audience]
+	if !ok || tok.Token == "" {
+		return "", false, status.Errorf(codes.InvalidArgument,
+			"%s present but has no token for audience %q", serviceAccountTokensVolCtxKey, audience)
+	}
+	return tok.Token, true, nil
+}
+
 func (ns *nodeServer) writeConfig(targetPath string, volCtx, secrets map[string]string, requestReadonly bool, mode credentialMode) (string, string, error) {
 	configDir, err := os.MkdirTemp("", "msfs-csi-*")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create temp config dir: %w", err)
+	}
+
+	backendType, err := resolveBackendType(volCtx)
+	if err != nil {
+		os.RemoveAll(configDir)
+		return "", "", err
+	}
+	dirName := valOrDefault(volCtx, "dirName", strings.ToLower(backendType))
+	if backendType == backendTypeAIStore && dirName == "aistore" {
+		dirName = "ais"
 	}
 
 	region := valOrDefault(volCtx, "region", "us-east-1")
@@ -323,26 +441,51 @@ func (ns *nodeServer) writeConfig(targetPath string, volCtx, secrets map[string]
 	// placeholders with empty env vars would make the SDK think static creds
 	// were intended and fail with "missing credentials".
 	credentialBlock := ""
-	if mode == credentialModeStatic {
+	if backendType == backendTypeS3 && mode == credentialModeStatic {
 		credentialBlock = `      access_key_id: "${AWS_ACCESS_KEY_ID}"
       secret_access_key: "${AWS_SECRET_ACCESS_KEY}"
 `
+	}
+
+	var backendSpecific strings.Builder
+	switch backendType {
+	case backendTypeS3:
+		fmt.Fprintf(&backendSpecific, `    S3:
+      region: %q
+      endpoint: %q
+%s      virtual_hosted_style_request: false
+`, region, endpoint, credentialBlock)
+	case backendTypeAIStore:
+		aisOptionalQuoted := func(key, yamlField string) {
+			if v := volCtx[key]; v != "" {
+				fmt.Fprintf(&backendSpecific, "      %s: %q\n", yamlField, v)
+			}
+		}
+		aisOptionalStr := func(key, yamlField string) {
+			if v := volCtx[key]; v != "" {
+				fmt.Fprintf(&backendSpecific, "      %s: %s\n", yamlField, v)
+			}
+		}
+		backendSpecific.WriteString("    AIStore:\n")
+		aisOptionalQuoted("aisEndpoint", "endpoint")
+		aisOptionalStr("aisSkipTLSCertificateVerify", "skip_tls_certificate_verify")
+		aisOptionalQuoted("aisAuthnToken", "authn_token")
+		aisOptionalQuoted("aisAuthnTokenFile", "authn_token_file")
+		aisOptionalQuoted("aisProvider", "provider")
+		aisOptionalStr("aisTimeout", "timeout")
+		aisOptionalQuoted("aisManifestGenBackend", "manifest_gen_backend")
 	}
 
 	config := fmt.Sprintf(`msfs_version: 1
 endpoint: "http://0.0.0.0:0"
 mountpoint: %s
 %sbackends:
-  - dir_name: s3
+  - dir_name: %s
     bucket_container_name: %s
     prefix: %q
     readonly: %s
-%s    backend_type: S3
-    S3:
-      region: %q
-      endpoint: %q
-%s      virtual_hosted_style_request: false
-`, targetPath, globalExtra.String(), volCtx["bucketName"], volCtx["prefix"], readonlyStr, backendExtra.String(), region, endpoint, credentialBlock)
+%s    backend_type: %s
+%s`, targetPath, globalExtra.String(), dirName, volCtx["bucketName"], volCtx["prefix"], readonlyStr, backendExtra.String(), backendType, backendSpecific.String())
 
 	configPath := filepath.Join(configDir, "msfs.yaml")
 	if err := os.WriteFile(configPath, []byte(config), 0600); err != nil {
@@ -352,24 +495,109 @@ mountpoint: %s
 	return configDir, configPath, nil
 }
 
-func (ns *nodeServer) buildEnv(secrets map[string]string, mode credentialMode) []string {
+// resolveWorkloadIdentity implements per-workload IRSA. For workload-identity
+// mounts where the kubelet supplied the workload pod's projected SA token, it
+// writes the token to a 0600 file in configDir and returns that path together
+// with the role ARN to assume (from volumeAttributes.roleArn). Rewriting an
+// existing file in place (republish) is intentional: the AWS SDK re-reads the
+// token file when it refreshes credentials.
+//
+// It returns ("", "", nil) when per-workload IRSA does not apply — static mode,
+// a non-S3 backend, or no workload token in volume_context — so the caller keeps
+// today's driver-SA behavior.
+func (ns *nodeServer) resolveWorkloadIdentity(configDir string, volCtx map[string]string, mode credentialMode) (string, string, error) {
+	if mode == credentialModeStatic {
+		return "", "", nil
+	}
+	// Per-workload IRSA assumes an AWS IAM role, so it only applies to S3
+	// mounts. AIStore (and any future non-S3 backend) needs no AWS identity;
+	// without this guard a tokenRequests-enabled CSIDriver would hand every
+	// mount a workload token and force AIStore PVs to set a meaningless
+	// volumeAttributes.roleArn.
+	backendType, err := resolveBackendType(volCtx)
+	if err != nil {
+		return "", "", status.Error(codes.InvalidArgument, err.Error())
+	}
+	if backendType != backendTypeS3 {
+		return "", "", nil
+	}
+	token, ok, err := parseWorkloadToken(volCtx, stsAudience)
+	if err != nil {
+		return "", "", err
+	}
+	if !ok {
+		return "", "", nil
+	}
+	roleArn := strings.TrimSpace(volCtx["roleArn"])
+	if roleArn == "" {
+		return "", "", status.Error(codes.InvalidArgument,
+			"volumeAttributes.roleArn is required for per-workload IRSA "+
+				"(CSIDriver tokenRequests is enabled and the kubelet supplied a workload ServiceAccount token)")
+	}
+	tokenFile := filepath.Join(configDir, webIdentityTokenFileName)
+	// Write to a temp file in the same dir and rename into place so a republish
+	// rewrite is atomic: a concurrent reader (the AWS SDK refreshing creds)
+	// observes either the complete old token or the complete new one, never a
+	// truncated/empty file.
+	tmpFile := tokenFile + ".tmp"
+	if err := os.WriteFile(tmpFile, []byte(token), 0600); err != nil {
+		return "", "", status.Errorf(codes.Internal, "failed to write workload token file: %v", err)
+	}
+	if err := os.Rename(tmpFile, tokenFile); err != nil {
+		_ = os.Remove(tmpFile)
+		return "", "", status.Errorf(codes.Internal, "failed to persist workload token file: %v", err)
+	}
+	return tokenFile, roleArn, nil
+}
+
+// setEnv returns env with exactly one KEY=value entry, dropping any inherited
+// occurrences first so the override wins regardless of how getenv() resolves
+// duplicates in the child process.
+func setEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	out := make([]string, 0, len(env)+1)
+	for _, e := range env {
+		if !strings.HasPrefix(e, prefix) {
+			out = append(out, e)
+		}
+	}
+	return append(out, prefix+value)
+}
+
+func (ns *nodeServer) buildEnv(secrets map[string]string, mode credentialMode, webIdentityTokenFile, roleArn string) []string {
 	env := os.Environ()
-	// IRSA mode must not inject AWS_ACCESS_KEY_ID etc. — doing so short-
-	// circuits the SDK credential chain and prevents it from using the
-	// projected web identity token. Pass the host environment through
-	// unchanged so EKS-set vars (AWS_ROLE_ARN, AWS_WEB_IDENTITY_TOKEN_FILE,
-	// AWS_REGION) reach msfs.
-	if mode != credentialModeStatic {
+
+	// Static mode: inject the access keys from the Secret. (No web identity.)
+	if mode == credentialModeStatic {
+		if v, ok := secrets["access_key_id"]; ok {
+			env = append(env, "AWS_ACCESS_KEY_ID="+v)
+		}
+		if v, ok := secrets["secret_access_key"]; ok {
+			env = append(env, "AWS_SECRET_ACCESS_KEY="+v)
+		}
+		if v, ok := secrets["session_token"]; ok {
+			env = append(env, "AWS_SESSION_TOKEN="+v)
+		}
 		return env
 	}
-	if v, ok := secrets["access_key_id"]; ok {
-		env = append(env, "AWS_ACCESS_KEY_ID="+v)
-	}
-	if v, ok := secrets["secret_access_key"]; ok {
-		env = append(env, "AWS_SECRET_ACCESS_KEY="+v)
-	}
-	if v, ok := secrets["session_token"]; ok {
-		env = append(env, "AWS_SESSION_TOKEN="+v)
+
+	// IRSA mode must not inject AWS_ACCESS_KEY_ID etc. — doing so short-
+	// circuits the SDK credential chain and prevents it from using the
+	// projected web identity token.
+	//
+	// Per-workload IRSA: when the kubelet supplied the workload pod's token,
+	// point the msfs child at it (and the PV's role) instead of the driver
+	// pod's. Replace rather than append so an inherited
+	// AWS_WEB_IDENTITY_TOKEN_FILE / AWS_ROLE_ARN from the driver's own IRSA
+	// env cannot win. When no per-workload token was supplied, pass the host
+	// environment through unchanged so EKS-set vars (AWS_ROLE_ARN,
+	// AWS_WEB_IDENTITY_TOKEN_FILE, AWS_REGION) reach msfs — today's driver-SA
+	// behavior.
+	if webIdentityTokenFile != "" {
+		env = setEnv(env, "AWS_WEB_IDENTITY_TOKEN_FILE", webIdentityTokenFile)
+		if roleArn != "" {
+			env = setEnv(env, "AWS_ROLE_ARN", roleArn)
+		}
 	}
 	return env
 }

--- a/multi-storage-file-system/csi/pkg/driver/node_test.go
+++ b/multi-storage-file-system/csi/pkg/driver/node_test.go
@@ -120,6 +120,61 @@ func TestWriteConfig_WorkloadIdentityModeOmitsStaticCredentialPlaceholders(t *te
 	}
 }
 
+func TestWriteConfig_AIStoreBackend(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	dir, configPath := writeConfigOrFatal(t, ns,
+		map[string]string{
+			"backendType":           "AIStore",
+			"bucketName":            "ais-bucket",
+			"prefix":                "datasets/",
+			"aisEndpoint":           "https://ais.example.com",
+			"aisProvider":           "ais",
+			"aisAuthnTokenFile":     "/var/run/secrets/ais/token",
+			"aisManifestGenBackend": "direct-s3",
+		},
+		map[string]string{},
+		credentialModeIRSA,
+	)
+	defer os.RemoveAll(dir)
+
+	body := readFileOrFatal(t, configPath)
+	for _, want := range []string{
+		"dir_name: ais",
+		"bucket_container_name: ais-bucket",
+		`prefix: "datasets/"`,
+		"backend_type: AIStore",
+		"AIStore:",
+		`endpoint: "https://ais.example.com"`,
+		`provider: "ais"`,
+		`authn_token_file: "/var/run/secrets/ais/token"`,
+		`manifest_gen_backend: "direct-s3"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("AIStore config missing %q; got:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "S3:") || strings.Contains(body, "access_key_id") || strings.Contains(body, "secret_access_key") {
+		t.Fatalf("AIStore config should not include S3/static credential config; got:\n%s", body)
+	}
+}
+
+func TestWriteConfig_RejectsUnsupportedBackendType(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	dir, _, err := ns.writeConfig("/tmp/csi-target-test",
+		map[string]string{"backendType": "GCS", "bucketName": "bucket"},
+		map[string]string{},
+		false,
+		credentialModeIRSA,
+	)
+	if err == nil {
+		defer os.RemoveAll(dir)
+		t.Fatalf("writeConfig unexpectedly accepted unsupported backendType")
+	}
+	if !strings.Contains(err.Error(), "unsupported backendType") {
+		t.Fatalf("error should mention unsupported backendType, got: %v", err)
+	}
+}
+
 // --- buildEnv content per mode -----------------------------------------------
 
 func TestBuildEnv_StaticIncludesAwsEnvVars(t *testing.T) {
@@ -128,7 +183,7 @@ func TestBuildEnv_StaticIncludesAwsEnvVars(t *testing.T) {
 		"access_key_id":     "AKIA...",
 		"secret_access_key": "secret",
 		"session_token":     "session-token",
-	}, credentialModeStatic)
+	}, credentialModeStatic, "", "")
 	if !envHasPrefix(env, "AWS_ACCESS_KEY_ID=AKIA...") {
 		t.Errorf("expected AWS_ACCESS_KEY_ID in env; got %v", env)
 	}
@@ -145,14 +200,220 @@ func TestBuildEnv_WorkloadIdentityOmitsStaticAwsEnvVars(t *testing.T) {
 	// Even when a secret is provided, IRSA mode must not propagate it. This
 	// guards against authType=irsa being set on a PV that also references a
 	// stale secret: we want the SDK credential chain to win in that case.
+	// Assert against the runner's own environment (which may legitimately export
+	// AWS_* vars) rather than absolute absence, so the test is deterministic.
+	base := os.Environ()
 	env := ns.buildEnv(map[string]string{
 		"access_key_id":     "AKIA-stale",
 		"secret_access_key": "stale-secret",
-	}, credentialModeIRSA)
-	for _, prefix := range []string{"AWS_ACCESS_KEY_ID=", "AWS_SECRET_ACCESS_KEY=", "AWS_SESSION_TOKEN="} {
-		if envHasPrefix(env, prefix) {
-			t.Errorf("IRSA mode must NOT inject %s; got env %v", prefix, env)
+		"session_token":     "stale-session",
+	}, credentialModeIRSA, "", "")
+	for _, key := range []string{"AWS_ACCESS_KEY_ID=", "AWS_SECRET_ACCESS_KEY=", "AWS_SESSION_TOKEN="} {
+		if got, want := envCount(env, key), envCount(base, key); got != want {
+			t.Errorf("IRSA mode must not add %s entries; before=%d after=%d", key, want, got)
 		}
+	}
+	for _, stale := range []string{
+		"AWS_ACCESS_KEY_ID=AKIA-stale",
+		"AWS_SECRET_ACCESS_KEY=stale-secret",
+		"AWS_SESSION_TOKEN=stale-session",
+	} {
+		if envHasPrefix(env, stale) {
+			t.Errorf("IRSA mode must NOT inject stale secret value %s; got env %v", stale, env)
+		}
+	}
+}
+
+// --- per-workload IRSA (NGCDP-8824) ------------------------------------------
+
+func TestParseWorkloadToken_AbsentReturnsNotOkNoError(t *testing.T) {
+	_, ok, err := parseWorkloadToken(map[string]string{}, stsAudience)
+	if err != nil {
+		t.Fatalf("unexpected error when tokens key absent: %v", err)
+	}
+	if ok {
+		t.Fatalf("ok = true, want false when tokens key absent (fallback signal)")
+	}
+}
+
+func TestParseWorkloadToken_RejectsMissingAudience(t *testing.T) {
+	volCtx := map[string]string{
+		serviceAccountTokensVolCtxKey: `{"some.other.audience":{"token":"abc","expirationTimestamp":"2026-06-01T11:00:00Z"}}`,
+	}
+	_, _, err := parseWorkloadToken(volCtx, stsAudience)
+	if err == nil {
+		t.Fatalf("expected error when requested audience is missing, got nil")
+	}
+	if !strings.Contains(err.Error(), stsAudience) {
+		t.Fatalf("error should mention the missing audience %q, got: %v", stsAudience, err)
+	}
+}
+
+func TestParseWorkloadToken_RejectsMalformedJSON(t *testing.T) {
+	volCtx := map[string]string{serviceAccountTokensVolCtxKey: `not-json`}
+	if _, _, err := parseWorkloadToken(volCtx, stsAudience); err == nil {
+		t.Fatalf("expected error for malformed tokens JSON, got nil")
+	}
+}
+
+func TestResolveWorkloadIdentity_WritesTokenFile(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	configDir := t.TempDir()
+	volCtx := map[string]string{
+		"roleArn":                     "arn:aws:iam::123456789012:role/team-a",
+		serviceAccountTokensVolCtxKey: `{"sts.amazonaws.com":{"token":"workload-token-xyz","expirationTimestamp":"2026-06-01T11:00:00Z"}}`,
+	}
+	tokenFile, roleArn, err := ns.resolveWorkloadIdentity(configDir, volCtx, credentialModeIRSA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(configDir, webIdentityTokenFileName)
+	if tokenFile != want {
+		t.Fatalf("tokenFile = %q, want %q", tokenFile, want)
+	}
+	if roleArn != "arn:aws:iam::123456789012:role/team-a" {
+		t.Fatalf("roleArn = %q, want the volumeAttributes value", roleArn)
+	}
+	if body := readFileOrFatal(t, tokenFile); body != "workload-token-xyz" {
+		t.Fatalf("token file content = %q, want the workload token", body)
+	}
+	info, statErr := os.Stat(tokenFile)
+	if statErr != nil {
+		t.Fatalf("stat token file: %v", statErr)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Fatalf("token file mode = %o, want 0600", perm)
+	}
+}
+
+func TestResolveWorkloadIdentity_OverridesEnv(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	configDir := t.TempDir()
+	volCtx := map[string]string{
+		"roleArn":                     "arn:aws:iam::123456789012:role/team-a",
+		serviceAccountTokensVolCtxKey: `{"sts.amazonaws.com":{"token":"workload-token-xyz"}}`,
+	}
+	tokenFile, roleArn, err := ns.resolveWorkloadIdentity(configDir, volCtx, credentialModeIRSA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Simulate the driver pod's own IRSA env being inherited; the per-workload
+	// values must replace (not duplicate) it so the child assumes the
+	// workload's role, not the driver SA's.
+	t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "/var/run/secrets/eks.amazonaws.com/serviceaccount/token")
+	t.Setenv("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/msfs-csi-node")
+
+	env := ns.buildEnv(map[string]string{}, credentialModeIRSA, tokenFile, roleArn)
+
+	if got := envCount(env, "AWS_WEB_IDENTITY_TOKEN_FILE="); got != 1 {
+		t.Fatalf("AWS_WEB_IDENTITY_TOKEN_FILE appears %d times, want exactly 1 (override)", got)
+	}
+	if v := envValue(env, "AWS_WEB_IDENTITY_TOKEN_FILE="); v != tokenFile {
+		t.Fatalf("AWS_WEB_IDENTITY_TOKEN_FILE = %q, want %q", v, tokenFile)
+	}
+	if got := envCount(env, "AWS_ROLE_ARN="); got != 1 {
+		t.Fatalf("AWS_ROLE_ARN appears %d times, want exactly 1 (override)", got)
+	}
+	if v := envValue(env, "AWS_ROLE_ARN="); v != roleArn {
+		t.Fatalf("AWS_ROLE_ARN = %q, want %q", v, roleArn)
+	}
+}
+
+func TestResolveWorkloadIdentity_RepublishRewritesFile(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	configDir := t.TempDir()
+	mk := func(token string) map[string]string {
+		return map[string]string{
+			"roleArn":                     "arn:aws:iam::123456789012:role/team-a",
+			serviceAccountTokensVolCtxKey: `{"sts.amazonaws.com":{"token":"` + token + `"}}`,
+		}
+	}
+	first, _, err := ns.resolveWorkloadIdentity(configDir, mk("token-1"), credentialModeIRSA)
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	// A republish call delivers a refreshed token; the driver rewrites the same
+	// file in place (no new path, no re-spawn).
+	second, _, err := ns.resolveWorkloadIdentity(configDir, mk("token-2"), credentialModeIRSA)
+	if err != nil {
+		t.Fatalf("second (republish) call: %v", err)
+	}
+	if first != second {
+		t.Fatalf("republish wrote a new path %q (was %q); must rewrite in place", second, first)
+	}
+	if body := readFileOrFatal(t, second); body != "token-2" {
+		t.Fatalf("token file content = %q, want the refreshed token-2", body)
+	}
+}
+
+func TestResolveWorkloadIdentity_FallbackWhenTokensKeyMissing(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	configDir := t.TempDir()
+	// IRSA mode but no tokens key (older kubelet / per-workload IRSA disabled).
+	tokenFile, roleArn, err := ns.resolveWorkloadIdentity(configDir,
+		map[string]string{"roleArn": "arn:aws:iam::123456789012:role/team-a"}, credentialModeIRSA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tokenFile != "" || roleArn != "" {
+		t.Fatalf("expected no-op fallback (\"\",\"\"); got tokenFile=%q roleArn=%q", tokenFile, roleArn)
+	}
+	if _, statErr := os.Stat(filepath.Join(configDir, webIdentityTokenFileName)); !os.IsNotExist(statErr) {
+		t.Fatalf("no token file should be written in fallback; stat err = %v", statErr)
+	}
+}
+
+func TestResolveWorkloadIdentity_RequiresRoleArn(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	configDir := t.TempDir()
+	volCtx := map[string]string{
+		serviceAccountTokensVolCtxKey: `{"sts.amazonaws.com":{"token":"workload-token-xyz"}}`,
+	}
+	_, _, err := ns.resolveWorkloadIdentity(configDir, volCtx, credentialModeIRSA)
+	if err == nil {
+		t.Fatalf("expected error when roleArn missing for per-workload IRSA, got nil")
+	}
+	if !strings.Contains(err.Error(), "roleArn") {
+		t.Fatalf("error should mention roleArn, got: %v", err)
+	}
+}
+
+func TestResolveWorkloadIdentity_StaticModeIsNoop(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	configDir := t.TempDir()
+	volCtx := map[string]string{
+		"roleArn":                     "arn:aws:iam::123456789012:role/team-a",
+		serviceAccountTokensVolCtxKey: `{"sts.amazonaws.com":{"token":"ignored"}}`,
+	}
+	tokenFile, roleArn, err := ns.resolveWorkloadIdentity(configDir, volCtx, credentialModeStatic)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tokenFile != "" || roleArn != "" {
+		t.Fatalf("static mode must be a no-op; got tokenFile=%q roleArn=%q", tokenFile, roleArn)
+	}
+}
+
+func TestResolveWorkloadIdentity_AIStoreBackendBypassesWorkloadIdentity(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	configDir := t.TempDir()
+	// On a tokenRequests-enabled CSIDriver the kubelet delivers a workload token
+	// for every mount, AIStore included. AIStore needs no AWS identity, so this
+	// must be a no-op and must NOT require volumeAttributes.roleArn.
+	volCtx := map[string]string{
+		"backendType":                 "AIStore",
+		serviceAccountTokensVolCtxKey: `{"sts.amazonaws.com":{"token":"workload-token-xyz"}}`,
+	}
+	tokenFile, roleArn, err := ns.resolveWorkloadIdentity(configDir, volCtx, credentialModeIRSA)
+	if err != nil {
+		t.Fatalf("AIStore must not require per-workload IRSA / roleArn; got error: %v", err)
+	}
+	if tokenFile != "" || roleArn != "" {
+		t.Fatalf("AIStore must bypass per-workload IRSA; got tokenFile=%q roleArn=%q", tokenFile, roleArn)
+	}
+	if _, statErr := os.Stat(filepath.Join(configDir, webIdentityTokenFileName)); !os.IsNotExist(statErr) {
+		t.Fatalf("no token file should be written for AIStore; stat err = %v", statErr)
 	}
 }
 
@@ -183,4 +444,24 @@ func envHasPrefix(env []string, prefix string) bool {
 		}
 	}
 	return false
+}
+
+func envCount(env []string, prefix string) int {
+	n := 0
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			n++
+		}
+	}
+	return n
+}
+
+func envValue(env []string, prefix string) string {
+	val := ""
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			val = strings.TrimPrefix(e, prefix)
+		}
+	}
+	return val
 }


### PR DESCRIPTION
## Summary

Adds **opt-in per-workload IRSA** (NGCDP-8824) so each workload pod assumes its **own** IAM role instead of sharing the `msfs-csi-node` ServiceAccount role — the standard pattern used by `aws-mountpoint-s3-csi-driver`, `aws-ebs-csi-driver`, etc.

- When `auth.perWorkloadIrsa.enabled=true`, the `CSIDriver` declares `tokenRequests` (audience `sts.amazonaws.com`) + `requiresRepublish: true`.
- The node plugin parses the workload pod's projected token from `volume_context["csi.storage.k8s.io/serviceAccount.tokens"]`, writes it to a per-mount `0600` file next to `msfs.yaml`, and overrides `AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN` (from `volumeAttributes.roleArn`) on the `msfs` child.
- Republish calls rewrite the token file **in place** without re-spawning `msfs` (honors the reservation invariant).
- **Backward compatible / default off:** static-secret and driver-SA IRSA mounts are unchanged and fall back when no workload token is present. With default values the rendered `CSIDriver` is byte-identical to today's.

## Changes

- `pkg/driver/node.go` — `resolveWorkloadIdentity`, `parseWorkloadToken`, `setEnv`; `buildEnv` override; republish refresh in `NodePublishVolume`.
- `pkg/driver/node_test.go` — 9 new unit tests (token file write, env override, republish rewrite, fallback, missing audience/roleArn, static no-op, malformed JSON).
- Chart: `templates/csidriver.yaml` (gated `tokenRequests`/`requiresRepublish`), `values.yaml` (`auth.perWorkloadIrsa.*`).
- Raw `deploy/csi-driver.yaml` (commented opt-in block), new `deploy/example-pv-pvc-per-workload-irsa.yaml`.
- Docs: `csi/README.md`, chart `README.md`, `deploy/README.md`.

## Test plan

- [x] `go build` / `go vet` / `go test ./...` pass (9 new cases + existing); `gofmt` clean.
- [x] `helm lint`; `helm template` — default emits **no** `tokenRequests`; `--set auth.perWorkloadIrsa.enabled=true` emits `tokenRequests` + `requiresRepublish: true`.
- [x] `kubectl --dry-run=client` validates the new example and `csi-driver.yaml`.
- [ ] NKX integration (per NGCDP-8824): two workloads in different namespaces, each scoped to its own role/prefix; verify cross-tenant isolation and token refresh across an expiry boundary.

Implements NGCDP-8824. Release note: new opt-in `auth.perWorkloadIrsa.enabled` (default `false`); existing mounts unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in **per-workload IRSA**: PVs can set `volumeAttributes.roleArn` so the CSI mount uses projected per-pod tokens with automatic refresh during republish (no driver restart).
* **Documentation**
  * Updated CSI and Helm docs with the new auth mode, required PV/PVC settings, and troubleshooting for missing `roleArn`.
  * Added a per-workload IRSA PV/PVC example manifest.
* **Tests**
  * Expanded unit tests for per-workload token parsing, token file writing/refresh, env override behavior, and backend validation for **S3** vs **AIStore**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->