### PR TITLE
feat(csi): add no-credentials (anonymous) connection mode

### DIFF
--- a/multi-storage-file-system/backend_s3.go
+++ b/multi-storage-file-system/backend_s3.go
@@ -56,9 +56,14 @@ func (backend *backendStruct) setupS3Context() (err error) {
 		configOptions = append(configOptions, config.WithSharedConfigFiles(nil), config.WithRegion(backendS3.region))
 	}
 
-	if backendS3.useCredentialsEnv {
+	switch {
+	case backendS3.anonymous:
+		// Anonymous access: install the sentinel provider so the SDK skips
+		// request signing entirely (public / no-auth S3-compatible endpoints).
+		configOptions = append(configOptions, config.WithSharedCredentialsFiles(nil), config.WithCredentialsProvider(aws.AnonymousCredentials{}))
+	case backendS3.useCredentialsEnv:
 		configOptions = append(configOptions, config.WithSharedCredentialsFiles(([]string{backendS3.credentialsFilePath})))
-	} else {
+	default:
 		configOptions = append(configOptions, config.WithSharedCredentialsFiles(nil), config.WithCredentialsProvider(credentials.StaticCredentialsProvider{
 			Value: aws.Credentials{
 				AccessKeyID:     backendS3.accessKeyID,

--- a/multi-storage-file-system/config.go
+++ b/multi-storage-file-system/config.go
@@ -1767,7 +1767,24 @@ func checkConfigFile() (err error) {
 					return
 				}
 
-				if backendConfigS3AsStruct.useCredentialsEnv {
+				backendConfigS3AsStruct.anonymous, ok = parseBool(backendConfigS3AsMap, "anonymous", false)
+				if !ok {
+					err = fmt.Errorf("bad S3.anonymous at backends[%v (\"%s\")]", backendsAsInterfaceSliceIndex, backendAsStructNew.dirName)
+					return
+				}
+
+				switch {
+				case backendConfigS3AsStruct.anonymous:
+					// Anonymous access: no credentials are used (unsigned requests).
+					// Ignore any credentials file / access keys, and clear
+					// useCredentialsEnv so setupS3Context does not load a shared
+					// credentials profile. A public or no-auth endpoint can then
+					// be configured without them.
+					backendConfigS3AsStruct.useCredentialsEnv = false
+					backendConfigS3AsStruct.credentialsFilePath = ""
+					backendConfigS3AsStruct.accessKeyID = ""
+					backendConfigS3AsStruct.secretAccessKey = ""
+				case backendConfigS3AsStruct.useCredentialsEnv:
 					backendConfigS3AsStruct.credentialsFilePath, ok = parseString(backendConfigS3AsMap, "credentials_file_path", "${AWS_SHARED_CREDENTIALS_FILE:-${HOME}/.aws/credentials}")
 					if !ok {
 						err = fmt.Errorf("bad S3.credentials_file_path at backends[%v (\"%s\")]", backendsAsInterfaceSliceIndex, backendAsStructNew.dirName)
@@ -1776,7 +1793,7 @@ func checkConfigFile() (err error) {
 
 					backendConfigS3AsStruct.accessKeyID = ""
 					backendConfigS3AsStruct.secretAccessKey = ""
-				} else {
+				default:
 					backendConfigS3AsStruct.credentialsFilePath = ""
 
 					backendConfigS3AsStruct.accessKeyID, ok = parseString(backendConfigS3AsMap, "access_key_id", "${AWS_ACCESS_KEY_ID}")
@@ -2457,6 +2474,11 @@ func checkConfigFile() (err error) {
 
 					if backendAsStructOld.backendTypeSpecifics.(*backendConfigS3Struct).virtualHostedStyleRequest != backendAsStructNew.backendTypeSpecifics.(*backendConfigS3Struct).virtualHostedStyleRequest {
 						err = fmt.Errorf("cannot change S3.virtual_hosted_style_request in backends[\"%s\"]", dirName)
+						return
+					}
+
+					if backendAsStructOld.backendTypeSpecifics.(*backendConfigS3Struct).anonymous != backendAsStructNew.backendTypeSpecifics.(*backendConfigS3Struct).anonymous {
+						err = fmt.Errorf("cannot change S3.anonymous in backends[\"%s\"]", dirName)
 						return
 					}
 

--- a/multi-storage-file-system/config_test.go
+++ b/multi-storage-file-system/config_test.go
@@ -1098,3 +1098,87 @@ func TestResolveCacheStorage_Invalid(t *testing.T) {
 		})
 	}
 }
+
+// TestS3AnonymousBackend verifies an S3 backend can be configured for anonymous
+// (unsigned) access with no access_key_id / secret_access_key.
+func TestS3AnonymousBackend(t *testing.T) {
+	initGlobals(testOsArgs(testGlobals.testConfigFilePathMap[".yaml"]))
+
+	err := os.WriteFile(globals.configFilePath, []byte(`
+msfs_version: 1
+backends: [
+  {
+    dir_name: s3pub,
+    bucket_container_name: public-bucket,
+    prefix: "p/",
+    backend_type: S3,
+    S3: {
+      region: us-east-1,
+      endpoint: "http://minio:9000",
+      anonymous: true,
+    },
+  },
+]
+`), 0o600)
+	if err != nil {
+		t.Fatalf("os.WriteFile() failed: %v", err)
+	}
+
+	if err = checkConfigFile(); err != nil {
+		t.Fatalf("checkConfigFile() unexpectedly failed for anonymous S3: %v", err)
+	}
+
+	backend, ok := globals.backendsToMount["s3pub"]
+	if !ok {
+		t.Fatalf("expected backend \"s3pub\" to be configured")
+	}
+	s3cfg, ok := backend.backendTypeSpecifics.(*backendConfigS3Struct)
+	if !ok {
+		t.Fatalf("expected backend \"s3pub\" backendTypeSpecifics to be *backendConfigS3Struct")
+	}
+	if !s3cfg.anonymous {
+		t.Errorf("expected anonymous=true")
+	}
+	if s3cfg.accessKeyID != "" || s3cfg.secretAccessKey != "" {
+		t.Errorf("expected empty access keys for anonymous S3, got accessKeyID=%q secretAccessKey=%q", s3cfg.accessKeyID, s3cfg.secretAccessKey)
+	}
+}
+
+// TestS3AnonymousClearsUseCredentialsEnv verifies that anonymous wins over
+// use_credentials_env: the flag is normalized to false so setupS3Context does
+// not load a shared credentials profile.
+func TestS3AnonymousClearsUseCredentialsEnv(t *testing.T) {
+	initGlobals(testOsArgs(testGlobals.testConfigFilePathMap[".yaml"]))
+
+	err := os.WriteFile(globals.configFilePath, []byte(`
+msfs_version: 1
+backends: [
+  {
+    dir_name: s3pub,
+    bucket_container_name: public-bucket,
+    backend_type: S3,
+    S3: {
+      region: us-east-1,
+      endpoint: "http://minio:9000",
+      anonymous: true,
+      use_credentials_env: true,
+    },
+  },
+]
+`), 0o600)
+	if err != nil {
+		t.Fatalf("os.WriteFile() failed: %v", err)
+	}
+
+	if err = checkConfigFile(); err != nil {
+		t.Fatalf("checkConfigFile() unexpectedly failed: %v", err)
+	}
+
+	s3cfg := globals.backendsToMount["s3pub"].backendTypeSpecifics.(*backendConfigS3Struct)
+	if !s3cfg.anonymous {
+		t.Errorf("expected anonymous=true")
+	}
+	if s3cfg.useCredentialsEnv {
+		t.Errorf("expected useCredentialsEnv cleared when anonymous, got true")
+	}
+}

--- a/multi-storage-file-system/csi/README.md
+++ b/multi-storage-file-system/csi/README.md
@@ -104,7 +104,7 @@ kubectl apply -f csi/deploy/daemonset.yaml
 
 ### 3. Configure credentials (choose one mode)
 
-The driver supports two credential modes via `volumeAttributes.authType`. Default is `auto`: static when a secret is provided, otherwise IRSA.
+The driver supports static, IRSA, and no-credentials modes via `volumeAttributes.authType`. Default is `auto`: static when a secret is provided, otherwise IRSA. Use `none` (alias `anonymous`) to connect with no credentials at all — S3 sends unsigned requests and AIStore uses an empty token (e.g. a local AIS cluster or a public bucket).
 
 **Recommended on EKS — IRSA / workload identity (no Secret needed):**
 
@@ -227,10 +227,11 @@ The Dockerfile is at `multi-storage-file-system/Dockerfile.csi` (build context n
 ## How NodePublishVolume works
 
 1. Kubelet calls `NodePublishVolume` with `targetPath`, `volumeAttributes`, and `secrets`.
-2. The plugin resolves the credential mode from `volumeAttributes.authType` (`auto` / `static` / `irsa`).
-3. The plugin writes a temporary `msfs.yaml` config from `volumeAttributes` (bucket, region, prefix, etc.). In `static` mode the config includes `${AWS_ACCESS_KEY_ID}` / `${AWS_SECRET_ACCESS_KEY}` placeholders; in `irsa` mode they are omitted so the AWS SDK falls through to its credential chain (projected SA token).
+2. The plugin resolves the credential mode from `volumeAttributes.authType` (`auto` / `static` / `irsa` / `none`).
+3. The plugin writes a temporary `msfs.yaml` config from `volumeAttributes` (bucket, region, prefix, etc.). In `static` mode the config includes `${AWS_ACCESS_KEY_ID}` / `${AWS_SECRET_ACCESS_KEY}` placeholders; in `irsa` mode they are omitted so the AWS SDK falls through to its credential chain (projected SA token); in `none` mode an S3 backend gets `anonymous: true` (unsigned requests) and an AIStore backend is left with no token.
 4. Credentials are supplied to msfs according to the mode:
    - **`static`** — AWS keys from the K8s Secret (`nodePublishSecretRef`) are exported as env vars on the msfs process.
+   - **`none` (alias `anonymous`)** — no Secret, no IRSA, and no AWS env vars are injected. For S3 the generated config sets `anonymous: true` so the SDK skips request signing; for AIStore the token is left empty (anonymous access). Useful for public buckets or no-auth endpoints such as a local AIS cluster.
    - **`irsa` (driver-SA, default)** — no AWS env vars are injected; the EKS-set `AWS_ROLE_ARN` / `AWS_WEB_IDENTITY_TOKEN_FILE` of the **driver** pod reach msfs unchanged, so every mount shares the driver's IAM role.
    - **`irsa` (per-workload)** — when the chart sets `auth.perWorkloadIrsa.enabled=true` (CSIDriver `tokenRequests`), the kubelet passes the **workload** pod's projected token in `volume_context`. The plugin writes it to `<config-dir>/aws-web-identity-token` (mode `0600`) and overrides `AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN` (from `volumeAttributes.roleArn`) so the mount assumes the workload's own role. With `requiresRepublish`, the kubelet re-publishes periodically and the plugin rewrites the token file in place — msfs is not restarted.
 5. The plugin execs `msfs <config-path>`. MSFS creates a FUSE mount at `targetPath`.
@@ -250,7 +251,7 @@ The Dockerfile is at `multi-storage-file-system/Dockerfile.csi` (build context n
 | `bucketName` | Yes | - | Bucket name / AIStore bucket name |
 | `backendType` | No | `S3` | MSFS backend emitted by the CSI driver: `S3` or `AIStore` |
 | `dirName` | No | `s3` / `ais` | Directory name exposed under the MSFS mount for the generated backend |
-| `authType` | No | `auto` | Credential mode: `auto` (static if Secret provided, else IRSA), `static`, `irsa` (alias `wif`) |
+| `authType` | No | `auto` | Credential mode: `auto` (static if Secret provided, else IRSA), `static`, `irsa` (alias `wif`), `none` (alias `anonymous`; no credentials — unsigned S3 / empty AIStore token) |
 | `roleArn` | No | - | IAM role ARN the mount assumes under **per-workload IRSA** (`auth.perWorkloadIrsa.enabled=true`). Required in that mode; ignored otherwise. |
 | `region` | No | `us-east-1` | AWS region (`backendType=S3`) |
 | `endpoint` | No | `https://s3.<region>.amazonaws.com` | S3 endpoint URL (`backendType=S3`) |

--- a/multi-storage-file-system/csi/charts/msfs-csi/README.md
+++ b/multi-storage-file-system/csi/charts/msfs-csi/README.md
@@ -39,13 +39,14 @@ There is no Controller Deployment / StatefulSet — see `../../README.md#archite
 
 ## Auth modes
 
-The driver supports three credential modes, selected per-volume via `volumeAttributes.authType`:
+The driver supports four credential modes, selected per-volume via `volumeAttributes.authType`:
 
 | Mode | Behavior | Needs Secret? |
 |---|---|---|
 | `auto` (default) | Static when a `nodePublishSecretRef` is provided, otherwise IRSA | Optional |
 | `static` | Read keys from `nodePublishSecretRef`; reject if incomplete | **Required** |
 | `irsa` (alias `wif`) | Skip secret injection; let the AWS SDK use the projected SA token | No |
+| `none` (alias `anonymous`) | Connect with no credentials at all: S3 issues unsigned requests (`anonymous: true`), AIStore connects with an empty token (e.g. a local AIS cluster or a public bucket) | No |
 
 The chart's `auth.mode` value only sets the default emitted in chart-rendered guidance — your PV/inline volume specs can still mix modes per-volume.
 

--- a/multi-storage-file-system/csi/charts/msfs-csi/values.yaml
+++ b/multi-storage-file-system/csi/charts/msfs-csi/values.yaml
@@ -88,7 +88,7 @@ staticCredentials:
 
 # -- Default credential mode written into example manifests rendered by this
 # chart. Volume specs you author yourself can override per-volume via
-# volumeAttributes.authType. Allowed values: auto, static, irsa, wif.
+# volumeAttributes.authType. Allowed values: auto, static, irsa, wif, none, anonymous.
 auth:
   mode: irsa
 

--- a/multi-storage-file-system/csi/pkg/driver/node.go
+++ b/multi-storage-file-system/csi/pkg/driver/node.go
@@ -36,12 +36,18 @@ const (
 //   - credentialModeAuto: pick static when a secret with at least the two
 //     required keys is present, otherwise IRSA. This is the default so
 //     existing manifests keep working unchanged.
+//   - credentialModeNone: connect with no credentials at all — no Secret and no
+//     IRSA. Injects no AWS_* env vars and emits no credential placeholders. For
+//     S3 it emits anonymous: true (unsigned requests, for public / no-auth
+//     endpoints); for AIStore it leaves the token empty (anonymous access, e.g.
+//     a local AIS cluster).
 type credentialMode string
 
 const (
 	credentialModeAuto   credentialMode = "auto"
 	credentialModeStatic credentialMode = "static"
 	credentialModeIRSA   credentialMode = "irsa"
+	credentialModeNone   credentialMode = "none"
 )
 
 // Canonical backend types accepted in volumeAttributes.backendType.
@@ -295,6 +301,8 @@ func hasStaticSecretKeys(secrets map[string]string) bool {
 //     referenced Secret; partial credentials are rejected.
 //   - "irsa" / "wif" never require a Secret. Either alias resolves to
 //     credentialModeIRSA.
+//   - "none" / "anonymous" never require a Secret and supply no credentials at
+//     all (no IRSA, no access keys). Either alias resolves to credentialModeNone.
 //   - "auto" (or unset) picks static if a complete Secret was provided,
 //     otherwise IRSA. This preserves backward compatibility with existing
 //     static-secret manifests while letting new IRSA-based PVs omit
@@ -318,9 +326,11 @@ func resolveCredentialMode(volCtx, secrets map[string]string) (credentialMode, e
 		return credentialModeStatic, nil
 	case string(credentialModeIRSA), "wif":
 		return credentialModeIRSA, nil
+	case string(credentialModeNone), "anonymous":
+		return credentialModeNone, nil
 	default:
 		return "", status.Errorf(codes.InvalidArgument,
-			"unsupported authType %q (expected one of: auto, static, irsa, wif)", requested)
+			"unsupported authType %q (expected one of: auto, static, irsa, wif, none, anonymous)", requested)
 	}
 }
 
@@ -434,17 +444,25 @@ func (ns *nodeServer) writeConfig(targetPath string, volCtx, secrets map[string]
 		fmt.Fprintf(&globalExtra, "allow_other: %s\n", v)
 	}
 
-	// In IRSA mode we deliberately omit the access_key_id / secret_access_key
-	// placeholders so the AWS SDK falls through to its credential chain and
-	// picks up the projected ServiceAccount token (AWS_ROLE_ARN +
-	// AWS_WEB_IDENTITY_TOKEN_FILE) that EKS sets on the pod. Including the
-	// placeholders with empty env vars would make the SDK think static creds
-	// were intended and fail with "missing credentials".
+	// The S3 block's credential lines depend on the mode:
+	//   - static: emit access_key_id / secret_access_key placeholders bound to
+	//     the AWS_* env vars buildEnv injects from the Secret.
+	//   - none: emit anonymous: true so the S3 backend issues unsigned requests
+	//     (public / no-auth endpoints) — no Secret, no IRSA.
+	//   - IRSA: emit nothing so the AWS SDK falls through to its credential chain
+	//     and picks up the projected ServiceAccount token (AWS_ROLE_ARN +
+	//     AWS_WEB_IDENTITY_TOKEN_FILE). Emitting empty placeholders here would
+	//     make the SDK think static creds were intended and fail.
 	credentialBlock := ""
-	if backendType == backendTypeS3 && mode == credentialModeStatic {
-		credentialBlock = `      access_key_id: "${AWS_ACCESS_KEY_ID}"
+	if backendType == backendTypeS3 {
+		switch mode {
+		case credentialModeStatic:
+			credentialBlock = `      access_key_id: "${AWS_ACCESS_KEY_ID}"
       secret_access_key: "${AWS_SECRET_ACCESS_KEY}"
 `
+		case credentialModeNone:
+			credentialBlock = "      anonymous: true\n"
+		}
 	}
 
 	var backendSpecific strings.Builder
@@ -469,8 +487,12 @@ func (ns *nodeServer) writeConfig(targetPath string, volCtx, secrets map[string]
 		backendSpecific.WriteString("    AIStore:\n")
 		aisOptionalQuoted("aisEndpoint", "endpoint")
 		aisOptionalStr("aisSkipTLSCertificateVerify", "skip_tls_certificate_verify")
-		aisOptionalQuoted("aisAuthnToken", "authn_token")
-		aisOptionalQuoted("aisAuthnTokenFile", "authn_token_file")
+		// none (anonymous) mode uses no credentials, so any supplied AIStore
+		// token is ignored — the backend connects with an empty token.
+		if mode != credentialModeNone {
+			aisOptionalQuoted("aisAuthnToken", "authn_token")
+			aisOptionalQuoted("aisAuthnTokenFile", "authn_token_file")
+		}
 		aisOptionalQuoted("aisProvider", "provider")
 		aisOptionalStr("aisTimeout", "timeout")
 		aisOptionalQuoted("aisManifestGenBackend", "manifest_gen_backend")
@@ -502,11 +524,12 @@ mountpoint: %s
 // existing file in place (republish) is intentional: the AWS SDK re-reads the
 // token file when it refreshes credentials.
 //
-// It returns ("", "", nil) when per-workload IRSA does not apply — static mode,
-// a non-S3 backend, or no workload token in volume_context — so the caller keeps
-// today's driver-SA behavior.
+// It returns ("", "", nil) when per-workload IRSA does not apply — static or
+// no-credentials mode, a non-S3 backend, or no workload token in volume_context
+// — so the caller keeps today's driver-SA behavior.
 func (ns *nodeServer) resolveWorkloadIdentity(configDir string, volCtx map[string]string, mode credentialMode) (string, string, error) {
-	if mode == credentialModeStatic {
+	// Static and no-credentials mounts never use a projected workload token.
+	if mode == credentialModeStatic || mode == credentialModeNone {
 		return "", "", nil
 	}
 	// Per-workload IRSA assumes an AWS IAM role, so it only applies to S3

--- a/multi-storage-file-system/csi/pkg/driver/node_test.go
+++ b/multi-storage-file-system/csi/pkg/driver/node_test.go
@@ -69,6 +69,20 @@ func TestResolveCredentialMode_IrsaDoesNotRequireSecret(t *testing.T) {
 	}
 }
 
+func TestResolveCredentialMode_NoneAndAnonymous(t *testing.T) {
+	for _, alias := range []string{"none", "NONE", "anonymous", " none "} {
+		t.Run(alias, func(t *testing.T) {
+			mode, err := resolveCredentialMode(map[string]string{"authType": alias}, map[string]string{})
+			if err != nil {
+				t.Fatalf("unexpected error for authType=%q: %v", alias, err)
+			}
+			if mode != credentialModeNone {
+				t.Fatalf("mode = %q, want %q", mode, credentialModeNone)
+			}
+		})
+	}
+}
+
 func TestResolveCredentialMode_RejectsUnknownAuthType(t *testing.T) {
 	_, err := resolveCredentialMode(map[string]string{"authType": "magic"}, map[string]string{})
 	if err == nil {
@@ -158,6 +172,71 @@ func TestWriteConfig_AIStoreBackend(t *testing.T) {
 	}
 }
 
+func TestWriteConfig_NoneModeS3EmitsAnonymous(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	dir, configPath := writeConfigOrFatal(t, ns,
+		map[string]string{"bucketName": "public-bucket"},
+		map[string]string{},
+		credentialModeNone,
+	)
+	defer os.RemoveAll(dir)
+
+	body := readFileOrFatal(t, configPath)
+	if !strings.Contains(body, "anonymous: true") {
+		t.Fatalf("none mode S3 config should set anonymous: true; got:\n%s", body)
+	}
+	if strings.Contains(body, "access_key_id") || strings.Contains(body, "secret_access_key") {
+		t.Fatalf("none mode config must NOT contain static credential placeholders; got:\n%s", body)
+	}
+}
+
+func TestWriteConfig_NoneModeAIStoreOmitsAnonymousAndCreds(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	dir, configPath := writeConfigOrFatal(t, ns,
+		map[string]string{
+			"backendType": "AIStore",
+			"bucketName":  "ais-bucket",
+			"aisEndpoint": "https://ais.example.com",
+		},
+		map[string]string{},
+		credentialModeNone,
+	)
+	defer os.RemoveAll(dir)
+
+	body := readFileOrFatal(t, configPath)
+	if !strings.Contains(body, "backend_type: AIStore") {
+		t.Fatalf("expected AIStore backend; got:\n%s", body)
+	}
+	// anonymous is an S3-only field; for AIStore, no-credentials means an empty
+	// token, so neither an anonymous flag nor a token should be emitted.
+	if strings.Contains(body, "anonymous:") || strings.Contains(body, "authn_token") {
+		t.Fatalf("none mode AIStore config must not emit anonymous/token; got:\n%s", body)
+	}
+}
+
+func TestWriteConfig_NoneModeAIStoreIgnoresTokenInputs(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	// Even when AIStore token attributes are supplied, none (anonymous) mode
+	// must not emit them — the backend connects with an empty token.
+	dir, configPath := writeConfigOrFatal(t, ns,
+		map[string]string{
+			"backendType":       "AIStore",
+			"bucketName":        "ais-bucket",
+			"aisEndpoint":       "https://ais.example.com",
+			"aisAuthnToken":     "inline-token",
+			"aisAuthnTokenFile": "/var/run/secrets/ais/token",
+		},
+		map[string]string{},
+		credentialModeNone,
+	)
+	defer os.RemoveAll(dir)
+
+	body := readFileOrFatal(t, configPath)
+	if strings.Contains(body, "authn_token") {
+		t.Fatalf("none mode must ignore AIStore token inputs; got:\n%s", body)
+	}
+}
+
 func TestWriteConfig_RejectsUnsupportedBackendType(t *testing.T) {
 	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
 	dir, _, err := ns.writeConfig("/tmp/csi-target-test",
@@ -220,6 +299,22 @@ func TestBuildEnv_WorkloadIdentityOmitsStaticAwsEnvVars(t *testing.T) {
 	} {
 		if envHasPrefix(env, stale) {
 			t.Errorf("IRSA mode must NOT inject stale secret value %s; got env %v", stale, env)
+		}
+	}
+}
+
+func TestBuildEnv_NoneOmitsAwsEnvVars(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	base := os.Environ()
+	// none mode must not inject any AWS credential env vars, even if a secret
+	// was somehow supplied.
+	env := ns.buildEnv(map[string]string{
+		"access_key_id":     "AKIA-ignored",
+		"secret_access_key": "ignored-secret",
+	}, credentialModeNone, "", "")
+	for _, key := range []string{"AWS_ACCESS_KEY_ID=", "AWS_SECRET_ACCESS_KEY=", "AWS_SESSION_TOKEN="} {
+		if got, want := envCount(env, key), envCount(base, key); got != want {
+			t.Errorf("none mode must not add %s entries; before=%d after=%d", key, want, got)
 		}
 	}
 }
@@ -414,6 +509,22 @@ func TestResolveWorkloadIdentity_AIStoreBackendBypassesWorkloadIdentity(t *testi
 	}
 	if _, statErr := os.Stat(filepath.Join(configDir, webIdentityTokenFileName)); !os.IsNotExist(statErr) {
 		t.Fatalf("no token file should be written for AIStore; stat err = %v", statErr)
+	}
+}
+
+func TestResolveWorkloadIdentity_NoneModeIsNoop(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	configDir := t.TempDir()
+	// none mode never assumes a role, even if the kubelet supplied a token.
+	volCtx := map[string]string{
+		serviceAccountTokensVolCtxKey: `{"sts.amazonaws.com":{"token":"ignored"}}`,
+	}
+	tokenFile, roleArn, err := ns.resolveWorkloadIdentity(configDir, volCtx, credentialModeNone)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tokenFile != "" || roleArn != "" {
+		t.Fatalf("none mode must be a no-op; got tokenFile=%q roleArn=%q", tokenFile, roleArn)
 	}
 }
 

--- a/multi-storage-file-system/globals.go
+++ b/multi-storage-file-system/globals.go
@@ -107,6 +107,7 @@ type backendConfigS3Struct struct {
 	credentialsFilePath       string        //     JSON/YAML "credentials_file_path"          default:"${AWS_SHARED_CREDENTIALS_FILE:-~/.aws/credentials}"
 	accessKeyID               string        //     JSON/YAML "access_key_id"                  default:"${AWS_ACCESS_KEY_ID}"
 	secretAccessKey           string        //     JSON/YAML "secret_access_key"              default:"${AWS_SECRET_ACCESS_KEY}"
+	anonymous                 bool          //     JSON/YAML "anonymous"                      default:false
 	skipTLSCertificateVerify  bool          //     JSON/YAML "skip_tls_certificate_verify"    default:false
 	virtualHostedStyleRequest bool          //     JSON/YAML "virtual_hosted_style_request"   default:false
 	unsignedPayload           bool          //     JSON/YAML "unsigned_payload"               default:false


### PR DESCRIPTION
## Summary
Adds an opt-in **no-credentials / anonymous** connection mode to the MSFS CSI driver and the core S3 backend (NGCDP-9029; follow-up to #84). This is Shane's clarified "empty secret" ask — connect with *no* creds of any kind (no IRSA, no access keys), e.g. a local AIS cluster or a public S3 bucket.

- **CSI:** `volumeAttributes.authType: none` (alias `anonymous`) → no Secret, no IRSA, no AWS env vars injected, per-workload identity bypassed. S3 mounts emit `anonymous: true`; AIStore mounts are left with an empty token.
- **Core S3:** new `anonymous` config field; the parser no longer requires `access_key_id`/`secret_access_key` when it is set, and `setupS3Context` installs `aws.AnonymousCredentials{}` so requests are unsigned. Rejected for live change via SIGHUP, consistent with the other S3 fields.
- Fully backward compatible — `auto` / `static` / `irsa` behavior is unchanged.

## Test plan
- [x] `go build` / `go vet` / `gofmt` clean (CSI + MSFS modules)
- [x] CSI unit tests: `none`/`anonymous` resolution, S3 emits `anonymous: true`, AIStore omits token/anonymous, `buildEnv` injects nothing, workload-identity no-op
- [x] MSFS unit test: anonymous S3 backend parses with no access keys
- [ ] (manual) mount a public S3 bucket / local AIS cluster with `authType: none`

Tracked by NGCDP-9029.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an anonymous/no-credentials option for S3-backed storage and CSI volume mounts, including `none`/`anonymous` aliases.
  * CSI config generation now emits `anonymous: true` for S3 in this mode and omits AWS credential placeholders/env vars; AIStore uses an empty/anonymous token behavior.
* **Bug Fixes**
  * Live config reload now rejects changes that alter the S3 anonymous setting without restart.
* **Documentation**
  * Updated CSI driver and Helm chart docs/values to document the new `none`/`anonymous` credential mode.
* **Tests**
  * Added tests covering S3 anonymous parsing, generated config output, environment variable omission, and AIStore token handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->