### PR TITLE
fix: remove deprecated Python API compatibility

### DIFF
--- a/multi-storage-client-docs/src/references/configuration.rst
+++ b/multi-storage-client-docs/src/references/configuration.rst
@@ -286,13 +286,13 @@ The POSIX filesystem provider.
 
 Options: See parameters in :py:class:`multistorageclient.providers.posix_file.PosixFileStorageProvider`.
 
-MSC includes a default POSIX filesystem profile that is used when no configuration file is found. This profile provides basic local filesystem access:
+MSC includes a default POSIX filesystem profile named ``__filesystem__``. When that profile is requested and not explicitly defined in configuration, MSC synthesizes it so basic local filesystem access remains available:
 
 .. code-block:: yaml
    :caption: Example configuration.
 
    profiles:
-     default:
+     __filesystem__:
        storage_provider:
          type: file
          options:

--- a/multi-storage-client/src/multistorageclient/client/client.py
+++ b/multi-storage-client/src/multistorageclient/client/client.py
@@ -313,7 +313,6 @@ class StorageClient(AbstractStorageClient):
         max_workers: int = 32,
         look_ahead: int = 2,
         include_url_prefix: bool = False,
-        follow_symlinks: Optional[bool] = None,
         patterns: Optional[PatternList] = None,
         symlink_handling: SymlinkHandling = SymlinkHandling.FOLLOW,
     ) -> Iterator[ObjectMetadata]:
@@ -327,7 +326,6 @@ class StorageClient(AbstractStorageClient):
         :param max_workers: Maximum concurrent workers for provider-level recursive listing.
         :param look_ahead: Prefixes to buffer per worker for provider-level recursive listing.
         :param include_url_prefix: Whether to include the URL prefix ``msc://profile`` in the result.
-        :param follow_symlinks: **Deprecated.** Use ``symlink_handling`` instead.
         :param patterns: PatternList for include/exclude filtering. If None, all files are included.
         :param symlink_handling: How to handle symbolic links during listing. Only applicable for POSIX file storage providers.
         :return: An iterator over ObjectMetadata for matching files.
@@ -339,7 +337,6 @@ class StorageClient(AbstractStorageClient):
             max_workers=max_workers,
             look_ahead=look_ahead,
             include_url_prefix=include_url_prefix,
-            follow_symlinks=follow_symlinks,
             patterns=patterns,
             symlink_handling=symlink_handling,
         )
@@ -493,7 +490,6 @@ class StorageClient(AbstractStorageClient):
         execution_mode: ExecutionMode = ExecutionMode.LOCAL,
         patterns: Optional[PatternList] = None,
         preserve_source_attributes: bool = False,
-        follow_symlinks: Optional[bool] = None,
         source_files: Optional[list[str]] = None,
         ignore_hidden: bool = True,
         commit_metadata: bool = True,
@@ -521,9 +517,6 @@ class StorageClient(AbstractStorageClient):
                 request for each object to retrieve attributes, which can significantly impact performance on large-scale
                 sync operations. For production use at scale, configure a ``metadata_provider`` in your storage profile.
 
-        :param follow_symlinks: **Deprecated.** Use ``symlink_handling`` instead. If the source StorageClient is PosixFile,
-            whether to follow symbolic links. ``True`` maps to :py:attr:`SymlinkHandling.FOLLOW`; ``False`` maps to
-            :py:attr:`SymlinkHandling.SKIP`. Cannot be combined with a non-default ``symlink_handling``.
         :param source_files: Optional list of file paths (relative to source_path) to sync. When provided, only these
             specific files will be synced, skipping enumeration of the source path. Cannot be used together with patterns.
         :param ignore_hidden: Whether to ignore hidden files and directories. Default is ``True``.
@@ -538,8 +531,7 @@ class StorageClient(AbstractStorageClient):
             :py:attr:`SymlinkHandling.SKIP` excludes symlinks from the sync.
             :py:attr:`SymlinkHandling.PRESERVE` recreates symlinks on the target via :py:meth:`make_symlink`
             instead of copying bytes (required for round-trip preservation of symlinks).
-        :raises ValueError: If both source_files and patterns are provided, or if ``follow_symlinks`` is combined
-            with a non-default ``symlink_handling``.
+        :raises ValueError: If both source_files and patterns are provided.
         :raises NotImplementedError: If sync operations are not supported (e.g., CompositeStorageClient as target).
         """
         return self._delegate.sync_from(
@@ -552,7 +544,6 @@ class StorageClient(AbstractStorageClient):
             execution_mode,
             patterns,
             preserve_source_attributes,
-            follow_symlinks,
             source_files,
             ignore_hidden,
             commit_metadata,
@@ -604,7 +595,6 @@ class StorageClient(AbstractStorageClient):
 
     def list(
         self,
-        prefix: str = "",
         path: str = "",
         start_after: Optional[str] = None,
         end_at: Optional[str] = None,
@@ -612,34 +602,25 @@ class StorageClient(AbstractStorageClient):
         include_url_prefix: bool = False,
         attribute_filter_expression: Optional[str] = None,
         show_attributes: bool = False,
-        follow_symlinks: Optional[bool] = None,
         patterns: Optional[PatternList] = None,
         symlink_handling: SymlinkHandling = SymlinkHandling.FOLLOW,
     ) -> Iterator[ObjectMetadata]:
         """
         List objects in the storage provider under the specified path.
 
-        **IMPORTANT**: Use the ``path`` parameter for new code. The ``prefix`` parameter is
-        deprecated and will be removed in a future version.
-
-        :param prefix: [DEPRECATED] Use ``path`` instead. The prefix to list objects under.
         :param path: The directory or file path to list objects under. This should be a
                     complete filesystem path (e.g., "my-bucket/documents/" or "data/2024/").
-                    Cannot be used together with ``prefix``.
         :param start_after: The key to start after (i.e. exclusive). An object with this key doesn't have to exist.
         :param end_at: The key to end at (i.e. inclusive). An object with this key doesn't have to exist.
         :param include_directories: Whether to include directories in the result. When ``True``, directories are returned alongside objects.
         :param include_url_prefix: Whether to include the URL prefix ``msc://profile`` in the result.
         :param attribute_filter_expression: The attribute filter expression to apply to the result.
         :param show_attributes: Whether to return attributes in the result. WARNING: Depending on implementation, there may be a performance impact if this is set to ``True``.
-        :param follow_symlinks: **Deprecated.** Use ``symlink_handling`` instead.
         :param patterns: PatternList for include/exclude filtering. If None, all files are included.
         :param symlink_handling: How to handle symbolic links during listing. Only applicable for POSIX file storage providers.
         :return: An iterator over ObjectMetadata for matching objects.
