### PR TITLE
feat: promote stable MSC features

### DIFF
--- a/multi-storage-client-docs/src/references/configuration.rst
+++ b/multi-storage-client-docs/src/references/configuration.rst
@@ -16,10 +16,6 @@ The top-level configuration schema consists of six main sections:
 
   * Optional list of configuration file paths to include and merge. This enables modular configuration management by splitting settings across multiple files.
 
-* ``experimental_features``
-
-  * Optional dictionary to enable experimental features. When omitted, all experimental features are disabled.
-
 * ``profiles``
 
   * Dictionary containing profile configurations. Each profile defines storage, metadata, and credentials providers.
@@ -36,14 +32,15 @@ The top-level configuration schema consists of six main sections:
 
   * Configuration for mapping existing non-MSC URLs to existing MSC profiles.
 
+* ``posix``
+
+  * Configuration for POSIX filesystem mounts.
+
 .. code-block:: yaml
    :caption: Top-level schema.
 
    # Optional. List of config files to include
    include: <list_of_config_paths>
-
-   # Optional. Experimental features flags
-   experimental_features: <experimental_features_config>
 
    # Optional. Dictionary of profile configurations
    profiles: <profile_config>
@@ -56,6 +53,9 @@ The top-level configuration schema consists of six main sections:
 
    # Optional. Path mapping configuration
    path_mapping: <path_mapping_config>
+
+   # Optional. POSIX mount configuration
+   posix: <posix_config>
 
 *******************
 Multi-Configuration
@@ -129,51 +129,37 @@ Merge Rules
 
 * **Profiles**: Combined from all files. Identical profile definitions are allowed (idempotent). Different definitions for the same profile name raise an error.
 * **OpenTelemetry**: Metrics attributes are concatenated. Reader and exporter must be identical across all files or defined in only one file.
-* **Path Mapping / Experimental Features**: Entries are merged. Identical entries are allowed. Conflicting entries raise an error.
+* **Path Mapping**: Entries are merged. Identical entries are allowed. Conflicting entries raise an error.
 * **Cache / POSIX**: Must be identical across all files or defined in only one file.
 
-*********************
-Experimental Features
-*********************
+*****
+POSIX
+*****
 
-The ``experimental_features`` section allows you to enable experimental features that are under active development.
-These features may have breaking changes in future releases.
+The top-level ``posix`` section configures POSIX filesystem mounts when MSFS reads an MSC-compatible configuration file.
 
-.. warning::
-   Experimental features are not guaranteed to be stable and may change or be removed in future versions.
-   Use with caution in production environments.
+.. list-table::
+   :header-rows: 1
 
-Currently available experimental features:
+   * - Option
+     - Default
+     - Description
+   * - ``mountname``
+     - ``msfs``
+     - FUSE mount name that appears in commands such as ``mount`` and ``df``.
+   * - ``mountpoint``
+     - ``${MSFS_MOUNTPOINT:-/mnt}``
+     - Filesystem path where the FUSE mount is created.
+   * - ``allow_other``
+     - ``true``
+     - Allows users other than the one launching the tool to see the mountpoint.
+   * - ``auto_sighup_interval``
+     - ``0``
+     - Time in seconds between config re-reads. ``0`` requires an explicit ``SIGHUP``.
 
-* ``cache_mru_eviction``
+.. note::
 
-  * Enables the MRU (Most Recently Used) eviction policy for cache (boolean, default: not enabled)
-
-* ``cache_purge_factor``
-
-  * Enables the purge_factor parameter for controlling cache eviction aggressiveness (boolean, default: not enabled)
-
-.. code-block:: yaml
-   :caption: Example: Enable specific experimental features
-
-   experimental_features:
-     cache_mru_eviction: true
-     cache_purge_factor: true
-
-   cache:
-     size: "10G"
-     eviction_policy:
-       policy: mru           # Requires cache_mru_eviction: true
-       purge_factor: 50      # Requires cache_purge_factor: true
-
-If you attempt to use an experimental feature without enabling it, you'll receive a clear error message:
-
-.. code-block:: text
-
-   ValueError: MRU eviction policy is experimental and not enabled.
-   Enable it by adding to config:
-     experimental_features:
-       cache_mru_eviction: true
+   These defaults reflect MSFS runtime behavior after translating the MSC-compatible ``posix`` section into MSFS mount settings.
 
 *******
 Profile
@@ -588,14 +574,11 @@ Options: See parameters in :py:class:`multistorageclient.providers.huggingface.H
 
    For detailed configuration instructions, see the `HuggingFace documentation <https://huggingface.co/docs/huggingface_hub/en/guides/download#faster-downloads>`_.
 
