### PR TITLE
fix: retry transient GCS delete_many failures

### DIFF
--- a/multi-storage-client/src/multistorageclient/client/single.py
+++ b/multi-storage-client/src/multistorageclient/client/single.py
@@ -736,6 +736,7 @@ class SingleStorageClient(AbstractStorageClient):
             else:
                 raise FileNotFoundError(f"The file at '{path}' was not found.")
 
+    @retry
     def delete_many(self, paths: list[str]) -> None:
         """
         Delete multiple files at the specified paths. Only files are supported; directories are not deleted.

--- a/multi-storage-client/src/multistorageclient/contrib/torch/core.py
+++ b/multi-storage-client/src/multistorageclient/contrib/torch/core.py
@@ -14,12 +14,14 @@
 # limitations under the License.
 
 import os
-from typing import IO, Any, Union
+from typing import IO, Any, Union, cast
 
-import torch as _torch
+import torch as _torch_module
 
 from ...pathlib import MultiStoragePath
 from ...shortcuts import open as msc_open
+
+_torch = cast(Any, _torch_module)
 
 
 def load(f: Union[str, os.PathLike[str], IO[bytes]], *args: Any, **kwargs: Any) -> Any:

--- a/multi-storage-client/src/multistorageclient/providers/gcs.py
+++ b/multi-storage-client/src/multistorageclient/providers/gcs.py
@@ -374,6 +374,8 @@ class GoogleStorageProvider(BaseStorageProvider):
                 raise RetryableError(
                     f"Failed to {operation} object(s) at {bucket}/{key}. {message}. status_code: {status_code}"
                 ) from error
+        except RetryableError:
+            raise
         except Exception as error:
             error_details = str(error)
             raise RuntimeError(
@@ -526,6 +528,10 @@ class GoogleStorageProvider(BaseStorageProvider):
                         status_code = response.status_code
                         if 200 <= status_code < 300 or status_code == 404:
                             continue
+                        if status_code in {408, 429} or 500 <= status_code < 600:
+                            raise RetryableError(
+                                f"GCS batch delete failed with status_code: {status_code}, response: {response.text}"
+                            )
                         raise RuntimeError(
                             f"GCS batch delete failed with status_code: {status_code}, response: {response.text}"
                         )

--- a/multi-storage-client/tests/test_multistorageclient/unit/contrib/test_torch.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/contrib/test_torch.py
@@ -14,14 +14,17 @@
 # limitations under the License.
 
 import uuid
+from typing import Any, cast
 
 import pytest
-import torch
+import torch as torch_module
 import torch.distributed.checkpoint as dcp
 
 import multistorageclient as msc
 from multistorageclient.types import MSC_PROTOCOL
 from test_multistorageclient.unit.utils import config, tempdatastore
+
+torch = cast(Any, torch_module)
 
 
 @pytest.fixture
@@ -213,6 +216,7 @@ def test_torch_save_with_attributes(temp_data_store_type: type[tempdatastore.Tem
 
         test_uuid = str(uuid.uuid4())
         file_path = f"test-torch-attributes-{test_uuid}.pt"
+        file_path2 = f"test-torch-attributes-path-{test_uuid}.pt"
         tensor = torch.tensor([1, 2, 3, 4])
 
         test_attributes = {
@@ -240,7 +244,6 @@ def test_torch_save_with_attributes(temp_data_store_type: type[tempdatastore.Tem
                     assert metadata.metadata[key] == value, f"Attribute '{key}' has incorrect value"
 
             # Test save with attributes using MultiStoragePath
-            file_path2 = f"test-torch-attributes-path-{test_uuid}.pt"
             msc.torch.save(tensor, msc.Path(f"{MSC_PROTOCOL}test/{file_path2}"), attributes=test_attributes)
 
             result = msc.torch.load(msc.Path(f"{MSC_PROTOCOL}test/{file_path2}"))

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_pathlib.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_pathlib.py
@@ -292,7 +292,7 @@ def test_path_ordering():
         "/tmp/z",
     ]
     with pytest.raises(TypeError):
-        msc.Path("/tmp/testfile") < "/tmp/other"
+        _ = msc.Path("/tmp/testfile") < "/tmp/other"
 
 
 def test_pickable_path():

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_retry.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_retry.py
@@ -13,12 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, cast
+from typing import Any, Optional, cast
 from unittest.mock import patch
 
 import pytest
 
 from multistorageclient import StorageClient, StorageClientConfig
+from multistorageclient.providers.gcs import GoogleStorageProvider
 from multistorageclient.retry import batch_retry, retry
 from multistorageclient.types import BatchTransferError, BatchTransferFailure, Range, RetryableError, StorageProvider
 
@@ -50,6 +51,17 @@ class FakeStorageProvider:
         if self.attempts < self.error_count:
             raise RetryableError("Simulated connection time out error.")
         return b"File content"
+
+
+class FakeDeleteManyStorageProvider:
+    def __init__(self, error_count):
+        self.attempts = 0
+        self.error_count = error_count
+
+    def delete_objects(self, paths: list[str]) -> None:
+        self.attempts += 1
+        if self.attempts < self.error_count:
+            raise RetryableError("Simulated delete_many transient error.")
 
 
 def test_retry_decorator_in_storage_client():
@@ -89,6 +101,62 @@ def test_retry_decorator_in_storage_client():
 
     assert "Simulated connection time out error." in str(e), f"Unexpected error message: {str(e)}"
     assert storage_provider.attempts == 3
+
+
+def test_delete_many_retries_retryable_errors():
+    config = StorageClientConfig.from_json(
+        """{
+        "profiles": {
+            "default": {
+                "storage_provider": {
+                    "type": "file",
+                    "options": {
+                        "base_path": "/"
+                    }
+                }
+            }
+        }
+    }"""
+    )
+    storage_client = StorageClient(config)
+    storage_provider = FakeDeleteManyStorageProvider(error_count=2)
+    storage_client._storage_provider = cast(StorageProvider, storage_provider)
+
+    with patch("time.sleep"):
+        storage_client.delete_many(["some_path"])
+
+    assert storage_provider.attempts == 2
+
+
+def test_gcs_batch_delete_service_unavailable_response_is_retryable():
+    class FakeBatch:
+        _responses = [type("Response", (), {"status_code": 503, "text": "server(s) are not responding"})()]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+    class FakeBucket:
+        def blob(self, key):
+            return type("Blob", (), {"delete": lambda self: None})()
+
+    class FakeGCSClient:
+        def bucket(self, bucket):
+            return FakeBucket()
+
+        def batch(self, raise_exception=False):
+            return FakeBatch()
+
+    storage_provider = cast(Any, GoogleStorageProvider.__new__(GoogleStorageProvider))
+    storage_provider._gcs_client = FakeGCSClient()
+    storage_provider._refresh_gcs_client_if_needed = lambda: None
+
+    with pytest.raises(RetryableError) as exc_info:
+        storage_provider._delete_objects(["bucket/key"])
+
+    assert "status_code: 503" in str(exc_info.value)
 
 
 def test_retry_decorator_outside_storage_client():


### PR DESCRIPTION
## Description

- Retry transient GCS `delete_many` failures during batch deletes.
- Preserve retryability for GCS batch delete `408`, `429`, and `5xx` response statuses.
- Add focused regression tests for `delete_many` retry behavior.

## Changes

- Added `@retry` to `SingleStorageClient.delete_many`.
- Updated GCS batch delete response handling to raise `RetryableError` for transient response statuses.
- Added unit tests covering `delete_many` retry and GCS batch delete `503` handling.

Closes NGCDP-8087

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bulk delete operations now retry automatically when temporary failures occur.
  * Google Cloud Storage batch deletes now treat timeouts, throttling, and server errors (5xx) as retryable for improved reliability.
  * Retryable errors are now propagated consistently instead of being converted into generic failures.

* **Tests**
  * Added unit test coverage for retry behavior in bulk deletes.
  * Added unit test coverage to verify Google Cloud Storage 503 batch delete responses raise retryable errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->