### PR TITLE
feat(csi): support multi-bucket / multi-backend volumes

### DIFF
--- a/multi-storage-file-system/config.go
+++ b/multi-storage-file-system/config.go
@@ -1910,6 +1910,22 @@ func checkConfigFile() (err error) {
 		aisCfg.manifestGenBackend = srcBackend
 	}
 
+	// Reject duplicate manifest_path across backends: manifest generation does a
+	// RemoveAll on the output path, so two backends sharing a manifest_path would
+	// clobber each other's generated manifest. Runs on initial load and SIGHUP
+	// reload, covering native configs as well as CSI-generated ones.
+	manifestPathOwner := make(map[string]string, len(config.backends))
+	for _, manifestBackend := range config.backends {
+		if manifestBackend.manifestPath == "" {
+			continue
+		}
+		if prev, found := manifestPathOwner[manifestBackend.manifestPath]; found {
+			err = fmt.Errorf("duplicate manifest_path %q at backends[\"%s\"] and [\"%s\"]", manifestBackend.manifestPath, prev, manifestBackend.dirName)
+			return
+		}
+		manifestPathOwner[manifestBackend.manifestPath] = manifestBackend.dirName
+	}
+
 	if globals.config == nil {
 		// Move all (local) config.backends to globals.backendsToMount
 

--- a/multi-storage-file-system/config_test.go
+++ b/multi-storage-file-system/config_test.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -1180,5 +1181,102 @@ backends: [
 	}
 	if s3cfg.useCredentialsEnv {
 		t.Errorf("expected useCredentialsEnv cleared when anonymous, got true")
+	}
+}
+
+// TestDuplicateManifestPathRejected verifies that two backends sharing the same
+// manifest_path are rejected: generateManifest does a RemoveAll on the output
+// path, so sharing it would clobber one backend's generated manifest.
+func TestDuplicateManifestPathRejected(t *testing.T) {
+	initGlobals(testOsArgs(testGlobals.testConfigFilePathMap[".yaml"]))
+
+	err := os.WriteFile(globals.configFilePath, []byte(`
+msfs_version: 1
+backends: [
+  {
+    dir_name: a,
+    bucket_container_name: test,
+    prefix: "pa/",
+    readonly: true,
+    manifest_path: "/tmp/msfs-test-manifest-shared",
+    backend_type: S3,
+    S3: {
+      region: us-east-1,
+      endpoint: "http://minio:9000",
+      access_key_id: minioadmin,
+      secret_access_key: minioadmin,
+    },
+  },
+  {
+    dir_name: b,
+    bucket_container_name: test,
+    prefix: "pb/",
+    readonly: true,
+    manifest_path: "/tmp/msfs-test-manifest-shared",
+    backend_type: S3,
+    S3: {
+      region: us-east-1,
+      endpoint: "http://minio:9000",
+      access_key_id: minioadmin,
+      secret_access_key: minioadmin,
+    },
+  },
+]
+`), 0o600)
+	if err != nil {
+		t.Fatalf("os.WriteFile() failed: %v", err)
+	}
+
+	if err = checkConfigFile(); err == nil {
+		t.Fatalf("checkConfigFile() unexpectedly allowed duplicate manifest_path")
+	} else if !strings.Contains(err.Error(), "manifest_path") {
+		t.Fatalf("error should mention manifest_path, got: %v", err)
+	}
+}
+
+// TestDistinctManifestPathsAccepted verifies that backends with distinct
+// manifest_path values are accepted.
+func TestDistinctManifestPathsAccepted(t *testing.T) {
+	initGlobals(testOsArgs(testGlobals.testConfigFilePathMap[".yaml"]))
+
+	err := os.WriteFile(globals.configFilePath, []byte(`
+msfs_version: 1
+backends: [
+  {
+    dir_name: a,
+    bucket_container_name: test,
+    prefix: "pa/",
+    readonly: true,
+    manifest_path: "/tmp/msfs-test-manifest-a",
+    backend_type: S3,
+    S3: {
+      region: us-east-1,
+      endpoint: "http://minio:9000",
+      access_key_id: minioadmin,
+      secret_access_key: minioadmin,
+    },
+  },
+  {
+    dir_name: b,
+    bucket_container_name: test,
+    prefix: "pb/",
+    readonly: true,
+    manifest_path: "/tmp/msfs-test-manifest-b",
+    backend_type: S3,
+    S3: {
+      region: us-east-1,
+      endpoint: "http://minio:9000",
+      access_key_id: minioadmin,
+      secret_access_key: minioadmin,
+    },
+  },
+]
+`), 0o600)
+	if err != nil {
+		t.Fatalf("os.WriteFile() failed: %v", err)
+	}
+
+	if err = checkConfigFile(); err != nil {
+		t.Fatalf("checkConfigFile() unexpectedly failed for distinct manifest_path: %v", err)
 	}
 }