-``rust_client`` (experimental)
-------------------------------
-
-.. warning::
-   The Rust client is an experimental feature starting from v0.24 and is subject to change in future releases.
+``rust_client``
+---------------
 
 Due to Python's Global Interpreter Lock (GIL), achieving optimal multi-threading performance within a single Python process is challenging.
-To address this limitation, MSC introduces an experimental Rust client, which aims to improve performance in multi-threaded scenarios.
+To address this limitation, MSC provides a Rust client, which aims to improve performance in multi-threaded scenarios.
 
 To enable the Rust client, add the ``rust_client`` option to your storage provider configuration.
 
@@ -982,12 +965,12 @@ Options:
 
     * ``"fifo"``: First In, First Out (stable)
     * ``"lru"``: Least Recently Used (stable)
-    * ``"mru"``: Most Recently Used (**experimental** - requires ``cache_mru_eviction: true``)
+    * ``"mru"``: Most Recently Used
     * ``"random"``: Random eviction (stable)
 
   * ``refresh_interval``: Interval in seconds to trigger cache eviction (optional, minimum: ``"1"``, default: ``"300"``)
 
-  * ``purge_factor``: (**experimental** - requires ``cache_purge_factor: true``) Percentage of cache to delete during eviction (0-100, optional, default: ``"0"``)
+  * ``purge_factor``: Percentage of cache to delete during eviction (0-100, optional, default: ``"0"``)
 
     * ``0`` = Delete only what's needed to stay under limit (default behavior)
     * ``20`` = Delete 20% of max cache size (keep 80%)
@@ -1022,10 +1005,7 @@ Options:
        refresh_interval: 3600
 
 .. code-block:: yaml
-   :caption: Example configuration with purge_factor to reduce eviction frequency (experimental).
-
-   experimental_features:
-     cache_purge_factor: true  # Enable experimental feature
+   :caption: Example configuration with purge_factor to reduce eviction frequency.
 
    cache:
      size: 500G
@@ -1036,11 +1016,7 @@ Options:
        purge_factor: 20  # Delete 20% during eviction (keep 400GB free space)
 
 .. code-block:: yaml
-   :caption: Example configuration with MRU eviction policy (experimental).
-
-   experimental_features:
-     cache_mru_eviction: true    # Enable experimental feature
-     cache_purge_factor: true    # Enable experimental feature
+   :caption: Example configuration with MRU eviction policy.
 
    cache:
      size: 500G

--- a/multi-storage-client-docs/src/user_guide/cache.rst
+++ b/multi-storage-client-docs/src/user_guide/cache.rst
@@ -213,11 +213,11 @@ Available eviction policies:
 
 * **LRU (Least Recently Used)**: Evicts files that haven't been accessed recently, keeping frequently accessed files in cache. Best for workloads with temporal locality where recent files are likely to be accessed again.
 
-* **MRU (Most Recently Used)** (**Experimental**): Evicts the most recently accessed files first, keeping older files in cache. Useful for workloads that scan through datasets sequentially and are unlikely to re-access recently read files. Requires ``experimental_features: {cache_mru_eviction: true}`` in config.
+* **MRU (Most Recently Used)**: Evicts the most recently accessed files first, keeping older files in cache. Useful for workloads that scan through datasets sequentially and are unlikely to re-access recently read files.
 
 * **RANDOM**: Randomly selects files for eviction (except the most recently added file). Provides unpredictable but fair eviction behavior.
 
-The ``purge_factor`` parameter (**Experimental**) controls how aggressively the cache is cleaned during eviction. It specifies the percentage of maximum cache size to delete (0-100) when eviction is triggered, reducing the frequency of future eviction cycles. Requires ``experimental_features: {cache_purge_factor: true}`` in config.
+The ``purge_factor`` parameter controls how aggressively the cache is cleaned during eviction. It specifies the percentage of maximum cache size to delete (0-100) when eviction is triggered, reducing the frequency of future eviction cycles.
 
 * ``purge_factor = 0`` (default): Delete only what's needed to stay just under the cache limit. This provides minimal cleanup and may trigger frequent evictions.
 * ``purge_factor = 20``: Delete 20% of max cache size. For a 100GB cache, this keeps 80GB after eviction, providing 20GB of free space.
