### PR TITLE
chore: update MSC docs

### DIFF
--- a/multi-storage-client-docs/src/user_guide/cli.rst
+++ b/multi-storage-client-docs/src/user_guide/cli.rst
@@ -23,13 +23,13 @@ The ``msc help`` command displays general help information and available command
    msc help <command>
 
    commands:
-   config    MSC configuration management commands
+   config   Configuration management commands
    explorer  Start the MSC Explorer application for browsing files
-   glob      Find files using Unix-style wildcard patterns with optional attribute filtering
-   help      Display help for commands
-   ls        List files and directories with optional attribute filtering
-   rm        Delete files with a given prefix
-   sync      Synchronize files from the source storage to the target storage
+   help     Display help for commands
+   ls       List files and directories with optional attribute filtering
+   mcp-server Start the Multi-Storage Client MCP (Model Context Protocol) server
+   rm       Delete files or directories
+   sync     Synchronize files from the source storage to the target storage
 
 
 ******
@@ -179,9 +179,40 @@ The ``msc explorer`` command starts the MSC Explorer web application, providing 
 The Explorer will start on ``http://127.0.0.1:8888``. Open this URL in your browser to access the interface.
 
 .. note::
-   Requires optional dependencies: ``pip install multistorageclient[explorer]``
+   Requires optional dependencies: ``pip install "multi-storage-client[explorer]"``
 
 For complete details about the MSC Explorer and its features, see :doc:`/user_guide/explorer`.
+
+**************
+msc mcp-server
+**************
+
+The ``msc mcp-server`` command starts the MSC Model Context Protocol (MCP) server for AI assistants and other MCP-compatible clients.
+
+.. code-block:: text
+  :caption: mcp-server command help output
+
+  $ msc help mcp-server
+  usage: msc mcp-server {start} ...
+
+  Start the Multi-Storage Client MCP (Model Context Protocol) server
+
+  positional arguments:
+    {start}  MCP server commands
+      start  Start the MCP server
+
+.. code-block:: shell
+
+  $ msc mcp-server start
+
+.. code-block:: shell
+
+  $ msc mcp-server start --config /path/to/config.yaml
+
+.. note::
+   Requires optional dependencies: ``pip install "multi-storage-client[mcp]"``
+
+For complete details about configuring and using the MCP server, see :doc:`/user_guide/mcp_server`.
 
 ******
 msc rm

--- a/multi-storage-client-docs/src/user_guide/installation.rst
+++ b/multi-storage-client-docs/src/user_guide/installation.rst
@@ -16,7 +16,6 @@ into MSC's operations and performance, making it harder to debug issues and opti
 
    pip install multi-storage-client[observability-otel]
 
-
 .. code-block:: shell
    :caption: Install MSC with storage provider dependencies.
 

--- a/multi-storage-client-docs/src/user_guide/mcp_server.rst
+++ b/multi-storage-client-docs/src/user_guide/mcp_server.rst
@@ -56,9 +56,6 @@ You can also start the server manually for testing or debugging:
    # Start with a specific configuration file
    msc mcp-server start --config /path/to/config.yaml
 
-   # Start with verbose logging for debugging
-   msc mcp-server start --config /path/to/config.yaml --verbose
-
 .. _cursor-configuration:
 
 *************
@@ -508,4 +505,3 @@ The AI assistant can help you identify the right files, confirm the operation, a
    * :doc:`/references/configuration` - Complete configuration reference
 
    * `Model Context Protocol <https://modelcontextprotocol.io/>`_ - Official MCP documentation
-


### PR DESCRIPTION
## Description

- Refresh the documented `msc help` output to match the current CLI commands.
- Remove the stale `msc glob` command from the CLI docs and add `msc mcp-server`.
- Add a CLI docs section for `msc mcp-server start` and `--config`.
- Fix the Explorer install extra package name.
- Remove a stale `--verbose` MCP server example that is not supported.

Closes NGCDP-7517

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI help references to include the new `mcp-server` command and remove `glob`.
  * Added documentation for `msc mcp-server`, including usage, examples, and dependency requirements.
  * Refined the `msc explorer` note with clearer guidance for installing optional dependencies.
  * Made minor formatting and spacing adjustments in the installation and server docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->