### PR TITLE
chore: release MSC 0.51.0

### DIFF
--- a/.github/workflows/.source.yml
+++ b/.github/workflows/.source.yml
@@ -109,12 +109,12 @@ jobs:
         run: |
           just python-binary=${{ matrix.python-binary }} build
           just python-binary=${{ matrix.python-binary }} run-minimal-verification
-      - if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
-        working-directory: multi-storage-client-scripts
-        run: |
-          # TODO: After MSC 1.0 is released, fetch the 1.0 tag used by check-api-compat.
-          git fetch --no-tags --prune origin main:refs/remotes/origin/main
-          uv run msc-scripts check-api-compat
+      # TODO: Re-enable after MSC 1.0 is released and compare against the 1.0 tag.
+      # - if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
+      #   working-directory: multi-storage-client-scripts
+      #   run: |
+      #     git fetch --no-tags --prune origin main:refs/remotes/origin/main
+      #     uv run msc-scripts check-api-compat
       - uses: actions/upload-artifact@v7
         with:
           if-no-files-found: error

--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -8,8 +8,6 @@
 
 ### Bug Fixes
 
-- Make `delete_many()` idempotent when missing keys are included.
-
 ## Multi-Storage File System (MSFS)
 
 ### Breaking Changes

--- a/.release_notes/0.51.0.md
+++ b/.release_notes/0.51.0.md
@@ -1,0 +1,32 @@
+## Multi-Storage Client (MSC)
+
+### New Features
+
+- Add a Python API compatibility guardrail.
+
+### Bug Fixes
+
+- Make `delete_many()` idempotent when missing keys are included.
+- Retry transient GCS `delete_many()` failures.
+- Reject unsafe cache delete paths.
+- Reject unknown top-level config keys correctly.
+- Normalize duplicate slashes in MSC URLs.
+- Preserve symlink chains.
+- Refresh sync progress totals immediately.
+- Upgrade vulnerable dependencies from security scans.
+
+## Multi-Storage File System (MSFS)
+
+### New Features
+
+- Support multi-bucket and multi-backend CSI volumes.
+- Add a no-credentials anonymous CSI connection mode.
+- Reload AIStore `authn_token_file` credentials after token rotation.
+- Add per-workload IRSA support with CSIDriver `tokenRequests` and `requiresRepublish`.
+- Add a per-inode disk cache backend.
+- Mark MSFS packages with pre-release version metadata.
+
+### Bug Fixes
+
+- Use optimistic-lock copy operations to remove warm-read serialization.
+- Align manifest directory listings.

--- a/multi-storage-client/pyproject.toml
+++ b/multi-storage-client/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 
 [project]
 name = "multi-storage-client"
-version = "0.50.0"
+version = "0.51.0"
 description = "Unified high-performance Python client for object and file stores."
 authors = [
     { name = "NVIDIA Multi-Storage Client Team" }

--- a/uv.lock
+++ b/uv.lock
@@ -2060,7 +2060,7 @@ wheels = [
 
 [[package]]
 name = "multi-storage-client"
-version = "0.50.0"
+version = "0.51.0"
 source = { editable = "multi-storage-client" }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Description

Prepare the 0.51.0 release.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.51.0, covering new multi-storage client and file system capabilities plus several bug fixes and security updates.
  * Removed an outdated bug-fix note from the unreleased changelog.

* **Chores**
  * Updated the package version to 0.51.0.
  * Adjusted automated checks so one API compatibility step is currently disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->