@@ -227,11 +227,7 @@ The ``purge_factor`` parameter (**Experimental**) controls how aggressively the 
 Use higher purge factors (20-50%) when you want to reduce eviction frequency at the cost of some cache hits. Use ``purge_factor=0`` (default) when cache hit rate is more important than eviction frequency. Consider your workload patterns: if cache fills up quickly and frequently, a moderate purge factor (20-30%) can improve performance by reducing lock contention during eviction.
 
 .. code-block:: yaml
-   :caption: Example configuration with purge_factor for aggressive cleanup (experimental).
-
-   experimental_features:
-     cache_mru_eviction: true      # Enable MRU policy
-     cache_purge_factor: true      # Enable purge_factor
+   :caption: Example configuration with purge_factor for aggressive cleanup.
 
    cache:
      size: 500G

--- a/multi-storage-client-docs/src/user_guide/explorer.rst
+++ b/multi-storage-client-docs/src/user_guide/explorer.rst
@@ -4,10 +4,6 @@ Web User Interface (MSC Explorer)
 
 The Multi-Storage Client (MSC) Explorer is a web-based user interface that provides a graphical way to browse and view files across multiple storage backends. It complements the CLI and Python SDK by offering a visual, read-only interface for users who prefer point-and-click interactions to explore their data.
 
-.. note::
-
-   The Web User Interface is currently an **experimental feature**. Functionality and interfaces may change in future releases.
-
 ********
 Overview
 ********
@@ -75,4 +71,3 @@ See :doc:`/references/configuration` for details on how to configure storage pro
    * :doc:`/user_guide/cli` - MSC Command Line Interface
    * :doc:`/user_guide/quickstart` - Getting started with MSC configuration
    * :doc:`/references/configuration` - Complete configuration reference
-

--- a/multi-storage-client-docs/src/user_guide/rust.rst
+++ b/multi-storage-client-docs/src/user_guide/rust.rst
@@ -2,10 +2,7 @@
 Rust Client
 ###########
 
-The MSC Rust Client is an experimental feature that provides enhanced performance for storage operations by leveraging Rust.
-
-.. warning::
-   The Rust Client is an experimental feature starting from v0.24 and is subject to change in future releases.
+The MSC Rust Client provides enhanced performance for storage operations by leveraging Rust.
 
 ********
 Overview

--- a/multi-storage-client/src/multistorageclient/config.py
+++ b/multi-storage-client/src/multistorageclient/config.py
@@ -637,7 +637,6 @@ class StorageClientConfigLoader:
         self._telemetry_provider = telemetry_provider or telemetry_init
 
         self._cache_dict = config_dict.get("cache", None)
-        self._experimental_features = config_dict.get("experimental_features", None)
 
         self._provider_bundle = self._build_provider_bundle(provider_bundle)
         self._inject_profiles_from_bundle()
@@ -991,37 +990,6 @@ class StorageClientConfigLoader:
                     f"This creates a circular reference which is not allowed."
                 )
 
-    # todo: remove once experimental features are stable
-    def _validate_experimental_features(self, eviction_policy: EvictionPolicyConfig) -> None:
-        """
-        Validate that experimental features are enabled when used.
-
-        :param eviction_policy: The eviction policy configuration to validate
-        :raises ValueError: If experimental features are used without being enabled
-        """
-        # Validate MRU eviction policy
-        if eviction_policy.policy.upper() == "MRU":
-            if not (self._experimental_features and self._experimental_features.get("cache_mru_eviction")):
-                raise ValueError(
-                    "MRU eviction policy is experimental and not enabled.\n"
-                    "Enable it by adding to config:\n"
-                    "  experimental_features:\n"
-                    "    cache_mru_eviction: true"
-                )
-
-        # Validate purge_factor
-        if eviction_policy.purge_factor != 0:
-            if eviction_policy.purge_factor < 0 or eviction_policy.purge_factor > 100:
-                raise ValueError("purge_factor must be between 0 and 100")
-
-            if not (self._experimental_features and self._experimental_features.get("cache_purge_factor")):
-                raise ValueError(
-                    "purge_factor is experimental and not enabled.\n"
-                    "Enable it by adding to config:\n"
-                    "  experimental_features:\n"
-                    "    cache_purge_factor: true"
-                )
-
     def build_config(self) -> "StorageClientConfig":
         bundle = self._provider_bundle
         backends = bundle.storage_backends
@@ -1131,10 +1099,6 @@ class StorageClientConfigLoader:
                 )
             else:
                 eviction_policy = EvictionPolicyConfig(policy="fifo", refresh_interval=DEFAULT_CACHE_REFRESH_INTERVAL)