-        :raises ValueError: If both ``path`` and ``prefix`` parameters are provided (both non-empty).
         """
         return self._delegate.list(
-            prefix,
             path,
             start_after,
             end_at,
@@ -647,7 +628,6 @@ class StorageClient(AbstractStorageClient):
             include_url_prefix,
             attribute_filter_expression,
             show_attributes,
-            follow_symlinks=follow_symlinks,
             patterns=patterns,
             symlink_handling=symlink_handling,
         )

--- a/multi-storage-client/src/multistorageclient/client/composite.py
+++ b/multi-storage-client/src/multistorageclient/client/composite.py
@@ -304,7 +304,6 @@ class CompositeStorageClient(AbstractStorageClient):
         max_workers: int = 32,
         look_ahead: int = 2,
         include_url_prefix: bool = False,
-        follow_symlinks: Optional[bool] = None,
         patterns: Optional[PatternList] = None,
         symlink_handling: SymlinkHandling = SymlinkHandling.FOLLOW,
     ) -> Iterator[ObjectMetadata]:
@@ -314,7 +313,6 @@ class CompositeStorageClient(AbstractStorageClient):
             end_at=end_at,
             include_directories=False,
             include_url_prefix=include_url_prefix,
-            follow_symlinks=follow_symlinks,
             patterns=patterns,
             symlink_handling=symlink_handling,
         )
@@ -411,7 +409,6 @@ class CompositeStorageClient(AbstractStorageClient):
         execution_mode: ExecutionMode = ExecutionMode.LOCAL,
         patterns: Optional[PatternList] = None,
         preserve_source_attributes: bool = False,
-        follow_symlinks: Optional[bool] = None,
         source_files: Optional[list[str]] = None,
         ignore_hidden: bool = True,
         commit_metadata: bool = True,
@@ -441,7 +438,6 @@ class CompositeStorageClient(AbstractStorageClient):
 
     def list(
         self,
-        prefix: str = "",
         path: str = "",
         start_after: Optional[str] = None,
         end_at: Optional[str] = None,
@@ -449,27 +445,15 @@ class CompositeStorageClient(AbstractStorageClient):
         include_url_prefix: bool = False,
         attribute_filter_expression: Optional[str] = None,
         show_attributes: bool = False,
-        follow_symlinks: Optional[bool] = None,
         patterns: Optional[PatternList] = None,
         symlink_handling: SymlinkHandling = SymlinkHandling.FOLLOW,
     ) -> Iterator[ObjectMetadata]:
-        # Parameter validation - either path or prefix, not both
-        if path and prefix:
-            raise ValueError(
-                f"Cannot specify both 'path' ({path!r}) and 'prefix' ({prefix!r}). "
-                f"Please use only the 'path' parameter for new code. "
-                f"Migration guide: Replace list(prefix={prefix!r}) with list(path={prefix!r})"
-            )
-
-        # Use path if provided, otherwise fall back to prefix
-        effective_path = path if path else prefix
-
         # Apply patterns to the objects
         pattern_matcher = PatternMatcher(patterns) if patterns else None
 
         # Delegate to metadata provider (always present for CompositeStorageClient)
         for obj in self._metadata_provider.list_objects(
-            effective_path,
+            path,
             start_after=start_after,
             end_at=end_at,
             include_directories=include_directories,

--- a/multi-storage-client/src/multistorageclient/client/single.py
+++ b/multi-storage-client/src/multistorageclient/client/single.py
@@ -47,7 +47,7 @@ from ..types import (
     SymlinkHandling,
     SyncResult,
 )
-from ..utils import NullStorageClient, PatternMatcher, join_paths, resolve_symlink_handling
+from ..utils import NullStorageClient, PatternMatcher, join_paths
 from .types import AbstractStorageClient
 
 logger = logging.getLogger(__name__)
@@ -865,7 +865,6 @@ class SingleStorageClient(AbstractStorageClient):
         max_workers: int = 32,
         look_ahead: int = 2,
         include_url_prefix: bool = False,
-        follow_symlinks: Optional[bool] = None,
         patterns: Optional[PatternList] = None,
         symlink_handling: SymlinkHandling = SymlinkHandling.FOLLOW,
     ) -> Iterator[ObjectMetadata]:
@@ -879,13 +878,10 @@ class SingleStorageClient(AbstractStorageClient):
         :param max_workers: Maximum concurrent workers for provider-level recursive listing.
         :param look_ahead: Prefixes to buffer per worker for provider-level recursive listing.
         :param include_url_prefix: Whether to include the URL prefix ``msc://profile`` in the result.
-        :param follow_symlinks: **Deprecated.** Use ``symlink_handling`` instead.
         :param patterns: PatternList for include/exclude filtering. If None, all files are included.
         :param symlink_handling: How to handle symbolic links during listing. Only applicable for POSIX file storage providers.
         :return: An iterator over ObjectMetadata for matching files.
         """