--- a/multi-storage-file-system/csi/README.md
+++ b/multi-storage-file-system/csi/README.md
@@ -248,7 +248,8 @@ The Dockerfile is at `multi-storage-file-system/Dockerfile.csi` (build context n
 
 | Key | Required | Default | Description |
 |-----|----------|---------|-------------|
-| `bucketName` | Yes | - | Bucket name / AIStore bucket name |
+| `bucketName` | Conditional | - | Bucket / AIStore bucket name. Required for a single-backend volume; omit when using `backendsJson`. |
+| `backendsJson` | No | - | JSON array of backend objects to expose **multiple** backends in one volume (multi-bucket / multi-backend). Each object: `dirName`, `backendType`, `bucketName` (required), `prefix`, `readonly`, plus S3 (`region`, `endpoint`) and AIStore (`aisEndpoint`, `aisProvider`, `aisAuthnToken`, `aisAuthnTokenFile`, `aisSkipTLSCertificateVerify`, `aisTimeout`, `aisManifestGenBackend`) fields, plus the per-backend tuning fields (`manifestPath`, `manifestGenWorkers`, `flatDirConfirmationPages`, `traceLevel`, `directoryPageSize`, `uid`, `gid`, `dirPerm`, `filePerm`, `flushOnClose`, `multipartCacheLineThreshold`, `uploadPartCacheLines`, `uploadPartConcurrency`) — numeric values passed as strings (e.g. `"uid": "1000"`). When set, the single-backend attributes below are ignored. Credentials (`authType` / Secret) are shared by all backends. |
 | `backendType` | No | `S3` | MSFS backend emitted by the CSI driver: `S3` or `AIStore` |
 | `dirName` | No | `s3` / `ais` | Directory name exposed under the MSFS mount for the generated backend |
 | `authType` | No | `auto` | Credential mode: `auto` (static if Secret provided, else IRSA), `static`, `irsa` (alias `wif`), `none` (alias `anonymous`; no credentials — unsigned S3 / empty AIStore token) |
@@ -267,6 +268,25 @@ The Dockerfile is at `multi-storage-file-system/Dockerfile.csi` (build context n
 | `aisSkipTLSCertificateVerify` | No | `false` | Skip AIStore endpoint TLS verification |
 | `aisTimeout` | No | `30000` | AIStore client timeout in milliseconds |
 | `aisManifestGenBackend` | No | - | Existing backend name used by MSFS for AIStore LIST/STAT-DIR delegation |
+
+## Multiple backends in one volume
+
+By default a volume exposes a single backend built from the flat attributes above. To expose **several** backends under one mount (e.g. two S3 buckets, or S3 + native AIStore), set `volumeAttributes.backendsJson` to a JSON array — each entry becomes one MSFS backend, mounted under its own `dirName` subdirectory. The single-backend attributes (`bucketName`, `backendType`, `region`, …) are ignored when `backendsJson` is present.
+
+```yaml
+    volumeAttributes:
+      authType: irsa            # credentials are shared by all backends
+      backendsJson: |
+        [
+          {"dirName": "images",  "backendType": "S3", "bucketName": "my-images", "prefix": "train/", "region": "us-west-2"},
+          {"dirName": "labels",  "backendType": "S3", "bucketName": "my-labels"},
+          {"dirName": "cache",   "backendType": "AIStore", "bucketName": "ds", "aisEndpoint": "http://ais:51080", "aisProvider": "ais"}
+        ]
+```
+
+This mounts `images/`, `labels/`, and `cache/` under the volume. `dirName` values must be unique; an unsupported `backendType`, a missing `bucketName`, or a duplicate `manifestPath` across entries is rejected. Credentials are volume-level: every S3 backend shares the one `authType` / `nodePublishSecretRef` (per-backend distinct AWS identities are out of scope). Per-backend tuning fields (`manifestPath`, `manifestGenWorkers`, `uid`, perms, …) are supported per entry (numeric values passed as strings).
+
+**`manifestPath` under CSI:** the `msfs` process runs inside the CSI node DaemonSet pod, so `manifestPath` resolves in that pod's filesystem (not the application pod) and is **not** persisted by the driver — the generated config dir is removed on `NodeUnpublishVolume`. As a result the manifest is **regenerated on every (re)mount**. Persisting it across mounts requires a DaemonSet-mounted volume and is tracked as a follow-up (NGCDP-9116). Note that manifest generation does a `RemoveAll` on `manifestPath`, which is why two backends in one volume may not share one.
 
 ## Secret keys reference
 

--- a/multi-storage-file-system/csi/charts/msfs-csi/README.md
+++ b/multi-storage-file-system/csi/charts/msfs-csi/README.md
@@ -252,6 +252,22 @@ volumeAttributes:
 
 The driver writes these into the generated `msfs.yaml` as `backend_type: AIStore`. AWS-specific `authType` / IRSA settings are only needed for S3-backed mounts.
 
+## Multiple backends in one volume
+
+To expose several backends under one mount (multi-bucket, or mixed S3 + AIStore), set `volumeAttributes.backendsJson` to a JSON array instead of the single-backend attributes — each entry is mounted under its own `dirName` subdirectory:
+
+```yaml
+volumeAttributes:
+  authType: irsa            # shared by all backends
+  backendsJson: |
+    [
+      {"dirName": "images", "backendType": "S3", "bucketName": "my-images", "prefix": "train/", "region": "us-west-2"},
+      {"dirName": "cache",  "backendType": "AIStore", "bucketName": "ds", "aisEndpoint": "http://ais:51080", "aisProvider": "ais"}
+    ]
+```
+
+`dirName` values must be unique; a missing `bucketName`, unsupported `backendType`, or duplicate `manifestPath` is rejected. Credentials are volume-level (one `authType` / Secret shared by all S3 backends). Per-backend tuning fields (`manifestPath`, `manifestGenWorkers`, `uid`, perms, …) may be set per entry (numeric values as strings); under CSI a `manifestPath` manifest is regenerated on every (re)mount (not persisted by the driver — see NGCDP-9116). See the [CSI README](../../README.md#multiple-backends-in-one-volume) for the full field list.
+
 ## Verification after install
 
 ```bash

--- a/multi-storage-file-system/csi/deploy/README.md
+++ b/multi-storage-file-system/csi/deploy/README.md
@@ -99,3 +99,5 @@ No privileged pods, no SYS_ADMIN, no mount propagation needed in the app pod.
 | `manifestPath` | No | - | Path for manifest generation output |
 | `manifestGenWorkers` | No | - | Number of manifest generation workers |
 | `flatDirConfirmationPages` | No | - | Flat directory confirmation pages |
+
+> Multiple backends in one volume (multi-bucket / multi-backend via `backendsJson`) and the full per-backend tuning field set are documented in the [CSI driver README](../README.md#multiple-backends-in-one-volume). Note: under CSI a `manifestPath` manifest is regenerated on every (re)mount — the driver does not persist it (follow-up: NGCDP-9116).

--- a/multi-storage-file-system/csi/pkg/driver/node.go
+++ b/multi-storage-file-system/csi/pkg/driver/node.go
@@ -115,8 +115,8 @@ func (ns *nodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 	secrets := req.GetSecrets()
 
 	bucketName := volCtx["bucketName"]
-	if bucketName == "" {
-		return nil, status.Error(codes.InvalidArgument, "volumeAttributes.bucketName is required")
+	if bucketName == "" && strings.TrimSpace(volCtx["backendsJson"]) == "" {
+		return nil, status.Error(codes.InvalidArgument, "volumeAttributes.bucketName (or backendsJson) is required")
 	}
 
 	// Reservation pattern: check-and-insert under one lock so two concurrent
@@ -174,6 +174,14 @@ func (ns *nodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 	configDir, configPath, err := ns.writeConfig(targetPath, volCtx, secrets, req.GetReadonly(), mode)
 	if err != nil {
 		releaseReservation()
+		// Preserve a gRPC status code already set by writeConfig — e.g.
+		// InvalidArgument from parseVolumeBackends for a malformed or
+		// duplicate-manifest_path backendsJson — so a misconfigured volume
+		// fails fast with the correct code instead of a generic Internal.
+		// Only unclassified I/O errors (temp dir / file write) are wrapped.
+		if _, ok := status.FromError(err); ok {
+			return nil, err
+		}
 		return nil, status.Errorf(codes.Internal, "failed to write msfs config: %v", err)
 	}
 
@@ -193,7 +201,11 @@ func (ns *nodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	klog.Infof("starting msfs: %s %s (mountpoint=%s, bucket=%s, authMode=%s)", ns.msfsBinary, configPath, targetPath, bucketName, mode)
+	bucketLabel := bucketName
+	if strings.TrimSpace(volCtx["backendsJson"]) != "" {
+		bucketLabel = "(backendsJson)"
+	}
+	klog.Infof("starting msfs: %s %s (mountpoint=%s, bucket=%s, authMode=%s)", ns.msfsBinary, configPath, targetPath, bucketLabel, mode)
 	if err := cmd.Start(); err != nil {
 		os.RemoveAll(configDir)
 		releaseReservation()
@@ -338,13 +350,21 @@ func resolveCredentialMode(volCtx, secrets map[string]string) (credentialMode, e
 // form (backendTypeS3 or backendTypeAIStore), defaulting to S3. An unsupported
 // value is rejected so a misconfigured PV fails fast.
 func resolveBackendType(volCtx map[string]string) (string, error) {
-	switch strings.ToUpper(strings.TrimSpace(valOrDefault(volCtx, "backendType", backendTypeS3))) {
-	case "S3":
+	return normalizeBackendType(volCtx["backendType"])
+}
+
+// normalizeBackendType maps a raw backendType value to its canonical form
+// (backendTypeS3 or backendTypeAIStore). An empty value defaults to S3; an
+// unsupported value is an error. Shared by the single-backend flat attributes
+// and the per-entry backendsJson path.
+func normalizeBackendType(raw string) (string, error) {
+	switch strings.ToUpper(strings.TrimSpace(raw)) {
+	case "", "S3":
 		return backendTypeS3, nil
 	case "AISTORE":
 		return backendTypeAIStore, nil
 	default:
-		return "", fmt.Errorf("unsupported backendType %q (expected S3 or AIStore)", volCtx["backendType"])
+		return "", fmt.Errorf("unsupported backendType %q (expected S3 or AIStore)", raw)
 	}
 }
 
@@ -375,86 +395,305 @@ func parseWorkloadToken(volCtx map[string]string, audience string) (string, bool
 	return tok.Token, true, nil
 }
 
-func (ns *nodeServer) writeConfig(targetPath string, volCtx, secrets map[string]string, requestReadonly bool, mode credentialMode) (string, string, error) {
-	configDir, err := os.MkdirTemp("", "msfs-csi-*")
-	if err != nil {
-		return "", "", fmt.Errorf("failed to create temp config dir: %w", err)
+// csiBackend is one resolved backend for a CSI volume — produced either from the
+// single-backend flat volumeAttributes or from one entry of backendsJson.
+type csiBackend struct {
+	dirName     string
+	backendType string // backendTypeS3 | backendTypeAIStore
+	bucketName  string
+	prefix      string
+	readonly    bool
+	// S3
+	region   string
+	endpoint string
+	// AIStore
+	aisEndpoint                 string
+	aisProvider                 string
+	aisAuthnToken               string
+	aisAuthnTokenFile           string
+	aisSkipTLSCertificateVerify string
+	aisTimeout                  string
+	aisManifestGenBackend       string
+	// manifestPath is the raw per-backend manifest_path value (also rendered into
+	// `extra`); kept as a field so duplicate-path validation can read it.
+	manifestPath string
+	// extra holds pre-rendered per-backend tuning lines shared by the flat and
+	// backendsJson paths. Each line already carries its 4-space indent and
+	// trailing newline.
+	extra string
+}
+
+// volumeBackendJSON is the on-the-wire shape of one entry in
+// volumeAttributes.backendsJson (a JSON array). It mirrors the flat
+// single-backend volumeAttributes, including the optional per-backend tuning
+// fields (manifest_path, uid, perms, upload tuning, ...) which are rendered via
+// the shared renderBackendTuningExtra helper. All values are strings (k8s
+// volumeAttributes are strings); numeric knobs are passed as strings, e.g.
+// "uid": "1000", "manifestGenWorkers": "200".
+type volumeBackendJSON struct {
+	DirName                     string `json:"dirName"`
+	BackendType                 string `json:"backendType"`
+	BucketName                  string `json:"bucketName"`
+	Prefix                      string `json:"prefix"`
+	Readonly                    *bool  `json:"readonly"`
+	Region                      string `json:"region"`
+	Endpoint                    string `json:"endpoint"`
+	AisEndpoint                 string `json:"aisEndpoint"`
+	AisProvider                 string `json:"aisProvider"`
+	AisAuthnToken               string `json:"aisAuthnToken"`
+	AisAuthnTokenFile           string `json:"aisAuthnTokenFile"`
+	AisSkipTLSCertificateVerify string `json:"aisSkipTLSCertificateVerify"`
+	AisTimeout                  string `json:"aisTimeout"`
+	AisManifestGenBackend       string `json:"aisManifestGenBackend"`
+	// Per-backend tuning (optional; mirror the flat single-backend attributes).
+	ManifestPath                string `json:"manifestPath"`
+	ManifestGenWorkers          string `json:"manifestGenWorkers"`
+	FlatDirConfirmationPages    string `json:"flatDirConfirmationPages"`
+	TraceLevel                  string `json:"traceLevel"`
+	DirectoryPageSize           string `json:"directoryPageSize"`
+	Uid                         string `json:"uid"`
+	Gid                         string `json:"gid"`
+	DirPerm                     string `json:"dirPerm"`
+	FilePerm                    string `json:"filePerm"`
+	FlushOnClose                string `json:"flushOnClose"`
+	MultipartCacheLineThreshold string `json:"multipartCacheLineThreshold"`
+	UploadPartCacheLines        string `json:"uploadPartCacheLines"`
+	UploadPartConcurrency       string `json:"uploadPartConcurrency"`
+}
+
+// defaultDirName returns the mount subdirectory name used when a backend does
+// not specify dirName ("ais" for AIStore, "s3" for S3).
+func defaultDirName(backendType string) string {
+	if backendType == backendTypeAIStore {
+		return "ais"
+	}
+	return strings.ToLower(backendType)
+}
+
+// parseVolumeBackends resolves the list of backends for a volume. When
+// volumeAttributes.backendsJson is present it is parsed as a JSON array (one
+// MSFS backend per entry); otherwise a single backend is built from the flat
+// volumeAttributes, preserving today's exact behavior. dir_names must be unique.
+func parseVolumeBackends(volCtx map[string]string, requestReadonly bool) ([]csiBackend, error) {
+	// Volume-level readonly default (kubelet request flag wins; otherwise honor
+	// volumeAttributes["readonly"]; default read-only). Each backend inherits
+	// this unless it overrides readonly itself.
+	volumeReadonly := true
+	if !requestReadonly && volCtx["readonly"] == "false" {
+		volumeReadonly = false
 	}
 
+	var backends []csiBackend
+	if raw := strings.TrimSpace(volCtx["backendsJson"]); raw != "" {
+		var entries []volumeBackendJSON
+		if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "failed to parse backendsJson: %v", err)
+		}
+		if len(entries) == 0 {
+			return nil, status.Error(codes.InvalidArgument, "backendsJson must contain at least one backend")
+		}
+		for i := range entries {
+			b, err := backendFromJSON(entries[i], volumeReadonly)
+			if err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "backendsJson[%d]: %v", i, err)
+			}
+			// A read-only publish is a hard floor: a per-backend "readonly": false
+			// must not be able to make a read-only mount writable.
+			if requestReadonly {
+				b.readonly = true
+			}
+			backends = append(backends, b)
+		}
+	} else {
+		b, err := singleBackendFromVolCtx(volCtx, volumeReadonly)
+		if err != nil {
+			// Mirror the backendsJson path: surface flat parse/validation
+			// failures (e.g. an unsupported backendType) as InvalidArgument
+			// rather than letting the caller wrap them as a generic Internal.
+			if _, ok := status.FromError(err); ok {
+				return nil, err
+			}
+			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		}
+		backends = append(backends, b)
+	}
+
+	seen := make(map[string]bool, len(backends))
+	seenManifestPath := make(map[string]string, len(backends))
+	for _, b := range backends {
+		if seen[b.dirName] {
+			return nil, status.Errorf(codes.InvalidArgument, "duplicate backend dir_name %q", b.dirName)
+		}
+		seen[b.dirName] = true
+		// Reject duplicate manifest_path: manifest generation does a RemoveAll on
+		// the output path, so two backends sharing one would clobber each other.
+		// Normalize first so aliases like "/x/y" and "/x/y/" are treated as one.
+		if manifestPath := strings.TrimSpace(b.manifestPath); manifestPath != "" {
+			key := filepath.Clean(manifestPath)
+			if prev, ok := seenManifestPath[key]; ok {
+				return nil, status.Errorf(codes.InvalidArgument, "duplicate backend manifest_path %q (backends %q and %q)", manifestPath, prev, b.dirName)
+			}
+			seenManifestPath[key] = b.dirName
+		}
+	}
+	return backends, nil
+}
+
+// renderBackendTuningExtra renders the optional per-backend tuning fields into a
+// 4-space-indented block (each line ready to drop into a backend entry, before
+// `backend_type`). `get` returns the raw value for a camelCase volumeAttributes
+// key ("" when unset). This is the single source of truth for the field set,
+// order, and quoting, shared by the flat single-backend path and the
+// backendsJson path so the two cannot drift.
+func renderBackendTuningExtra(get func(key string) string) string {
+	var extra strings.Builder
+	optionalStr := func(key, yamlField string) {
+		if v := get(key); v != "" {
+			fmt.Fprintf(&extra, "    %s: %s\n", yamlField, v)
+		}
+	}
+	optionalQuoted := func(key, yamlField string) {
+		if v := get(key); v != "" {
+			fmt.Fprintf(&extra, "    %s: %q\n", yamlField, v)
+		}
+	}
+	optionalQuoted("manifestPath", "manifest_path")
+	optionalStr("manifestGenWorkers", "manifest_gen_workers")
+	optionalStr("flatDirConfirmationPages", "flat_dir_confirmation_pages")
+	optionalStr("traceLevel", "trace_level")
+	optionalStr("directoryPageSize", "directory_page_size")
+	optionalStr("uid", "uid")
+	optionalStr("gid", "gid")
+	optionalQuoted("dirPerm", "dir_perm")
+	optionalQuoted("filePerm", "file_perm")
+	optionalStr("flushOnClose", "flush_on_close")
+	optionalStr("multipartCacheLineThreshold", "multipart_cache_line_threshold")
+	optionalStr("uploadPartCacheLines", "upload_part_cache_lines")
+	optionalStr("uploadPartConcurrency", "upload_part_concurrency")
+	return extra.String()
+}
+
+// backendFromJSON converts one backendsJson entry into a csiBackend, applying
+// defaults (dirName, S3 region/endpoint) and validating required fields.
+func backendFromJSON(e volumeBackendJSON, volumeReadonly bool) (csiBackend, error) {
+	backendType, err := normalizeBackendType(e.BackendType)
+	if err != nil {
+		return csiBackend{}, err
+	}
+	if strings.TrimSpace(e.BucketName) == "" {
+		return csiBackend{}, fmt.Errorf("bucketName is required")
+	}
+	dirName := strings.TrimSpace(e.DirName)
+	if dirName == "" {
+		dirName = defaultDirName(backendType)
+	}
+	readonly := volumeReadonly
+	if e.Readonly != nil {
+		readonly = *e.Readonly
+	}
+	b := csiBackend{
+		dirName:                     dirName,
+		backendType:                 backendType,
+		bucketName:                  e.BucketName,
+		prefix:                      e.Prefix,
+		readonly:                    readonly,
+		region:                      e.Region,
+		endpoint:                    e.Endpoint,
+		aisEndpoint:                 e.AisEndpoint,
+		aisProvider:                 e.AisProvider,
+		aisAuthnToken:               e.AisAuthnToken,
+		aisAuthnTokenFile:           e.AisAuthnTokenFile,
+		aisSkipTLSCertificateVerify: e.AisSkipTLSCertificateVerify,
+		aisTimeout:                  e.AisTimeout,
+		aisManifestGenBackend:       e.AisManifestGenBackend,
+	}
+	if backendType == backendTypeS3 {
+		if b.region == "" {
+			b.region = "us-east-1"
+		}
+		if b.endpoint == "" {
+			b.endpoint = fmt.Sprintf("https://s3.%s.amazonaws.com", b.region)
+		}
+	}
+	b.manifestPath = e.ManifestPath
+	attrs := map[string]string{
+		"manifestPath":                e.ManifestPath,
+		"manifestGenWorkers":          e.ManifestGenWorkers,
+		"flatDirConfirmationPages":    e.FlatDirConfirmationPages,
+		"traceLevel":                  e.TraceLevel,
+		"directoryPageSize":           e.DirectoryPageSize,
+		"uid":                         e.Uid,
+		"gid":                         e.Gid,
+		"dirPerm":                     e.DirPerm,
+		"filePerm":                    e.FilePerm,
+		"flushOnClose":                e.FlushOnClose,
+		"multipartCacheLineThreshold": e.MultipartCacheLineThreshold,
+		"uploadPartCacheLines":        e.UploadPartCacheLines,
+		"uploadPartConcurrency":       e.UploadPartConcurrency,
+	}
+	b.extra = renderBackendTuningExtra(func(key string) string { return attrs[key] })
+	return b, nil
+}
+
+// singleBackendFromVolCtx builds the one backend described by the flat
+// volumeAttributes. It renders the per-backend tuning fields into `extra` so the
+// generated config is byte-identical to the pre-multi-backend behavior.
+func singleBackendFromVolCtx(volCtx map[string]string, volumeReadonly bool) (csiBackend, error) {
 	backendType, err := resolveBackendType(volCtx)
 	if err != nil {
-		os.RemoveAll(configDir)
-		return "", "", err
+		return csiBackend{}, err
 	}
 	dirName := valOrDefault(volCtx, "dirName", strings.ToLower(backendType))
 	if backendType == backendTypeAIStore && dirName == "aistore" {
 		dirName = "ais"
 	}
-
 	region := valOrDefault(volCtx, "region", "us-east-1")
 	endpoint := valOrDefault(volCtx, "endpoint", fmt.Sprintf("https://s3.%s.amazonaws.com", region))
 
-	// Honor the CSI request's readonly flag (set by kubelet from the PV's
-	// access mode). Fall back to volumeAttributes["readonly"] only when the
-	// request flag is false. Default is read-only.
-	readonlyStr := "true"
-	if !requestReadonly && volCtx["readonly"] == "false" {
-		readonlyStr = "false"
-	}
+	extra := renderBackendTuningExtra(func(key string) string { return volCtx[key] })
 
-	var backendExtra strings.Builder
-	optionalBackendStr := func(key, yamlField string) {
-		if v := volCtx[key]; v != "" {
-			fmt.Fprintf(&backendExtra, "    %s: %s\n", yamlField, v)
+	return csiBackend{
+		dirName:                     dirName,
+		backendType:                 backendType,
+		bucketName:                  volCtx["bucketName"],
+		prefix:                      volCtx["prefix"],
+		readonly:                    volumeReadonly,
+		region:                      region,
+		endpoint:                    endpoint,
+		aisEndpoint:                 volCtx["aisEndpoint"],
+		aisProvider:                 volCtx["aisProvider"],
+		aisAuthnToken:               volCtx["aisAuthnToken"],
+		aisAuthnTokenFile:           volCtx["aisAuthnTokenFile"],
+		aisSkipTLSCertificateVerify: volCtx["aisSkipTLSCertificateVerify"],
+		aisTimeout:                  volCtx["aisTimeout"],
+		aisManifestGenBackend:       volCtx["aisManifestGenBackend"],
+		manifestPath:                volCtx["manifestPath"],
+		extra:                       extra,
+	}, nil
+}
+
+// volumeHasS3Backend reports whether the volume contains at least one S3 backend
+// (per-workload IRSA only applies to S3). On a parse error it returns true so the
+// publish path surfaces the real error rather than silently skipping IRSA.
+func volumeHasS3Backend(volCtx map[string]string) bool {
+	backends, err := parseVolumeBackends(volCtx, false)
+	if err != nil {
+		return true
+	}
+	for _, b := range backends {
+		if b.backendType == backendTypeS3 {
+			return true
 		}
 	}
-	optionalBackendQuoted := func(key, yamlField string) {
-		if v := volCtx[key]; v != "" {
-			fmt.Fprintf(&backendExtra, "    %s: %q\n", yamlField, v)
-		}
-	}
+	return false
+}
 
-	optionalBackendQuoted("manifestPath", "manifest_path")
-	optionalBackendStr("manifestGenWorkers", "manifest_gen_workers")
-	optionalBackendStr("flatDirConfirmationPages", "flat_dir_confirmation_pages")
-	optionalBackendStr("traceLevel", "trace_level")
-	optionalBackendStr("directoryPageSize", "directory_page_size")
-	optionalBackendStr("uid", "uid")
-	optionalBackendStr("gid", "gid")
-	optionalBackendQuoted("dirPerm", "dir_perm")
-	optionalBackendQuoted("filePerm", "file_perm")
-	optionalBackendStr("flushOnClose", "flush_on_close")
-	optionalBackendStr("multipartCacheLineThreshold", "multipart_cache_line_threshold")
-	optionalBackendStr("uploadPartCacheLines", "upload_part_cache_lines")
-	optionalBackendStr("uploadPartConcurrency", "upload_part_concurrency")
-
-	var globalExtra strings.Builder
-	optionalGlobalStr := func(key, yamlField string) {
-		if v := volCtx[key]; v != "" {
-			fmt.Fprintf(&globalExtra, "%s: %s\n", yamlField, v)
-		}
-	}
-
-	optionalGlobalStr("cacheLineSize", "cache_line_size")
-	optionalGlobalStr("cacheLines", "cache_lines")
-	optionalGlobalStr("cacheLinesToPrefetch", "cache_lines_to_prefetch")
-	optionalGlobalStr("dirtyCacheLinesFlushTrigger", "dirty_cache_lines_flush_trigger")
-	optionalGlobalStr("dirtyCacheLinesMax", "dirty_cache_lines_max")
-	if v := volCtx["allowOther"]; v != "" {
-		fmt.Fprintf(&globalExtra, "allow_other: %s\n", v)
-	}
-
-	// The S3 block's credential lines depend on the mode:
-	//   - static: emit access_key_id / secret_access_key placeholders bound to
-	//     the AWS_* env vars buildEnv injects from the Secret.
-	//   - none: emit anonymous: true so the S3 backend issues unsigned requests
-	//     (public / no-auth endpoints) — no Secret, no IRSA.
-	//   - IRSA: emit nothing so the AWS SDK falls through to its credential chain
-	//     and picks up the projected ServiceAccount token (AWS_ROLE_ARN +
-	//     AWS_WEB_IDENTITY_TOKEN_FILE). Emitting empty placeholders here would
-	//     make the SDK think static creds were intended and fail.
+// renderMSFSBackend renders one MSFS `- dir_name:` backend block. The S3
+// credential lines follow the volume credential mode (static placeholders /
+// anonymous / IRSA-omit); AIStore fields come from the backend's ais* values.
+func renderMSFSBackend(b csiBackend, mode credentialMode) string {
 	credentialBlock := ""
-	if backendType == backendTypeS3 {
+	if b.backendType == backendTypeS3 {
 		switch mode {
 		case credentialModeStatic:
 			credentialBlock = `      access_key_id: "${AWS_ACCESS_KEY_ID}"
@@ -466,48 +705,90 @@ func (ns *nodeServer) writeConfig(targetPath string, volCtx, secrets map[string]
 	}
 
 	var backendSpecific strings.Builder
-	switch backendType {
+	switch b.backendType {
 	case backendTypeS3:
 		fmt.Fprintf(&backendSpecific, `    S3:
       region: %q
       endpoint: %q
 %s      virtual_hosted_style_request: false
-`, region, endpoint, credentialBlock)
+`, b.region, b.endpoint, credentialBlock)
 	case backendTypeAIStore:
-		aisOptionalQuoted := func(key, yamlField string) {
-			if v := volCtx[key]; v != "" {
+		aisQuoted := func(yamlField, v string) {
+			if v != "" {
 				fmt.Fprintf(&backendSpecific, "      %s: %q\n", yamlField, v)
 			}
 		}
-		aisOptionalStr := func(key, yamlField string) {
-			if v := volCtx[key]; v != "" {
+		aisStr := func(yamlField, v string) {
+			if v != "" {
 				fmt.Fprintf(&backendSpecific, "      %s: %s\n", yamlField, v)
 			}
 		}
 		backendSpecific.WriteString("    AIStore:\n")
-		aisOptionalQuoted("aisEndpoint", "endpoint")
-		aisOptionalStr("aisSkipTLSCertificateVerify", "skip_tls_certificate_verify")
+		aisQuoted("endpoint", b.aisEndpoint)
+		aisStr("skip_tls_certificate_verify", b.aisSkipTLSCertificateVerify)
 		// none (anonymous) mode uses no credentials, so any supplied AIStore
 		// token is ignored — the backend connects with an empty token.
 		if mode != credentialModeNone {
-			aisOptionalQuoted("aisAuthnToken", "authn_token")
-			aisOptionalQuoted("aisAuthnTokenFile", "authn_token_file")
+			aisQuoted("authn_token", b.aisAuthnToken)
+			aisQuoted("authn_token_file", b.aisAuthnTokenFile)
 		}
-		aisOptionalQuoted("aisProvider", "provider")
-		aisOptionalStr("aisTimeout", "timeout")
-		aisOptionalQuoted("aisManifestGenBackend", "manifest_gen_backend")
+		aisQuoted("provider", b.aisProvider)
+		aisStr("timeout", b.aisTimeout)
+		aisQuoted("manifest_gen_backend", b.aisManifestGenBackend)
+	}
+
+	readonlyStr := "true"
+	if !b.readonly {
+		readonlyStr = "false"
+	}
+
+	return fmt.Sprintf(`  - dir_name: %s
+    bucket_container_name: %s
+    prefix: %q
+    readonly: %s
+%s    backend_type: %s
+%s`, b.dirName, b.bucketName, b.prefix, readonlyStr, b.extra, b.backendType, backendSpecific.String())
+}
+
+func (ns *nodeServer) writeConfig(targetPath string, volCtx, secrets map[string]string, requestReadonly bool, mode credentialMode) (string, string, error) {
+	configDir, err := os.MkdirTemp("", "msfs-csi-*")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create temp config dir: %w", err)
+	}
+
+	backends, err := parseVolumeBackends(volCtx, requestReadonly)
+	if err != nil {
+		os.RemoveAll(configDir)
+		return "", "", err
+	}
+
+	// Global (volume-level) tuning fields apply to the whole mount, not to an
+	// individual backend.
+	var globalExtra strings.Builder
+	optionalGlobalStr := func(key, yamlField string) {
+		if v := volCtx[key]; v != "" {
+			fmt.Fprintf(&globalExtra, "%s: %s\n", yamlField, v)
+		}
+	}
+	optionalGlobalStr("cacheLineSize", "cache_line_size")
+	optionalGlobalStr("cacheLines", "cache_lines")
+	optionalGlobalStr("cacheLinesToPrefetch", "cache_lines_to_prefetch")
+	optionalGlobalStr("dirtyCacheLinesFlushTrigger", "dirty_cache_lines_flush_trigger")
+	optionalGlobalStr("dirtyCacheLinesMax", "dirty_cache_lines_max")
+	if v := volCtx["allowOther"]; v != "" {
+		fmt.Fprintf(&globalExtra, "allow_other: %s\n", v)
+	}
+
+	var backendsBlock strings.Builder
+	for _, b := range backends {
+		backendsBlock.WriteString(renderMSFSBackend(b, mode))
 	}
 
 	config := fmt.Sprintf(`msfs_version: 1
 endpoint: "http://0.0.0.0:0"
 mountpoint: %s
 %sbackends:
-  - dir_name: %s
-    bucket_container_name: %s
-    prefix: %q
-    readonly: %s
-%s    backend_type: %s
-%s`, targetPath, globalExtra.String(), dirName, volCtx["bucketName"], volCtx["prefix"], readonlyStr, backendExtra.String(), backendType, backendSpecific.String())
+%s`, targetPath, globalExtra.String(), backendsBlock.String())
 
 	configPath := filepath.Join(configDir, "msfs.yaml")
 	if err := os.WriteFile(configPath, []byte(config), 0600); err != nil {
@@ -532,16 +813,12 @@ func (ns *nodeServer) resolveWorkloadIdentity(configDir string, volCtx map[strin
 	if mode == credentialModeStatic || mode == credentialModeNone {
 		return "", "", nil
 	}
-	// Per-workload IRSA assumes an AWS IAM role, so it only applies to S3
-	// mounts. AIStore (and any future non-S3 backend) needs no AWS identity;
-	// without this guard a tokenRequests-enabled CSIDriver would hand every
-	// mount a workload token and force AIStore PVs to set a meaningless
-	// volumeAttributes.roleArn.
-	backendType, err := resolveBackendType(volCtx)
-	if err != nil {
-		return "", "", status.Error(codes.InvalidArgument, err.Error())
-	}
-	if backendType != backendTypeS3 {
+	// Per-workload IRSA assumes an AWS IAM role, so it only applies when the
+	// volume has at least one S3 backend. A pure-AIStore volume (or any future
+	// non-S3 backend) needs no AWS identity; without this guard a
+	// tokenRequests-enabled CSIDriver would hand every mount a workload token
+	// and force such PVs to set a meaningless volumeAttributes.roleArn.
+	if !volumeHasS3Backend(volCtx) {
 		return "", "", nil
 	}
 	token, ok, err := parseWorkloadToken(volCtx, stsAudience)

--- a/multi-storage-file-system/csi/pkg/driver/node_test.go
+++ b/multi-storage-file-system/csi/pkg/driver/node_test.go
@@ -1,10 +1,15 @@
 package driver
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // --- credential-mode resolution ----------------------------------------------
@@ -245,12 +250,287 @@ func TestWriteConfig_RejectsUnsupportedBackendType(t *testing.T) {
 		false,
 		credentialModeIRSA,
 	)
+	defer os.RemoveAll(dir)
 	if err == nil {
-		defer os.RemoveAll(dir)
 		t.Fatalf("writeConfig unexpectedly accepted unsupported backendType")
 	}
 	if !strings.Contains(err.Error(), "unsupported backendType") {
 		t.Fatalf("error should mention unsupported backendType, got: %v", err)
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("flat unsupported backendType should be InvalidArgument, got %s: %v", status.Code(err), err)
+	}
+}
+
+// A read-only publish is a hard floor: a per-backend "readonly": false must not
+// be able to make a read-only mount writable.
+func TestWriteConfig_BackendsJsonReadonlyPublishForcesReadonly(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	backendsJSON := `[{"dirName":"a","backendType":"S3","bucketName":"bucket-a","readonly":false}]`
+	dir, configPath, err := ns.writeConfig("/tmp/csi-target-test",
+		map[string]string{"backendsJson": backendsJSON}, map[string]string{}, true, credentialModeIRSA)
+	if err != nil {
+		t.Fatalf("writeConfig returned error: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	body := readFileOrFatal(t, configPath)
+	if !strings.Contains(body, "readonly: true") || strings.Contains(body, "readonly: false") {
+		t.Fatalf("read-only publish must force readonly: true (never false); got:\n%s", body)
+	}
+}
+
+// Aliased manifest paths ("/x/y" vs "/x/y/") must collide after normalization.
+func TestWriteConfig_BackendsJsonRejectsDuplicateManifestPathNormalized(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	backendsJSON := `[
+	  {"dirName":"a","backendType":"S3","bucketName":"bucket-a","manifestPath":"/var/lib/msfs/shared"},
+	  {"dirName":"b","backendType":"S3","bucketName":"bucket-b","manifestPath":"/var/lib/msfs/shared/"}
+	]`
+	dir, _, err := ns.writeConfig("/tmp/csi-target-test",
+		map[string]string{"backendsJson": backendsJSON}, map[string]string{}, false, credentialModeIRSA)
+	defer os.RemoveAll(dir)
+	if err == nil {
+		t.Fatalf("expected duplicate (normalized) manifest_path to be rejected")
+	}
+	if !strings.Contains(err.Error(), "manifest_path") {
+		t.Fatalf("error should mention manifest_path, got: %v", err)
+	}
+}
+
+// --- multi-bucket / multi-backend (NGCDP-9024) -------------------------------
+
+func TestWriteConfig_BackendsJsonMultipleS3(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	backendsJSON := `[
+	  {"dirName":"a","backendType":"S3","bucketName":"bucket-a","prefix":"pa/","region":"us-east-1","endpoint":"https://s3.us-east-1.amazonaws.com"},
+	  {"dirName":"b","backendType":"S3","bucketName":"bucket-b","prefix":"pb/","region":"us-west-2","endpoint":"https://s3.us-west-2.amazonaws.com"}
+	]`
+	dir, configPath := writeConfigOrFatal(t, ns,
+		map[string]string{"backendsJson": backendsJSON},
+		map[string]string{},
+		credentialModeIRSA,
+	)
+	defer os.RemoveAll(dir)
+
+	body := readFileOrFatal(t, configPath)
+	for _, want := range []string{
+		"dir_name: a", "bucket_container_name: bucket-a", `prefix: "pa/"`, `region: "us-east-1"`,
+		"dir_name: b", "bucket_container_name: bucket-b", `prefix: "pb/"`, `region: "us-west-2"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("multi-S3 config missing %q; got:\n%s", want, body)
+		}
+	}
+	if n := strings.Count(body, "backend_type: S3"); n != 2 {
+		t.Fatalf("expected 2 S3 backends, got %d; config:\n%s", n, body)
+	}
+}
+
+func TestWriteConfig_BackendsJsonMixedS3AndAIStore(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	backendsJSON := `[
+	  {"dirName":"s3","backendType":"S3","bucketName":"bucket-a"},
+	  {"dirName":"ais","backendType":"AIStore","bucketName":"ds","aisEndpoint":"http://ais:51080","aisProvider":"ais"}
+	]`
+	dir, configPath := writeConfigOrFatal(t, ns,
+		map[string]string{"backendsJson": backendsJSON},
+		map[string]string{"access_key_id": "AKIA...", "secret_access_key": "secret"},
+		credentialModeStatic,
+	)
+	defer os.RemoveAll(dir)
+
+	body := readFileOrFatal(t, configPath)
+	for _, want := range []string{
+		"dir_name: s3", "backend_type: S3", `access_key_id: "${AWS_ACCESS_KEY_ID}"`,
+		"dir_name: ais", "backend_type: AIStore", `endpoint: "http://ais:51080"`, `provider: "ais"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("mixed S3+AIStore config missing %q; got:\n%s", want, body)
+		}
+	}
+}
+
+func TestWriteConfig_BackendsJsonRejectsDuplicateDirName(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	backendsJSON := `[{"dirName":"dup","bucketName":"a"},{"dirName":"dup","bucketName":"b"}]`
+	dir, _, err := ns.writeConfig("/tmp/csi-target-test",
+		map[string]string{"backendsJson": backendsJSON}, map[string]string{}, false, credentialModeIRSA)
+	defer os.RemoveAll(dir)
+	if err == nil {
+		t.Fatalf("expected duplicate dir_name to be rejected")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("error should mention duplicate dir_name, got: %v", err)
+	}
+}
+
+func TestWriteConfig_BackendsJsonRejectsUnsupportedBackendType(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	backendsJSON := `[{"dirName":"x","backendType":"GCS","bucketName":"a"}]`
+	dir, _, err := ns.writeConfig("/tmp/csi-target-test",
+		map[string]string{"backendsJson": backendsJSON}, map[string]string{}, false, credentialModeIRSA)
+	defer os.RemoveAll(dir)
+	if err == nil {
+		t.Fatalf("expected unsupported backendType in backendsJson to be rejected")
+	}
+	if !strings.Contains(err.Error(), "unsupported backendType") {
+		t.Fatalf("error should mention unsupported backendType, got: %v", err)
+	}
+}
+
+func TestWriteConfig_BackendsJsonRejectsMissingBucket(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	backendsJSON := `[{"dirName":"x","backendType":"S3"}]`
+	dir, _, err := ns.writeConfig("/tmp/csi-target-test",
+		map[string]string{"backendsJson": backendsJSON}, map[string]string{}, false, credentialModeIRSA)
+	defer os.RemoveAll(dir)
+	if err == nil {
+		t.Fatalf("expected missing bucketName to be rejected")
+	}
+	if !strings.Contains(err.Error(), "bucketName") {
+		t.Fatalf("error should mention bucketName, got: %v", err)
+	}
+}
+
+func TestWriteConfig_BackendsJsonRejectsMalformed(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	dir, _, err := ns.writeConfig("/tmp/csi-target-test",
+		map[string]string{"backendsJson": "not-json"}, map[string]string{}, false, credentialModeIRSA)
+	defer os.RemoveAll(dir)
+	if err == nil {
+		t.Fatalf("expected malformed backendsJson to be rejected")
+	}
+}
+
+// --- per-backend tuning fields in backendsJson (NGCDP-9024 follow-up) ---------
+
+func TestWriteConfig_BackendsJsonTuningFields(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	backendsJSON := `[
+	  {"dirName":"a","backendType":"S3","bucketName":"bucket-a","manifestPath":"/var/lib/msfs/m-a","manifestGenWorkers":"200","uid":"1000","gid":"1001","dirPerm":"775","traceLevel":"2"},
+	  {"dirName":"b","backendType":"S3","bucketName":"bucket-b","manifestPath":"/var/lib/msfs/m-b","flushOnClose":"false","filePerm":"640"}
+	]`
+	dir, configPath := writeConfigOrFatal(t, ns,
+		map[string]string{"backendsJson": backendsJSON},
+		map[string]string{},
+		credentialModeIRSA,
+	)
+	defer os.RemoveAll(dir)
+
+	body := readFileOrFatal(t, configPath)
+	for _, want := range []string{
+		`manifest_path: "/var/lib/msfs/m-a"`,
+		"manifest_gen_workers: 200",
+		"uid: 1000",
+		"gid: 1001",
+		`dir_perm: "775"`,
+		"trace_level: 2",
+		`manifest_path: "/var/lib/msfs/m-b"`,
+		"flush_on_close: false",
+		`file_perm: "640"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("tuning-fields config missing %q; got:\n%s", want, body)
+		}
+	}
+}
+
+func TestWriteConfig_BackendsJsonRejectsDuplicateManifestPath(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	backendsJSON := `[
+	  {"dirName":"a","backendType":"S3","bucketName":"bucket-a","manifestPath":"/var/lib/msfs/shared"},
+	  {"dirName":"b","backendType":"S3","bucketName":"bucket-b","manifestPath":"/var/lib/msfs/shared"}
+	]`
+	dir, _, err := ns.writeConfig("/tmp/csi-target-test",
+		map[string]string{"backendsJson": backendsJSON}, map[string]string{}, false, credentialModeIRSA)
+	defer os.RemoveAll(dir)
+	if err == nil {
+		t.Fatalf("expected duplicate manifest_path to be rejected")
+	}
+	if !strings.Contains(err.Error(), "manifest_path") {
+		t.Fatalf("error should mention manifest_path, got: %v", err)
+	}
+}
+
+// NodePublishVolume must surface a bad backendsJson (here: duplicate
+// manifest_path) as gRPC InvalidArgument, not a generic Internal — the
+// duplicate check runs in writeConfig before any msfs exec, and its
+// InvalidArgument code must not be masked by the caller's error wrapping.
+func TestNodePublishVolume_DuplicateManifestPathIsInvalidArgument(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	backendsJSON := `[{"dirName":"a","backendType":"S3","bucketName":"bucket-a","manifestPath":"/var/lib/msfs/shared"},{"dirName":"b","backendType":"S3","bucketName":"bucket-b","manifestPath":"/var/lib/msfs/shared"}]`
+	_, err := ns.NodePublishVolume(context.Background(), &csi.NodePublishVolumeRequest{
+		VolumeId:   "vol-dup",
+		TargetPath: t.TempDir(),
+		VolumeContext: map[string]string{
+			"backendsJson": backendsJSON,
+			// irsa needs no secret, so resolveCredentialMode succeeds and the
+			// request reaches writeConfig (which rejects the duplicate).
+			"authType": "irsa",
+		},
+		VolumeCapability: &csi.VolumeCapability{
+			AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER},
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected duplicate manifest_path to be rejected")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %s: %v", status.Code(err), err)
+	}
+	if !strings.Contains(err.Error(), "manifest_path") {
+		t.Fatalf("error should mention manifest_path, got: %v", err)
+	}
+}
+
+func TestWriteConfig_BackendsJsonNoTuningFieldsBackCompat(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	backendsJSON := `[{"dirName":"a","backendType":"S3","bucketName":"bucket-a"}]`
+	dir, configPath := writeConfigOrFatal(t, ns,
+		map[string]string{"backendsJson": backendsJSON},
+		map[string]string{},
+		credentialModeIRSA,
+	)
+	defer os.RemoveAll(dir)
+
+	body := readFileOrFatal(t, configPath)
+	for _, unwanted := range []string{"manifest_path:", "uid:", "gid:", "trace_level:", "flush_on_close:"} {
+		if strings.Contains(body, unwanted) {
+			t.Fatalf("entry without tuning fields should not emit %q; got:\n%s", unwanted, body)
+		}
+	}
+}
+
+// TestWriteConfig_SingleBackendTuningFieldsRendered guards the shared-renderer
+// refactor: the flat single-backend path must still emit the per-backend tuning
+// fields with the same quoting.
+func TestWriteConfig_SingleBackendTuningFieldsRendered(t *testing.T) {
+	ns := newNodeServer("node-test", "/usr/local/bin/msfs")
+	dir, configPath := writeConfigOrFatal(t, ns,
+		map[string]string{
+			"bucketName":         "bucket-a",
+			"backendType":        "S3",
+			"manifestPath":       "/var/lib/msfs/single",
+			"manifestGenWorkers": "200",
+			"uid":                "1000",
+			"dirPerm":            "775",
+		},
+		map[string]string{},
+		credentialModeIRSA,
+	)
+	defer os.RemoveAll(dir)
+
+	body := readFileOrFatal(t, configPath)
+	for _, want := range []string{
+		`manifest_path: "/var/lib/msfs/single"`,
+		"manifest_gen_workers: 200",
+		"uid: 1000",
+		`dir_perm: "775"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("single-backend tuning config missing %q; got:\n%s", want, body)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Adds multi-bucket / multi-backend support to the MSFS CSI driver (NGCDP-9024).

> **Stacked on #89** (no-creds/anonymous). Base is `feat-msfs-csi-anonymous-auth`; GitHub retargets this to `main` once #89 merges. The only new commit here is `27eefd4`.

- New `volumeAttributes.backendsJson` — a JSON array producing multiple MSFS backends from one volume (multi-bucket, or mixed S3 + native AIStore), each mounted under its own `dirName`.
- `writeConfig` refactored into `parseVolumeBackends()` + `renderMSFSBackend()`. The single-backend (flat-attribute) path renders **byte-identically** — fully backward compatible.
- `bucketName` optional when `backendsJson` is set; per-workload IRSA gate keys off whether the volume has any S3 backend. Validates unique `dirName`, supported `backendType`, required `bucketName`. Credentials stay volume-level.

## Test plan
- [x] `go build` / `go vet` / `gofmt` clean
- [x] All pre-existing CSI tests pass unchanged (single-backend output byte-identical)
- [x] New tests: 2× S3, mixed S3+AIStore, duplicate `dirName`, unsupported `backendType`, missing bucket, malformed JSON

Tracked by NGCDP-9024.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSI volumes can now mount multiple MSFS backends in a single volume using `backendsJson`, with unique per-backend `dirName` subdirectory mounting and support for mixing S3 and AIStore.
* **Bug Fixes**
  * Duplicate `manifestPath` values (including after path normalization) are now rejected; manifests are regenerated per (re)mount to avoid conflicts.
  * `NodePublishVolume` now returns consistent validation errors and enforces `readonly` per backend.
* **Documentation**
  * Updated CSI docs for `backendsJson` usage, `volumeAttributes` requirements, and `manifestPath` lifecycle.  
* **Tests**
  * Added coverage for multi-backend parsing, rendering, and validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->