-
-            # todo: remove once experimental features are stable
-            # Validate experimental features before creating cache_config
-            self._validate_experimental_features(eviction_policy)
 
             # Create cache config from the standardized format
             cache_config = CacheConfig(

--- a/multi-storage-client/src/multistorageclient/schema.py
+++ b/multi-storage-client/src/multistorageclient/schema.py
@@ -217,10 +217,7 @@ CONFIG_SCHEMA = {
         },
         "experimental_features": {
             "type": "object",
-            "properties": {
-                "cache_mru_eviction": {"type": "boolean"},
-                "cache_purge_factor": {"type": "boolean"},
-            },
+            "properties": {},
             "additionalProperties": False,
         },
         "profiles": PROFILE_SCHEMA,

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_config.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_config.py
@@ -2059,41 +2059,11 @@ def test_telemetry_init_automatic() -> None:
         assert config.telemetry_provider is not None
 
 
-# todo: remove test once experimental features are stable
-def test_experimental_features_mru_disabled():
-    """Test that MRU eviction policy requires experimental_features flag."""
+def test_mru_eviction_policy_does_not_require_experimental_feature():
+    """Test that MRU eviction policy is a stable cache feature."""
     with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
         profile = "data"
         config_dict = {
-            "profiles": {
-                profile: {
-                    **temp_data_store.profile_config_dict(),
-                    "caching_enabled": True,
-                }
-            },
-            "cache": {
-                "size": "10M",
-                "cache_line_size": "1M",  # Set explicitly to avoid default 64M exceeding cache size
-                "eviction_policy": {
-                    "policy": "mru",  # Experimental feature
-                },
-            },
-            # No experimental_features key
-        }
-
-        with pytest.raises(ValueError, match="MRU eviction policy is experimental"):
-            StorageClientConfig.from_dict(config_dict=config_dict, profile=profile)
-
-
-# todo: remove test once experimental features are stable
-def test_experimental_features_mru_enabled():
-    """Test that MRU eviction policy works when experimental_features flag is set."""
-    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
-        profile = "data"
-        config_dict = {
-            "experimental_features": {
-                "cache_mru_eviction": True,
-            },
             "profiles": {
                 profile: {
                     **temp_data_store.profile_config_dict(),
@@ -2114,42 +2084,11 @@ def test_experimental_features_mru_enabled():
         assert config.cache_config.eviction_policy.policy == "mru"
 
 
-# todo: remove test once experimental features are stable
-def test_experimental_features_purge_factor_disabled():
-    """Test that purge_factor requires experimental_features flag."""
+def test_purge_factor_does_not_require_experimental_feature():
+    """Test that purge_factor is a stable cache feature."""
     with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
         profile = "data"
         config_dict = {
-            "profiles": {
-                profile: {
-                    **temp_data_store.profile_config_dict(),
-                    "caching_enabled": True,
-                }
-            },
-            "cache": {
-                "size": "10M",
-                "cache_line_size": "1M",  # Set explicitly to avoid default 64M exceeding cache size
-                "eviction_policy": {
-                    "policy": "lru",
-                    "purge_factor": 50,  # Experimental feature
-                },
-            },
-            # No experimental_features key
-        }
-
-        with pytest.raises(ValueError, match="purge_factor is experimental"):
-            StorageClientConfig.from_dict(config_dict=config_dict, profile=profile)
-
-
-# todo: remove test once experimental features are stable
-def test_experimental_features_purge_factor_enabled():
-    """Test that purge_factor works when experimental_features flag is set."""
-    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
-        profile = "data"
-        config_dict = {
-            "experimental_features": {
-                "cache_purge_factor": True,
-            },
             "profiles": {
                 profile: {
                     **temp_data_store.profile_config_dict(),
@@ -2171,9 +2110,35 @@ def test_experimental_features_purge_factor_enabled():
         assert config.cache_config.eviction_policy.purge_factor == 50
 
 
-# todo: remove test once experimental features are stable
-def test_experimental_features_both_enabled():
-    """Test that both MRU and purge_factor work together."""
+def test_mru_and_purge_factor_do_not_require_experimental_features():
+    """Test that MRU and purge_factor can be used together without feature flags."""
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
+        profile = "data"
+        config_dict = {
+            "profiles": {
+                profile: {
+                    **temp_data_store.profile_config_dict(),
+                    "caching_enabled": True,
+                }
+            },
+            "cache": {
+                "size": "10M",
+                "cache_line_size": "1M",  # Set explicitly to avoid default 64M exceeding cache size
+                "eviction_policy": {
+                    "policy": "mru",
+                    "purge_factor": 50,
+                },
+            },
+        }
+
+        config = StorageClientConfig.from_dict(config_dict=config_dict, profile=profile)
+        assert config.cache_config is not None
+        assert config.cache_config.eviction_policy.policy == "mru"
+        assert config.cache_config.eviction_policy.purge_factor == 50
+
+
+def test_experimental_features_config_is_rejected():
+    """Test that removed experimental feature flags are no longer accepted."""
     with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
         profile = "data"
         config_dict = {
@@ -2197,10 +2162,52 @@ def test_experimental_features_both_enabled():
             },
         }
 
+        with pytest.raises(RuntimeError, match="Failed to validate the config file"):
+            StorageClientConfig.from_dict(config_dict=config_dict, profile=profile)
+
+
+def test_empty_experimental_features_config_is_allowed():
+    """Test that experimental_features remains available for future feature flags."""
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
+        profile = "data"
+        config_dict = {
+            "experimental_features": {},
+            "profiles": {
+                profile: {
+                    **temp_data_store.profile_config_dict(),
+                    "caching_enabled": True,
+                }
+            },
+            "cache": {
+                "size": "10M",
+                "cache_line_size": "1M",
+                "eviction_policy": {
+                    "policy": "mru",
+                    "purge_factor": 50,
+                },
+            },
+        }
+
         config = StorageClientConfig.from_dict(config_dict=config_dict, profile=profile)
         assert config.cache_config is not None
         assert config.cache_config.eviction_policy.policy == "mru"
         assert config.cache_config.eviction_policy.purge_factor == 50
+
+
+def test_empty_experimental_features_configs_merge():
+    """Test that empty experimental_features sections merge cleanly."""
+    base_config = {
+        "experimental_features": {},
+        "profiles": {},
+    }
+    new_config = {
+        "experimental_features": {},
+        "profiles": {},
+    }
+
+    merged = _merge_configs(base_config, new_config, "base.yaml", "new.yaml")
+
+    assert merged["experimental_features"] == {}
 
 
 def test_storage_client_config_validation_both_provider_types():

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_utils.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_utils.py
@@ -235,20 +235,13 @@ def test_merge_dictionaries_no_overwrite_allow_idempotent():
         "path_mapping": {
             "s3://bucket/data/": "msc://profile-a/",
             "gs://bucket/data/": "msc://profile-b/",
-        },
-        "experimental_features": {
-            "cache_mru_eviction": True,
-        },
+        }
     }
     dict_b = {
         "path_mapping": {
             "s3://bucket/data/": "msc://profile-a/",  # Identical - idempotent
             "s3://bucket2/data/": "msc://profile-c/",  # New key
-        },
-        "experimental_features": {
-            "cache_mru_eviction": True,  # Identical - idempotent
-            "cache_purge_factor": False,  # New key
-        },
+        }
     }
 
     merged, conflicts = merge_dictionaries_no_overwrite(dict_a, dict_b, allow_idempotent=True)
@@ -258,9 +251,6 @@ def test_merge_dictionaries_no_overwrite_allow_idempotent():
     assert len(merged["path_mapping"]) == 3
     assert merged["path_mapping"]["s3://bucket/data/"] == "msc://profile-a/"
     assert merged["path_mapping"]["s3://bucket2/data/"] == "msc://profile-c/"
-    assert len(merged["experimental_features"]) == 2
-    assert merged["experimental_features"]["cache_mru_eviction"] is True
-    assert merged["experimental_features"]["cache_purge_factor"] is False
 
     # Test case 2: Conflict - same key, different value, conflict even with allow_idempotent=True
     dict_a = {


### PR DESCRIPTION
## Description

- Promote local cache MRU eviction and `purge_factor` from experimental-gated options to stable cache configuration.
- Keep `experimental_features` as a reserved top-level config extension point, while removing the retired cache feature flags.
- Remove experimental wording from MSC docs for local caching, Rust Client, and MSC Explorer Web UI.

Relates to NGCDP-9152

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cache settings now support **MRU** eviction and **`purge_factor`** without requiring experimental flags.
  * POSIX filesystem mounts are now documented under a top-level `posix` section.

* **Bug Fixes**
  * Removed validation failures caused by outdated experimental cache options.
  * Improved consistency of config merging and schema validation around cache/POSIX and related rules.

* **Documentation**
  * Updated the configuration reference by removing the top-level `experimental_features` section and adjusting schema examples.
  * Updated cache, Rust client, and explorer documentation to remove “experimental” framing for stable features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->