-        symlink_handling = resolve_symlink_handling(follow_symlinks, symlink_handling)
-
         pattern_matcher = PatternMatcher(patterns) if patterns else None
 
         single_file, effective_path = self._resolve_single_file(
@@ -1053,7 +1049,6 @@ class SingleStorageClient(AbstractStorageClient):
         execution_mode: ExecutionMode = ExecutionMode.LOCAL,
         patterns: Optional[PatternList] = None,
         preserve_source_attributes: bool = False,
-        follow_symlinks: Optional[bool] = None,
         source_files: Optional[list[str]] = None,
         ignore_hidden: bool = True,
         commit_metadata: bool = True,
@@ -1081,9 +1076,6 @@ class SingleStorageClient(AbstractStorageClient):
                 request for each object to retrieve attributes, which can significantly impact performance on large-scale
                 sync operations. For production use at scale, configure a ``metadata_provider`` in your storage profile.
 
-        :param follow_symlinks: **Deprecated.** Use ``symlink_handling`` instead. If the source StorageClient is PosixFile,
-            whether to follow symbolic links. ``True`` maps to :py:attr:`SymlinkHandling.FOLLOW`; ``False`` maps to
-            :py:attr:`SymlinkHandling.SKIP`. Cannot be combined with a non-default ``symlink_handling``.
         :param source_files: Optional list of file paths (relative to source_path) to sync. When provided, only these
             specific files will be synced, skipping enumeration of the source path. Cannot be used together with patterns.
         :param ignore_hidden: Whether to ignore hidden files and directories. Default is ``True``.
@@ -1098,14 +1090,11 @@ class SingleStorageClient(AbstractStorageClient):
             :py:attr:`SymlinkHandling.SKIP` excludes symlinks from the sync.
             :py:attr:`SymlinkHandling.PRESERVE` recreates symlinks on the target via :py:meth:`make_symlink`
             instead of copying bytes (required for round-trip preservation of symlinks).
-        :raises ValueError: If both source_files and patterns are provided, or if ``follow_symlinks`` is combined
-            with a non-default ``symlink_handling``.
+        :raises ValueError: If both source_files and patterns are provided.
         :raises RuntimeError: If errors occur during sync operations. The sync will stop on first error (fail-fast).
         """
         if source_files and patterns:
             raise ValueError("Cannot specify both 'source_files' and 'patterns'. Please use only one filtering method.")
-
-        symlink_handling = resolve_symlink_handling(follow_symlinks, symlink_handling)
 
         pattern_matcher = PatternMatcher(patterns) if patterns else None
 
@@ -1207,7 +1196,6 @@ class SingleStorageClient(AbstractStorageClient):
 
     def list(
         self,
-        prefix: str = "",
         path: str = "",
         start_after: Optional[str] = None,
         end_at: Optional[str] = None,
@@ -1215,53 +1203,28 @@ class SingleStorageClient(AbstractStorageClient):
         include_url_prefix: bool = False,
         attribute_filter_expression: Optional[str] = None,
         show_attributes: bool = False,
-        follow_symlinks: Optional[bool] = None,
         patterns: Optional[PatternList] = None,
         symlink_handling: SymlinkHandling = SymlinkHandling.FOLLOW,
     ) -> Iterator[ObjectMetadata]:
         """
         List objects in the storage provider under the specified path.
 
-        **IMPORTANT**: Use the ``path`` parameter for new code. The ``prefix`` parameter is
-        deprecated and will be removed in a future version.
-
-        :param prefix: [DEPRECATED] Use ``path`` instead. The prefix to list objects under.
         :param path: The directory or file path to list objects under. This should be a
                     complete filesystem path (e.g., "my-bucket/documents/" or "data/2024/").
-                    Cannot be used together with ``prefix``.
         :param start_after: The key to start after (i.e. exclusive). An object with this key doesn't have to exist.
         :param end_at: The key to end at (i.e. inclusive). An object with this key doesn't have to exist.
         :param include_directories: Whether to include directories in the result. When ``True``, directories are returned alongside objects.
         :param include_url_prefix: Whether to include the URL prefix ``msc://profile`` in the result.
         :param attribute_filter_expression: The attribute filter expression to apply to the result.
         :param show_attributes: Whether to return attributes in the result. WARNING: Depending on implementation, there may be a performance impact if this is set to ``True``.
-        :param follow_symlinks: **Deprecated.** Use ``symlink_handling`` instead.
         :param patterns: PatternList for include/exclude filtering. If None, all files are included.
         :param symlink_handling: How to handle symbolic links during listing. Only applicable for POSIX file storage providers.
         :return: An iterator over ObjectMetadata for matching objects.
-        :raises ValueError: If both ``path`` and ``prefix`` parameters are provided (both non-empty).
         """
-        symlink_handling = resolve_symlink_handling(follow_symlinks, symlink_handling)
-
-        # Parameter validation - either path or prefix, not both
-        if path and prefix:
-            raise ValueError(
-                f"Cannot specify both 'path' ({path!r}) and 'prefix' ({prefix!r}). "
-                f"Please use only the 'path' parameter for new code. "
-                f"Migration guide: Replace list(prefix={prefix!r}) with list(path={prefix!r})"
-            )
-        elif prefix:
-            logger.debug(
-                f"The 'prefix' parameter is deprecated and will be removed in a future version. "
-                f"Please use the 'path' parameter instead. "
-                f"Migration guide: Replace list(prefix={prefix!r}) with list(path={prefix!r})"
-            )
-
         pattern_matcher = PatternMatcher(patterns) if patterns else None
-        effective_path = path if path else prefix
 
         single_file, effective_path = self._resolve_single_file(
-            effective_path, start_after, end_at, include_url_prefix, pattern_matcher
+            path, start_after, end_at, include_url_prefix, pattern_matcher
         )
         if single_file is not None:
             yield single_file

--- a/multi-storage-client/src/multistorageclient/client/types.py
+++ b/multi-storage-client/src/multistorageclient/client/types.py
@@ -217,7 +217,6 @@ class AbstractStorageClient(ABC):
         max_workers: int = 32,
         look_ahead: int = 2,
         include_url_prefix: bool = False,
-        follow_symlinks: Optional[bool] = None,
         patterns: Optional[PatternList] = None,
         symlink_handling: SymlinkHandling = SymlinkHandling.FOLLOW,
     ) -> Iterator[ObjectMetadata]:
@@ -230,7 +229,6 @@ class AbstractStorageClient(ABC):
         :param max_workers: Maximum concurrent workers for provider-level recursive listing.
         :param look_ahead: Prefixes to buffer per worker for provider-level recursive listing.
         :param include_url_prefix: Whether to include the URL prefix ``msc://profile`` in the result.
-        :param follow_symlinks: **Deprecated.** Use ``symlink_handling`` instead.
         :param patterns: PatternList for include/exclude filtering. If None, all files are included.
         :param symlink_handling: How to handle symbolic links during listing.
         :return: An iterator over ObjectMetadata for matching files.
@@ -398,7 +396,6 @@ class AbstractStorageClient(ABC):
         execution_mode: ExecutionMode = ExecutionMode.LOCAL,
         patterns: Optional[PatternList] = None,
         preserve_source_attributes: bool = False,
-        follow_symlinks: Optional[bool] = None,
         source_files: Optional[list[str]] = None,
         ignore_hidden: bool = True,
         commit_metadata: bool = True,
@@ -426,9 +423,6 @@ class AbstractStorageClient(ABC):
                 request for each object to retrieve attributes, which can significantly impact performance on large-scale
                 sync operations. For production use at scale, configure a ``metadata_provider`` in your storage profile.
 
-        :param follow_symlinks: **Deprecated.** Use ``symlink_handling`` instead. If the source StorageClient is PosixFile,
-            whether to follow symbolic links. ``True`` maps to :py:attr:`SymlinkHandling.FOLLOW`; ``False`` maps to
-            :py:attr:`SymlinkHandling.SKIP`. Cannot be combined with a non-default ``symlink_handling``.
         :param source_files: Optional list of file paths (relative to source_path) to sync. When provided, only these
             specific files will be synced, skipping enumeration of the source path. Cannot be used together with patterns.
         :param ignore_hidden: Whether to ignore hidden files and directories. Default is ``True``.
@@ -443,8 +437,7 @@ class AbstractStorageClient(ABC):
             :py:attr:`SymlinkHandling.SKIP` excludes symlinks from the sync.
             :py:attr:`SymlinkHandling.PRESERVE` recreates symlinks on the target via :py:meth:`make_symlink`
             instead of copying bytes (required for round-trip preservation of symlinks).
-        :raises ValueError: If both source_files and patterns are provided, or if ``follow_symlinks`` is combined
-            with a non-default ``symlink_handling``.
+        :raises ValueError: If both source_files and patterns are provided.
         :raises NotImplementedError: If sync operations are not supported (e.g., CompositeStorageClient as target).
         """
         pass
@@ -484,7 +477,6 @@ class AbstractStorageClient(ABC):
     @abstractmethod
     def list(
         self,
-        prefix: str = "",
         path: str = "",
         start_after: Optional[str] = None,
         end_at: Optional[str] = None,
@@ -492,27 +484,20 @@ class AbstractStorageClient(ABC):
         include_url_prefix: bool = False,
         attribute_filter_expression: Optional[str] = None,
         show_attributes: bool = False,
-        follow_symlinks: Optional[bool] = None,
         patterns: Optional[PatternList] = None,
         symlink_handling: SymlinkHandling = SymlinkHandling.FOLLOW,
     ) -> Iterator[ObjectMetadata]:
         """
         List objects in the storage provider under the specified path.
 
-        **IMPORTANT**: Use the ``path`` parameter for new code. The ``prefix`` parameter is
-        deprecated and will be removed in a future version.
-
-        :param prefix: [DEPRECATED] Use ``path`` instead. The prefix to list objects under.
         :param path: The directory or file path to list objects under. This should be a
                     complete filesystem path (e.g., "my-bucket/documents/" or "data/2024/").
-                    Cannot be used together with ``prefix``.
         :param start_after: The key to start after (i.e. exclusive). An object with this key doesn't have to exist.
         :param end_at: The key to end at (i.e. inclusive). An object with this key doesn't have to exist.
         :param include_directories: Whether to include directories in the result. When ``True``, directories are returned alongside objects.
         :param include_url_prefix: Whether to include the URL prefix ``msc://profile`` in the result.
         :param attribute_filter_expression: The attribute filter expression to apply to the result.
         :param show_attributes: Whether to return attributes in the result. WARNING: Depending on implementation, there may be a performance impact if this is set to ``True``.
-        :param follow_symlinks: [DEPRECATED] Use ``symlink_handling`` instead. Whether to follow symbolic links. Only applicable for POSIX file storage providers. When ``False``, symlinks are skipped during listing.
         :param patterns: PatternList for include/exclude filtering. If None, all files are included.
         :param symlink_handling: How symbolic links should be handled during listing.
             ``SymlinkHandling.FOLLOW`` (default) resolves symlinks and returns the target file's
@@ -520,7 +505,6 @@ class AbstractStorageClient(ABC):
             emits symlinks as zero-byte entries with ``symlink_target`` populated so they can be
             reproduced on a compatible destination.
         :return: An iterator over ObjectMetadata for matching objects.
-        :raises ValueError: If both ``path`` and ``prefix`` parameters are provided (both non-empty).
         """
         pass
 

--- a/multi-storage-client/src/multistorageclient/config.py
+++ b/multi-storage-client/src/multistorageclient/config.py
@@ -78,7 +78,6 @@ def create_implicit_profile_config(profile_name: str, protocol: str, base_path: 
     }
 
 
-LEGACY_POSIX_PROFILE_NAME = "default"
 RESERVED_POSIX_PROFILE_NAME = "__filesystem__"
 DEFAULT_POSIX_PROFILE = create_implicit_profile_config(RESERVED_POSIX_PROFILE_NAME, "file", "/")
 
@@ -417,22 +416,6 @@ def _find_config_file_paths() -> tuple[str]:
     )
 
     return tuple(paths)
-
-
-def _normalize_profile_name(profile: str, config_dict: dict[str, Any]) -> str:
-    """
-    Normalize the profile name to the reserved POSIX profile name if the legacy "default" POSIX profile is used.
-
-    :param profile: The profile name to normalize
-    :param config_dict: The configuration dictionary
-    :return: The normalized profile name
-    """
-    if profile == LEGACY_POSIX_PROFILE_NAME and profile not in config_dict.get("profiles", {}):
-        logger.warning(
-            f"The profile name '{LEGACY_POSIX_PROFILE_NAME}' is deprecated and will be removed in a future version. Please use '{RESERVED_POSIX_PROFILE_NAME}' instead."
-        )
-        return RESERVED_POSIX_PROFILE_NAME
-    return profile
 
 
 PACKAGE_NAME = "multistorageclient"
@@ -1444,7 +1427,7 @@ class StorageClientConfig:
         # Load config
         loader = StorageClientConfigLoader(
             config_dict=config_dict,
-            profile=_normalize_profile_name(profile, config_dict),
+            profile=profile,
             telemetry_provider=telemetry_provider,
         )
         config = loader.build_config()
@@ -1483,7 +1466,7 @@ class StorageClientConfig:
             )
         else:
             # Check if profile is the default POSIX profile or an implicit profile
-            if profile == RESERVED_POSIX_PROFILE_NAME or profile == LEGACY_POSIX_PROFILE_NAME:
+            if profile == RESERVED_POSIX_PROFILE_NAME:
                 implicit_profile_config = DEFAULT_POSIX_PROFILE
             elif profile.startswith("_"):
                 # Handle implicit profiles

--- a/multi-storage-client/src/multistorageclient/contrib/hydra.py
+++ b/multi-storage-client/src/multistorageclient/contrib/hydra.py
@@ -189,7 +189,7 @@ class MSCConfigSource(ConfigSource):
             list_path = path.rstrip("/") + "/" if path else ""
 
             # Get all items under this path
-            for item in client.list(prefix=list_path, include_directories=True):
+            for item in client.list(path=list_path, include_directories=True):
                 # Get the relative path from the base path
                 if item.key.startswith(list_path):
                     relative_path = item.key[len(list_path) :]

--- a/multi-storage-client/src/multistorageclient/providers/base.py
+++ b/multi-storage-client/src/multistorageclient/providers/base.py
@@ -829,7 +829,7 @@ class BaseStorageProvider(StorageProvider):
                 ),
             )
         except TypeError as exc:
-            if "symlink_handling" in str(exc) or "follow_symlinks" in str(exc):
+            if "symlink_handling" in str(exc):
                 logger.debug(
                     "Custom storage provider does not accept symlink_handling in _list_objects. "
                     "Please update your provider's interface."

--- a/multi-storage-client/src/multistorageclient/shortcuts.py
+++ b/multi-storage-client/src/multistorageclient/shortcuts.py
@@ -478,7 +478,6 @@ def list(
     include_directories: bool = False,
     attribute_filter_expression: Optional[str] = None,
     show_attributes: bool = False,
-    follow_symlinks: Optional[bool] = None,
     patterns: Optional[PatternList] = None,
     symlink_handling: SymlinkHandling = SymlinkHandling.FOLLOW,
 ) -> Iterator[ObjectMetadata]:
@@ -494,7 +493,6 @@ def list(
     :param include_directories: Whether to include directories in the result. When True, directories are returned alongside objects.
     :param attribute_filter_expression: The attribute filter expression to apply to the result.
     :param show_attributes: Whether to return attributes in the result.
-    :param follow_symlinks: **Deprecated.** Use ``symlink_handling`` instead.
     :param patterns: PatternList for include/exclude filtering. If None, all files are included.
     :param symlink_handling: How to handle symbolic links. Only applicable for POSIX file storage.
     :return: An iterator of :py:class:`ObjectMetadata` objects representing the files (and optionally directories)
@@ -509,7 +507,6 @@ def list(
         include_url_prefix=True,
         attribute_filter_expression=attribute_filter_expression,
         show_attributes=show_attributes,
-        follow_symlinks=follow_symlinks,
         patterns=patterns,
         symlink_handling=symlink_handling,
     )
@@ -521,7 +518,6 @@ def list_recursive(
     end_at: Optional[str] = None,
     max_workers: int = 32,
     look_ahead: int = 2,
-    follow_symlinks: Optional[bool] = None,
     patterns: Optional[PatternList] = None,
     symlink_handling: SymlinkHandling = SymlinkHandling.FOLLOW,
 ) -> Iterator[ObjectMetadata]:
@@ -536,7 +532,6 @@ def list_recursive(
     :param end_at: The key to end at (i.e. inclusive). An object with this key doesn't have to exist.
     :param max_workers: Maximum concurrent workers for provider-level recursive listing.
     :param look_ahead: Prefixes to buffer per worker for provider-level recursive listing.
-    :param follow_symlinks: **Deprecated.** Use ``symlink_handling`` instead.
     :param patterns: PatternList for include/exclude filtering. If None, all files are included.
     :param symlink_handling: How to handle symbolic links during listing.
     :return: An iterator of :py:class:`ObjectMetadata` objects representing files accessible under the specified URL path.
@@ -550,7 +545,6 @@ def list_recursive(
         max_workers=max_workers,
         look_ahead=look_ahead,
         include_url_prefix=True,
-        follow_symlinks=follow_symlinks,
         patterns=patterns,
         symlink_handling=symlink_handling,
     )

--- a/multi-storage-client/src/multistorageclient/utils.py
+++ b/multi-storage-client/src/multistorageclient/utils.py
@@ -29,31 +29,12 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 from lark import Lark, Transformer
 from wcmatch import glob as wcmatch_glob
 
-from .types import ExecutionMode, ObjectMetadata, PatternList, PatternType, SymlinkHandling
+from .types import ExecutionMode, ObjectMetadata, PatternList, PatternType
 
 if TYPE_CHECKING:
     from .client.types import AbstractStorageClient
 
 logger = logging.getLogger(__name__)
-
-
-def resolve_symlink_handling(follow_symlinks: Optional[bool], symlink_handling: SymlinkHandling) -> SymlinkHandling:
-    """Bridge the deprecated ``follow_symlinks`` flag to :class:`SymlinkHandling`.
-
-    When *follow_symlinks* is ``None`` (the caller did not pass it),
-    *symlink_handling* is returned as-is.  When *follow_symlinks* is explicitly
-    set **and** *symlink_handling* was also changed from the default, the two
-    conflict and a :class:`ValueError` is raised.  Otherwise the boolean is
-    translated: ``True`` → ``FOLLOW``, ``False`` → ``SKIP``.
-
-    This helper exists so every public entry-point that still accepts
-    ``follow_symlinks`` can share the same resolution logic.
-    """
-    if follow_symlinks is None:
-        return symlink_handling
-    if symlink_handling != SymlinkHandling.FOLLOW:
-        raise ValueError("Cannot specify both 'follow_symlinks' and a non-default 'symlink_handling'.")
-    return SymlinkHandling.FOLLOW if follow_symlinks else SymlinkHandling.SKIP
 
 
 def safe_makedirs(path: str, mode: int = 0o777, exist_ok: bool = True) -> None:

--- a/multi-storage-client/tests/test_multistorageclient/e2e/common.py
+++ b/multi-storage-client/tests/test_multistorageclient/e2e/common.py
@@ -32,7 +32,7 @@ MB = 1024 * 1024
 
 
 def delete_files(storage_client: msc.StorageClient, prefix: str) -> None:
-    for object in storage_client.list(prefix=prefix):
+    for object in storage_client.list(path=prefix):
         try:
             storage_client.delete(object.key)
         except FileNotFoundError:
@@ -200,12 +200,12 @@ def verify_storage_provider(storage_client: msc.StorageClient, prefix: str) -> N
         assert storage_client.info(path=f"{prefix}/dir1/dir2").type == "directory"
         assert storage_client.info(path=f"{prefix}/dir1/dir2").content_length == 0
 
-        directories = list(storage_client.list(prefix=f"{prefix}/dir1/", include_directories=True))
+        directories = list(storage_client.list(path=f"{prefix}/dir1/", include_directories=True))
         assert len(directories) == 1
         assert directories[0].key == f"{prefix}/dir1/dir2"
         assert directories[0].type == "directory"
 
-        directories = list(storage_client.list(prefix=f"{prefix}/dir1/", include_directories=False))
+        directories = list(storage_client.list(path=f"{prefix}/dir1/", include_directories=False))
         assert len(directories) == 0
 
         # delete directory with recursive flag will return an ValueError
@@ -229,7 +229,7 @@ def verify_storage_provider(storage_client: msc.StorageClient, prefix: str) -> N
         should_wait=len_should_wait(expected_len=3),
     )
 
-    immediate_children = list(storage_client.list(prefix=f"{prefix}/dir1/", include_directories=True))
+    immediate_children = list(storage_client.list(path=f"{prefix}/dir1/", include_directories=True))
     immediate_keys = [obj.key.replace(f"{prefix}/dir1/", "") for obj in immediate_children]
 
     assert len(immediate_children) == 3, f"Actual list: {immediate_children}"
@@ -243,7 +243,7 @@ def verify_storage_provider(storage_client: msc.StorageClient, prefix: str) -> N
     dir2_obj = next(obj for obj in immediate_children if obj.key.endswith("dir2"))
     assert dir2_obj.type == "directory"
 
-    all_files = list(storage_client.list(prefix=f"{prefix}/dir1/", include_directories=False))
+    all_files = list(storage_client.list(path=f"{prefix}/dir1/", include_directories=False))
     all_file_keys = [obj.key.replace(f"{prefix}/dir1/", "") for obj in all_files]
 
     assert len(all_files) == 3
@@ -349,7 +349,7 @@ def verify_storage_provider(storage_client: msc.StorageClient, prefix: str) -> N
     assert storage_client.info(path=symlink_path).symlink_target == "target.txt"
 
     # list() should populate symlink_target on symlink objects
-    objects = list(storage_client.list(prefix=symlink_prefix))
+    objects = list(storage_client.list(path=symlink_prefix))
     objects_by_suffix = {obj.key.split("/")[-1]: obj for obj in objects}
     assert objects_by_suffix["symlink.txt"].symlink_target == "target.txt"
     assert objects_by_suffix["target.txt"].symlink_target is None
@@ -1280,7 +1280,7 @@ def test_sync_from_preserves_symlinks(profile: str) -> None:
                 symlink_handling=SymlinkHandling.PRESERVE,
             )
 
-            cloud_objects_by_key = {entry.key: entry for entry in cloud_client.list(prefix=cloud_prefix)}
+            cloud_objects_by_key = {entry.key: entry for entry in cloud_client.list(path=cloud_prefix)}
             expected_cloud_keys = {
                 f"{cloud_prefix}/c.txt": (b"c content", None),
                 f"{cloud_prefix}/dir1/a.txt": (b"a content", None),

--- a/multi-storage-client/tests/test_multistorageclient/load/local.py
+++ b/multi-storage-client/tests/test_multistorageclient/load/local.py
@@ -105,7 +105,7 @@ def test_storage_client(storage_client: StorageClient) -> None:
     storage_client.info(path=file_path)
 
     # List the prefix directory.
-    list(storage_client.list(prefix=os.path.join(*file_path_fragments[:1])))
+    list(storage_client.list(path=os.path.join(*file_path_fragments[:1])))
 
     # Copy the file.
     storage_client.copy(src_path=file_path, dest_path=file_copy_path)

--- a/multi-storage-client/tests/test_multistorageclient/unit/client/test_client.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/client/test_client.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import pickle
 import threading
 from datetime import datetime, timezone
@@ -235,6 +236,17 @@ def test_single_client_is_rust_client_enabled(single_backend_config):
     assert single._is_rust_client_enabled() is True
 
 
+def test_list_recursive_rejects_removed_follow_symlinks_parameter(single_backend_config):
+    client = StorageClient(single_backend_config)
+
+    with pytest.raises(TypeError):
+        client.list_recursive(path="/tmp/data", follow_symlinks=False)  # type: ignore[call-arg]
+
+
+def test_list_rejects_removed_prefix_parameter(single_backend_config):
+    assert "prefix" not in inspect.signature(StorageClient.list).parameters
+
+
 def test_list_recursive_delegates_to_single_client(single_backend_config):
     client = StorageClient(single_backend_config)
     expected = iter([])
@@ -245,7 +257,7 @@ def test_list_recursive_delegates_to_single_client(single_backend_config):
         max_workers=8,
         look_ahead=4,
         include_url_prefix=True,
-        follow_symlinks=False,
+        symlink_handling=SymlinkHandling.SKIP,
     )
 
     assert result is expected
@@ -256,9 +268,8 @@ def test_list_recursive_delegates_to_single_client(single_backend_config):
         max_workers=8,
         look_ahead=4,
         include_url_prefix=True,
-        follow_symlinks=False,
         patterns=None,
-        symlink_handling=SymlinkHandling.FOLLOW,
+        symlink_handling=SymlinkHandling.SKIP,
     )
 
 
@@ -277,7 +288,6 @@ def test_list_recursive_delegates_to_composite_client(multi_backend_config):
         max_workers=32,
         look_ahead=2,
         include_url_prefix=False,
-        follow_symlinks=None,
         patterns=None,
         symlink_handling=SymlinkHandling.FOLLOW,
     )

--- a/multi-storage-client/tests/test_multistorageclient/unit/contrib/test_ray.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/contrib/test_ray.py
@@ -202,7 +202,7 @@ def test_storage_client_sync_with_files(ray_cluster):
 
         # Verify sync worked by checking target has the same files
         synced_files = [
-            f.key.removeprefix("target/") for f in list(target_client.list(prefix="target/")) if f.key.endswith(".txt")
+            f.key.removeprefix("target/") for f in list(target_client.list(path="target/")) if f.key.endswith(".txt")
         ]
         assert set(synced_files) == set(source_files), f"Expected {source_files}, found {synced_files}"
         assert len(synced_files) == 500, f"Expected 500 synced files, found {len(synced_files)}"
@@ -245,12 +245,12 @@ def test_storage_client_sync_replicas(ray_cluster):
 
         # Verify sync worked by checking replica1 has the same files
         replica1 = StorageClient(StorageClientConfig.from_dict(config_dict=config_dict, profile="replica1"))
-        synced_files = [f.key.removeprefix("source/") for f in list(replica1.list(prefix="")) if f.key.endswith(".txt")]
+        synced_files = [f.key.removeprefix("source/") for f in list(replica1.list(path="")) if f.key.endswith(".txt")]
         assert set(synced_files) == set(source_files), f"Expected {source_files}, found {synced_files}"
         assert len(synced_files) == 500, f"Expected 500 synced files, found {len(synced_files)}"
 
         # Verify sync worked by checking replica2 has the same files
         replica2 = StorageClient(StorageClientConfig.from_dict(config_dict=config_dict, profile="replica2"))
-        synced_files = [f.key.removeprefix("source/") for f in list(replica2.list(prefix="")) if f.key.endswith(".txt")]
+        synced_files = [f.key.removeprefix("source/") for f in list(replica2.list(path="")) if f.key.endswith(".txt")]
         assert set(synced_files) == set(source_files), f"Expected {source_files}, found {synced_files}"
         assert len(synced_files) == 500, f"Expected 500 synced files, found {len(synced_files)}"

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_metadata_rewrite.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_metadata_rewrite.py
@@ -170,7 +170,7 @@ def test_uuid_metadata_provider(temp_data_store_type: type[tempdatastore.Tempora
             storage_client.write(path, content)
 
         # Nothing visible until commit_metadata
-        assert len(list(storage_client.list(prefix=""))) == 0
+        assert len(list(storage_client.list(path=""))) == 0
 
         with pytest.raises(FileNotFoundError):
             _ = storage_client.info("file1.txt")
@@ -179,7 +179,7 @@ def test_uuid_metadata_provider(temp_data_store_type: type[tempdatastore.Tempora
 
         storage_client.commit_metadata()
 
-        assert set([f.key for f in storage_client.list(prefix="")]) == set(content_dict.keys())
+        assert set([f.key for f in storage_client.list(path="")]) == set(content_dict.keys())
 
         # Verify content via info, read, download_file, is_file
         for path, content in content_dict.items():
@@ -254,12 +254,12 @@ def test_uuid_metadata_provider(temp_data_store_type: type[tempdatastore.Tempora
 
         # call commit_metadata again, should be a no-op
         storage_client.commit_metadata()
-        assert set([f.key for f in storage_client.list(prefix="")]) == set(content_dict.keys())
+        assert set([f.key for f in storage_client.list(path="")]) == set(content_dict.keys())
 
         # Test delete API with recursive=True, which auto-commits.
         storage_client.delete(path="", recursive=True)
         # Assert that all files are deleted
-        assert len(list(storage_client.list(prefix=""))) == 0
+        assert len(list(storage_client.list(path=""))) == 0
 
         # Test ResolvedPath enum functionality
         # Test EXISTS state

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_outdated_storage_providers.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_outdated_storage_providers.py
@@ -108,11 +108,11 @@ def test_outdated_provider_through_client_api():
     result = list(client.list("data/files"))
     assert len(result) == 2
 
-    # Test case 2: Application that still uses the prefix parameter (works)
-    result = list(client.list(prefix="data/files"))
+    # Test case 2: Application that uses the path keyword (works)
+    result = list(client.list(path="data/files"))
     assert len(result) == 2
 
-    # Test case 3: Application that uses the new path parameter (works)
+    # Test case 3: Repeated path keyword calls continue to work
     result = list(client.list(path="data/files"))
     assert len(result) == 2
 

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_storage_providers.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_storage_providers.py
@@ -142,8 +142,8 @@ def test_storage_providers(temp_data_store_type: type[tempdatastore.TemporaryDat
             assert not storage_client.is_file(path=f"{lead}{file_path_fragments[0]}-nonexistent")
             assert not storage_client.is_file(path=f"{lead}{file_path_fragments[0]}")
 
-        assert len(list(storage_client.list(prefix=file_path_fragments[0]))) == 1
-        file_info_list = list(storage_client.list(prefix=os.path.join(*file_path_fragments[:2])))
+        assert len(list(storage_client.list(path=file_path_fragments[0]))) == 1
+        file_info_list = list(storage_client.list(path=os.path.join(*file_path_fragments[:2])))
         assert len(file_info_list) == 1
         listed_file_info = file_info_list[0]
         assert listed_file_info is not None
@@ -249,8 +249,8 @@ def test_storage_providers(temp_data_store_type: type[tempdatastore.TemporaryDat
         for path in [file_path, file_copy_path]:
             storage_client.delete(path=path)
             wait_for_is_file(storage_client=storage_client, path=path, is_file=False)
-        assert len(list(storage_client.list(prefix=file_path_fragments[0]))) == 0
-        assert len(list(storage_client.list(prefix=file_copy_path_fragments[0]))) == 0
+        assert len(list(storage_client.list(path=file_path_fragments[0]))) == 0
+        assert len(list(storage_client.list(path=file_copy_path_fragments[0]))) == 0
 
         # Open the file for appends (bytes).
         with storage_client.open(path=file_path, mode="ab", prefetch_file=True) as file:
@@ -303,7 +303,7 @@ def test_storage_providers(temp_data_store_type: type[tempdatastore.TemporaryDat
         # List the files (paginated).
         for i in file_numbers:
             files = list(
-                storage_client.list(prefix="", start_after=f"{i - 1}{file_extension}", end_at=f"{i}{file_extension}")
+                storage_client.list(path="", start_after=f"{i - 1}{file_extension}", end_at=f"{i}{file_extension}")
             )
             assert len(files) == 1
             assert files[0].key.endswith(f"{i}{file_extension}")
@@ -383,12 +383,12 @@ def test_storage_providers_list_directories(temp_data_store_type: type[tempdatas
         assert storage_client.info(path="dir1").content_length == 0
 
         # List directories
-        directories = list(storage_client.list(prefix="", include_directories=True))
+        directories = list(storage_client.list(path="", include_directories=True))
         assert len(directories) == 1
         assert directories[0].key == "dir1"
         assert directories[0].type == "directory"
 
-        directories = list(storage_client.list(prefix="", include_directories=False))
+        directories = list(storage_client.list(path="", include_directories=False))
         assert len(directories) == 0
 
 
@@ -685,7 +685,7 @@ def test_storage_with_root_base_path(temp_data_store_type: type[tempdatastore.Te
             storage_client.delete(path=fname)
             wait_for_is_file(storage_client=storage_client, path=fname, is_file=False)
 
-        assert len(list(storage_client.list(prefix=bucket))) == 0
+        assert len(list(storage_client.list(path=bucket))) == 0
 
 
 @pytest.mark.parametrize(

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_symlinks.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_symlinks.py
@@ -56,7 +56,7 @@ def test_list_symlinks_from_object_storage(temp_data_store_type: type[tempdatast
         │   └── file.txt            (regular file inside subdir)
         └── symlink_to_subdir       (symlink object whose target is "subdir")
 
-    The flat listing ``list(prefix=<prefix>)`` yields exactly these four
+    The flat listing ``list(path=<prefix>)`` yields exactly these four
     entries (symlink objects appear alongside regular files, with their
     ``symlink_target`` populated):
 
@@ -70,7 +70,7 @@ def test_list_symlinks_from_object_storage(temp_data_store_type: type[tempdatast
     ================================  ===============  ====================
 
     The hierarchical listing
-    ``list(prefix=<prefix>/, include_directories=True)`` yields exactly these
+    ``list(path=<prefix>/, include_directories=True)`` yields exactly these
     four entries -- the real ``subdir`` is collapsed into a single
     ``directory`` entry, but both symlink objects stay visible as their own
     entries (directory symlinks are **not** collapsed into the directory
@@ -122,7 +122,7 @@ def test_list_symlinks_from_object_storage(temp_data_store_type: type[tempdatast
         # Flat listing returns all underlying objects under the prefix: the
         # two regular files plus the two symlink objects. Only the symlinks
         # carry a non-None symlink_target.
-        objects = list(storage_client.list(prefix=symlink_prefix))
+        objects = list(storage_client.list(path=symlink_prefix))
         objects_by_key = {o.key: o for o in objects}
         assert len(objects) == 4
         assert objects_by_key[target_file_path].type == "file"
@@ -138,7 +138,7 @@ def test_list_symlinks_from_object_storage(temp_data_store_type: type[tempdatast
         # returns the real subdir as a directory entry and the two symlink
         # objects (including the directory symlink) as separate file entries
         # that still carry their symlink targets.
-        entries = list(storage_client.list(prefix=f"{symlink_prefix}/", include_directories=True))
+        entries = list(storage_client.list(path=f"{symlink_prefix}/", include_directories=True))
         entries_by_key = {e.key: e for e in entries}
         assert len(entries) == 4
         assert entries_by_key[subdir].type == "directory"
@@ -296,12 +296,12 @@ def test_list_symlinks_from_posix_with_follow(temp_data_store_type: type[tempdat
     ======================  ===============  =========================
 
     This is the backward-compatible behavior that matches the legacy
-    ``follow_symlinks=True`` listing semantics.
+    ``SymlinkHandling.FOLLOW`` listing semantics.
     """
     with temp_data_store_type() as temp_data_store:
         storage_client = _build_posix_storage_client_with_symlink_tree(temp_data_store)
 
-        objects = list(storage_client.list(prefix="", symlink_handling=SymlinkHandling.FOLLOW))
+        objects = list(storage_client.list(path="", symlink_handling=SymlinkHandling.FOLLOW))
         objects_by_key = {o.key: o for o in objects}
 
         assert set(objects_by_key.keys()) == {
@@ -339,12 +339,12 @@ def test_list_symlinks_from_posix_with_skip(temp_data_store_type: type[tempdatas
     ``dir2/b.txt``          ``file``         ``None``
     ======================  ===============  =========================
 
-    This matches the legacy ``follow_symlinks=False`` listing semantics.
+    This matches the ``SymlinkHandling.SKIP`` listing semantics.
     """
     with temp_data_store_type() as temp_data_store:
         storage_client = _build_posix_storage_client_with_symlink_tree(temp_data_store)
 
-        objects = list(storage_client.list(prefix="", symlink_handling=SymlinkHandling.SKIP))
+        objects = list(storage_client.list(path="", symlink_handling=SymlinkHandling.SKIP))
         objects_by_key = {o.key: o for o in objects}
 
         assert set(objects_by_key.keys()) == {"c.txt", "dir1/a.txt", "dir2/b.txt"}
@@ -382,7 +382,7 @@ def test_list_symlinks_from_posix_with_preserve(temp_data_store_type: type[tempd
     with temp_data_store_type() as temp_data_store:
         storage_client = _build_posix_storage_client_with_symlink_tree(temp_data_store)
 
-        objects = list(storage_client.list(prefix="", symlink_handling=SymlinkHandling.PRESERVE))
+        objects = list(storage_client.list(path="", symlink_handling=SymlinkHandling.PRESERVE))
         objects_by_key = {o.key: o for o in objects}
 
         assert set(objects_by_key.keys()) == {
@@ -424,7 +424,7 @@ def test_list_recursive_symlinks_from_posix_matches_list(
     with temp_data_store_type() as temp_data_store:
         storage_client = _build_posix_storage_client_with_symlink_tree(temp_data_store)
 
-        list_objects = list(storage_client.list(prefix="", symlink_handling=symlink_handling))
+        list_objects = list(storage_client.list(path="", symlink_handling=symlink_handling))
         recursive_objects = list(storage_client.list_recursive(path="", symlink_handling=symlink_handling))
 
         assert [(o.key, o.type, o.symlink_target) for o in recursive_objects] == [
@@ -486,7 +486,7 @@ def test_list_symlinks_from_posix_with_preserve_raises_on_external_target(
             os.symlink(outside_file, os.path.join(base_path, "escaping"))
 
             with pytest.raises(ValueError, match="points outside the base directory"):
-                list(storage_client.list(prefix="", symlink_handling=SymlinkHandling.PRESERVE))
+                list(storage_client.list(path="", symlink_handling=SymlinkHandling.PRESERVE))
 
 
 @pytest.mark.parametrize(
@@ -538,7 +538,7 @@ def test_list_symlinks_from_posix_with_preserve_raises_on_broken_target(
         os.symlink(os.path.join(base_path, "missing.txt"), os.path.join(base_path, "dangling"))
 
         with pytest.raises(FileNotFoundError, match="Broken symlink"):
-            list(storage_client.list(prefix="", symlink_handling=SymlinkHandling.PRESERVE))
+            list(storage_client.list(path="", symlink_handling=SymlinkHandling.PRESERVE))
 
 
 @pytest.mark.parametrize(
@@ -590,7 +590,7 @@ def test_list_symlinks_from_posix_with_follow_raises_on_broken_target(
         os.symlink(os.path.join(base_path, "missing.txt"), os.path.join(base_path, "dangling"))
 
         with pytest.raises(FileNotFoundError, match="Broken symlink"):
-            list(storage_client.list(prefix="", symlink_handling=SymlinkHandling.FOLLOW))
+            list(storage_client.list(path="", symlink_handling=SymlinkHandling.FOLLOW))
 
 
 @pytest.mark.parametrize(
@@ -645,7 +645,7 @@ def test_list_chained_symlinks_from_posix_with_preserve(temp_data_store_type: ty
         os.symlink("file.txt", os.path.join(base_path, "link_b.txt"))
         os.symlink("link_b.txt", os.path.join(base_path, "link_a.txt"))
 
-        objects = list(storage_client.list(prefix="", symlink_handling=SymlinkHandling.PRESERVE))
+        objects = list(storage_client.list(path="", symlink_handling=SymlinkHandling.PRESERVE))
         by_key = {o.key: o for o in objects}
 
         assert set(by_key.keys()) == {"file.txt", "link_b.txt", "link_a.txt"}
@@ -760,7 +760,7 @@ def test_sync_from_posix_to_s3_to_posix_preserves_symlinks():
             symlink_handling=SymlinkHandling.PRESERVE,
         )
 
-        s3_objects_by_key = {entry.key: entry for entry in s3_client.list(prefix=s3_prefix)}
+        s3_objects_by_key = {entry.key: entry for entry in s3_client.list(path=s3_prefix)}
         expected_s3_keys = {
             f"{s3_prefix}/c.txt": (b"c content", None),
             f"{s3_prefix}/dir1/a.txt": (b"a content", None),

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_config.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_config.py
@@ -118,24 +118,24 @@ def test_override_default_profile() -> None:
     assert 'Cannot override "__filesystem__" profile with different settings.' in str(ex.value)
 
 
-def test_legacy_posix_profile(file_storage_config) -> None:
+def test_default_posix_profile_no_longer_accepts_legacy_default_alias(file_storage_config) -> None:
     config = StorageClientConfig.from_file()
     assert config.profile == "__filesystem__"
 
-    config = StorageClientConfig.from_file(profile="default")
-    assert config.profile == "__filesystem__"
+    with pytest.raises(ValueError, match='Profile "default" not found'):
+        StorageClientConfig.from_file(profile="default")
 
     config = StorageClientConfig.from_json("{}")
     assert config.profile == "__filesystem__"
 
-    config = StorageClientConfig.from_json("{}", profile="default")
-    assert config.profile == "__filesystem__"
+    with pytest.raises(ValueError, match="Profile default not found"):
+        StorageClientConfig.from_json("{}", profile="default")
 
     config = StorageClientConfig.from_yaml("")
     assert config.profile == "__filesystem__"
 
-    config = StorageClientConfig.from_yaml("", profile="default")
-    assert config.profile == "__filesystem__"
+    with pytest.raises(ValueError, match="Profile default not found"):
+        StorageClientConfig.from_yaml("", profile="default")
 
 
 def test_credentials_provider() -> None:

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_shortcuts.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_shortcuts.py
@@ -30,7 +30,7 @@ from multistorageclient.file import ObjectFile
 from multistorageclient.providers.manifest_metadata import (
     DEFAULT_MANIFEST_BASE_DIR,
 )
-from multistorageclient.types import MSC_PROTOCOL, ObjectMetadata, PatternType, SourceVersionCheckMode
+from multistorageclient.types import MSC_PROTOCOL, ObjectMetadata, PatternType, SourceVersionCheckMode, SymlinkHandling
 from test_multistorageclient.unit.utils import config, tempdatastore
 
 MB = 1024 * 1024
@@ -189,7 +189,14 @@ def test_list(file_storage_config):
         assert len(results) == 0
 
 
-def test_list_follow_symlinks(file_storage_config):
+def test_list_rejects_removed_follow_symlinks_parameter(file_storage_config):
+    with tempfile.TemporaryDirectory() as tempdir:
+        url = f"{MSC_PROTOCOL}__filesystem__{tempdir}"
+        with pytest.raises(TypeError):
+            list(msc.list(url, follow_symlinks=True))  # type: ignore[call-arg]
+
+
+def test_list_symlink_handling(file_storage_config):
     with tempfile.TemporaryDirectory() as tempdir:
         real_path = os.path.join(tempdir, "real.txt")
         symlink_path = os.path.join(tempdir, "link.txt")
@@ -197,8 +204,8 @@ def test_list_follow_symlinks(file_storage_config):
             f.write("content")
         os.symlink(real_path, symlink_path)
         url = f"{MSC_PROTOCOL}__filesystem__{tempdir}"
-        with_follow = list(msc.list(url, follow_symlinks=True))
-        without_follow = list(msc.list(url, follow_symlinks=False))
+        with_follow = list(msc.list(url, symlink_handling=SymlinkHandling.FOLLOW))
+        without_follow = list(msc.list(url, symlink_handling=SymlinkHandling.SKIP))
         keys_with = {os.path.basename(k.key) for k in with_follow}
         keys_without = {os.path.basename(k.key) for k in without_follow}
         assert "real.txt" in keys_with
@@ -228,7 +235,14 @@ def test_list_recursive(file_storage_config):
         assert posix_keys == {"root.bin", "child.bin"}
 
 
-def test_list_recursive_follow_symlinks_and_patterns(file_storage_config):
+def test_list_recursive_rejects_removed_follow_symlinks_parameter(file_storage_config):
+    with tempfile.TemporaryDirectory() as tempdir:
+        url = f"{MSC_PROTOCOL}__filesystem__{tempdir}"
+        with pytest.raises(TypeError):
+            list(msc.list_recursive(url, follow_symlinks=True))  # type: ignore[call-arg]
+
+
+def test_list_recursive_symlink_handling_and_patterns(file_storage_config):
     with tempfile.TemporaryDirectory() as tempdir:
         real_path = os.path.join(tempdir, "real.bin")
         symlink_path = os.path.join(tempdir, "link.bin")
@@ -243,8 +257,8 @@ def test_list_recursive_follow_symlinks_and_patterns(file_storage_config):
         url = f"{MSC_PROTOCOL}__filesystem__{tempdir}"
         include_bins = [(PatternType.INCLUDE, "*.bin")]
 
-        with_follow = list(msc.list_recursive(url, follow_symlinks=True, patterns=include_bins))
-        without_follow = list(msc.list_recursive(url, follow_symlinks=False, patterns=include_bins))
+        with_follow = list(msc.list_recursive(url, symlink_handling=SymlinkHandling.FOLLOW, patterns=include_bins))
+        without_follow = list(msc.list_recursive(url, symlink_handling=SymlinkHandling.SKIP, patterns=include_bins))
 
         keys_with = {os.path.basename(k.key) for k in with_follow}
         keys_without = {os.path.basename(k.key) for k in without_follow}

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_sync.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_sync.py
@@ -30,7 +30,7 @@ from multistorageclient.config import StorageClientConfig
 from multistorageclient.constants import MEMORY_LOAD_LIMIT
 from multistorageclient.providers.base import BaseStorageProvider
 from multistorageclient.providers.manifest_metadata import DEFAULT_MANIFEST_BASE_DIR
-from multistorageclient.types import ExecutionMode, ObjectMetadata, PatternType, SyncError
+from multistorageclient.types import ExecutionMode, ObjectMetadata, PatternType, SymlinkHandling, SyncError
 from test_multistorageclient.unit.utils import config, tempdatastore
 
 
@@ -57,7 +57,7 @@ def verify_sync_and_contents(target_url: str, expected_files: dict):
         assert actual_content == expected_content, f"Mismatch in file {file}"
     # Ensure there is nothing in target that is not in expected_files
     target_client, target_path = msc.resolve_storage_client(target_url)
-    for targetf in target_client.list(prefix=target_path):
+    for targetf in target_client.list(path=target_path):
         key = targetf.key[len(target_path) :].lstrip("/")
         # Skip temporary files that start with a dot (like .plexihcg)
         if key.startswith(".") or os.path.basename(key).startswith("."):
@@ -446,7 +446,7 @@ def test_sync_replicas(temp_data_store_type: type[tempdatastore.TemporaryDataSto
 
         # Verify that the lock file is created and removed.
         target_client, target_path = msc.resolve_storage_client(replica_msc_url)
-        files = list(target_client.list(prefix=target_path))
+        files = list(target_client.list(path=target_path))
         assert len([f for f in files if f.key.endswith(".lock")]) == 0
 
 
@@ -753,7 +753,7 @@ def test_sync_from_symlink_files(temp_data_store_type: type[tempdatastore.Tempor
 
         target_msc_url = f"msc://{obj_profile}/synced-no-symlinks"
         target_client, target_path = msc.resolve_storage_client(target_msc_url)
-        target_client.sync_from(source_client, source_path, target_path, follow_symlinks=False)
+        target_client.sync_from(source_client, source_path, target_path, symlink_handling=SymlinkHandling.SKIP)
 
         time.sleep(1)
 

--- a/multi-storage-client/tests/test_multistorageclient/unit/utils/mocks.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/utils/mocks.py
@@ -70,11 +70,12 @@ class TestMetadataProvider(MetadataProvider):
 
     def list_objects(
         self,
-        prefix: str,
+        path: str,
         start_after: Optional[str] = None,
         end_at: Optional[str] = None,
         include_directories: bool = False,
         attribute_filter_expression: Optional[str] = None,
+        show_attributes: bool = False,
     ) -> Iterator[ObjectMetadata]:
         assert not include_directories, "Directories are not supported in the test metadata provider"
         return iter(


### PR DESCRIPTION
## Description

- Remove deprecated Python SDK compatibility APIs for listing and symlink handling.
- Stop treating `default` as an implicit alias for the POSIX `__filesystem__` profile.
- Update tests and docs to use the current `path` and `symlink_handling` APIs.

## Changes

- Removed `follow_symlinks` from `list`, `list_recursive`, and `sync_from`.
- Removed `StorageClient.list(prefix=...)`; callers now use `path=...`.
- Removed implicit `default -> __filesystem__` profile normalization.
- Updated internal call sites, unit/e2e test references, and config docs.
- Left `multi-storage-file-system` unchanged.

Closes NGCDP-8520

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * POSIX filesystem profiles now use `__filesystem__` as the default reserved profile name.
  * Listing and sync APIs now use `path` consistently for directory targeting.

* **Bug Fixes**
  * Symlink behavior is now controlled only through `symlink_handling`, with deprecated `follow_symlinks` support removed.
  * Legacy `default` profile selection is no longer accepted when choosing the POSIX filesystem profile.

* **Documentation**
  * Updated configuration examples and usage guidance to match the new names and parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->