### PR TITLE
chore: Decouple MSFS from MSC.

### DIFF
--- a/.github/workflows/.source.yml
+++ b/.github/workflows/.source.yml
@@ -194,7 +194,7 @@ jobs:
       - id: build-cache
         uses: actions/cache@v5
         with:
-          key: multi-storage-file-system-${{ hashFiles('flake.lock', 'flake.nix', 'nix/**/*', 'multi-storage-client/pyproject.toml', 'multi-storage-file-system/**/*') }}
+          key: multi-storage-file-system-${{ hashFiles('flake.lock', 'flake.nix', 'nix/**/*', 'multi-storage-file-system/**/*') }}
           path: |
             -
             multi-storage-file-system/build/debian/archives/*.deb

--- a/.gitlab/pipelines/.source.yml
+++ b/.gitlab/pipelines/.source.yml
@@ -199,7 +199,6 @@ multi-storage-file-system:
         - flake.lock
         - flake.nix
         - nix/**/*
-        - multi-storage-client/pyproject.toml
         - multi-storage-file-system/**/*
     - when: manual
       allow_failure: true

--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -1,17 +1,7 @@
 <!-- Add items anywhere within the relevant section to avoid merge conflicts. Only add entries for complete end-to-end features, not partial implementations. -->
 
-## Multi-Storage Client (MSC)
+## Breaking Changes
 
-### Breaking Changes
+## New Features
 
-### New Features
-
-### Bug Fixes
-
-## Multi-Storage File System (MSFS)
-
-### Breaking Changes
-
-### New Features
-
-### Bug Fixes
+## Bug Fixes

--- a/multi-storage-client-docs/src/user_guide/multi_storage_file_system.rst
+++ b/multi-storage-client-docs/src/user_guide/multi_storage_file_system.rst
@@ -17,7 +17,7 @@ While the Python Multi-Storage Client is designed for easy adoption of object st
 .. note::
 
    **Current Release Focus: Read Operations**
-   
+
    This release of MSFS fully supports the default read-only mode. If a backend has writes enabled, only a few modifying operations are currently supported (mkdir, rmdir, and unlink). The bulk of write support (i.e. file creation and file modification) is planned for a future release.
 
 Key Features
@@ -33,62 +33,33 @@ Key Features
 Installation
 ============
 
-Download from GitHub Releases
-=============================
+Download from GitHub Actions Artifacts
+======================================
 
-The easiest way to install MSFS is to download pre-built packages from the `GitHub releases page <https://github.com/NVIDIA/multi-storage-client/releases>`_.
+The easiest way to install MSFS is to download pre-built packages from our GitHub Actions artifacts.
 
-Download the release archive:
+Download the artifact archive:
 
-#. Navigate to the `releases page <https://github.com/NVIDIA/multi-storage-client/releases>`_
-#. Download either ``msfs.zip`` or ``msfs.tar.gz`` from the latest release assets
+#. Navigate to the `GitHub Actions Default Branch workflow <https://github.com/NVIDIA/multi-storage-client/actions/workflows/default_branch.yml>`_
+#. Select a workflow run for the desired commit
+#. Download the ``multi-storage-file-system`` artifact
 
 Extract the archive:
 
 .. code-block:: bash
-   :caption: Extract the release archive.
+   :caption: Extract the artifact archive.
 
-   # For ZIP archive
-   unzip msfs.zip
-
-   # For TAR.GZ archive
-   tar -xzf msfs.tar.gz
+   unzip multi-storage-file-system.zip
 
 The archive contains:
 
 - **RPM packages**: ``msfs-<version>-1.x86_64.rpm`` and ``msfs-<version>-1.aarch64.rpm``
 - **DEB packages**: ``msfs_<version>_amd64.deb`` and ``msfs_<version>_arm64.deb``
-- **Install script**: ``msfs_install.sh``
-- **Uninstall script**: ``msfs_uninstall.sh``
-
-Install MSFS:
-
-.. code-block:: bash
-   :caption: Install MSFS using the install script.
-
-   sudo ./msfs_install.sh
-
-The install script automatically:
-
-- **Detects your system architecture** (x86_64 or aarch64) using ``uname -m``
-- **Detects your package manager** (dpkg for Debian/Ubuntu or rpm for RHEL/CentOS/Fedora)
-- **Selects and installs the correct package** for your system
-
-You do not need to manually specify which package to install. The script handles architecture and package format detection automatically.
-
-Uninstall MSFS:
-
-.. code-block:: bash
-   :caption: Uninstall MSFS using the uninstall script.
-
-   sudo ./msfs_uninstall.sh
-
-The uninstall script automatically detects your package manager and removes MSFS accordingly.
 
 After installation, MSFS provides:
 
-- ``/usr/local/bin/msfs`` - The FUSE daemon binary
-- ``/usr/sbin/mount.msfs`` - Mount helper for standard ``mount`` command
+- ``/usr/bin/msfs`` - The FUSE daemon binary
+- ``/usr/bin/mount.msfs`` - Mount helper for standard ``mount`` command
 
 Build from Source
 =================
@@ -121,7 +92,7 @@ See :doc:`/references/configuration` for the complete MSC configuration schema.
 .. note::
 
    **Advanced Configuration Mode**
-   
+
    For advanced users requiring fine-grained control over FUSE behavior, caching parameters, and other low-level settings, MSFS provides an extended configuration mode (``msfs_version: 1``). This advanced mode is intended for specialized use cases and performance tuning. For details, see the `MSFS README <https://github.com/NVIDIA/multi-storage-client/blob/main/multi-storage-file-system/README.md>`_.
 
 Environment Variables
@@ -144,7 +115,7 @@ Configuration files support environment variable expansion using ``$VAR`` or ``$
 
 - ``MSC_CONFIG`` - Path to configuration file
 - ``MSFS_MOUNTPOINT`` - Mount point (overrides config file setting)
-- ``MSFS_BINARY`` - Path to msfs binary (default: ``/usr/local/bin/msfs``)
+- ``MSFS_BINARY`` - Path to msfs binary (default: ``/usr/bin/msfs``)
 - ``MSFS_LOG_DIR`` - Log directory (default: ``/var/log/msfs``)
 
 Usage
@@ -159,7 +130,7 @@ Manual mount/unmount using the MSFS binary directly:
 
    # Start MSFS daemon with config file
    export MSC_CONFIG=/path/to/config.yaml
-   /usr/local/bin/msfs
+   /usr/bin/msfs
 
    # In another terminal, verify mount
    mount | grep msfs
@@ -191,7 +162,7 @@ Mounting
 
 **How It Works:**
 
-When you run ``mount -t msfs <config> <mountpoint>``, the ``mount`` command automatically calls ``/usr/sbin/mount.msfs``, which:
+When you run ``mount -t msfs <config> <mountpoint>``, the ``mount`` command automatically calls ``/usr/bin/mount.msfs``, which:
 
 1. Exports ``MSC_CONFIG`` environment variable from the config file argument
 2. Exports ``MSFS_MOUNTPOINT`` environment variable from the mountpoint argument
@@ -202,7 +173,7 @@ When you run ``mount -t msfs <config> <mountpoint>``, the ``mount`` command auto
 .. note::
 
    The ``mount`` command behaves differently based on arguments:
-   
+
    - ``mount`` (no args) → Lists all mounted filesystems
    - ``mount -t msfs`` (type only) → Lists all MSFS filesystems (does NOT call mount.msfs)
    - ``mount -t msfs <config> <mountpoint>`` → Calls mount.msfs to perform the mount
@@ -240,7 +211,7 @@ MSFS filesystems can be automatically mounted at boot time using ``/etc/fstab``:
 2. **Mount Point** - Directory where the filesystem will be mounted
 3. **Type** - Filesystem type (``msfs``)
 4. **Options** - Mount options (comma-separated):
-   
+
    - ``defaults`` - Standard mount options
    - ``_netdev`` - Wait for network before mounting (recommended for remote storage)
    - ``noauto`` - Don't mount automatically at boot (mount manually)
@@ -255,7 +226,7 @@ After editing ``/etc/fstab``, test the configuration:
 
    # Mount all filesystems in fstab
    sudo mount -a
-   
+
    # Verify mount
    df -h /mnt/s3-data
 
@@ -417,13 +388,13 @@ Enable metrics collection by adding observability configuration:
                deployment.environment: production
          - type: host
          - type: process
-       
+
        reader:
          type: periodic
          options:
            collect_interval_millis: 1000
            export_interval_millis: 60000
-       
+
        exporter:
          type: otlp
          options:
@@ -551,7 +522,7 @@ Build optimized binaries for production deployment:
 .. code-block:: bash
 
    cd multi-storage-file-system
-   
+
    # Build for current platform
    make
 
@@ -572,15 +543,15 @@ Deploy MSFS using Docker containers:
    :caption: Dockerfile for MSFS deployment
 
    FROM ubuntu:22.04
-   
+
    RUN apt-get update && apt-get install -y fuse
-   
-   COPY msfs-linux-amd64 /usr/local/bin/msfs
-   COPY mount.msfs /usr/sbin/mount.msfs
-   
-   RUN chmod +x /usr/local/bin/msfs /usr/sbin/mount.msfs
-   
-   CMD ["/usr/local/bin/msfs"]
+
+   COPY msfs-linux-amd64 /usr/bin/msfs
+   COPY mount.msfs /usr/bin/mount.msfs
+
+   RUN chmod +x /usr/bin/msfs /usr/bin/mount.msfs
+
+   CMD ["/usr/bin/msfs"]
 
 .. code-block:: bash
 

--- a/multi-storage-client-scripts/src/multistorageclient_scripts/cli/publish_release/__init__.py
+++ b/multi-storage-client-scripts/src/multistorageclient_scripts/cli/publish_release/__init__.py
@@ -107,28 +107,10 @@ def func(arguments: Arguments) -> argparse_extensions.CommandFunction.ExitCode:
             )
         )
 
-        multi_storage_file_system_artifacts = pathlib.Path("../multi-storage-file-system/build").resolve()
-        multi_storage_file_system_debs = [
-            *multi_storage_file_system_artifacts.glob(f"debian/archives/*_{str(multi_storage_client_version)}_*.deb")
-        ]
-        multi_storage_file_system_rpms = [
-            *multi_storage_file_system_artifacts.glob(f"rpm/RPMS/*/*-{str(multi_storage_client_version)}-*.rpm")
-        ]
-        multi_storage_file_system_tars = [
-            *multi_storage_file_system_artifacts.glob(f"tar/*-{str(multi_storage_client_version)}-*.tar.*")
-        ]
-        multi_storage_file_system_zips = [
-            *multi_storage_file_system_artifacts.glob(f"zip/*-{str(multi_storage_client_version)}-*.zip")
-        ]
-
         release_assets = sorted(
             [
                 *multi_storage_client_wheels,
                 multi_storage_client_docs_archive,
-                *multi_storage_file_system_debs,
-                *multi_storage_file_system_rpms,
-                *multi_storage_file_system_tars,
-                *multi_storage_file_system_zips,
             ]
         )
 
@@ -169,22 +151,6 @@ def func(arguments: Arguments) -> argparse_extensions.CommandFunction.ExitCode:
 
         if len(multi_storage_client_wheels) == 0:
             raise FileNotFoundError(f"Missing multi-storage-client wheels in {str(multi_storage_client_artifacts)}!")
-        if len(multi_storage_file_system_debs) == 0:
-            raise FileNotFoundError(
-                f"Missing multi-storage-file-system debs in {str(multi_storage_file_system_artifacts)}!"
-            )
-        if len(multi_storage_file_system_rpms) == 0:
-            raise FileNotFoundError(
-                f"Missing multi-storage-file-system rpms in {str(multi_storage_file_system_artifacts)}!"
-            )
-        if len(multi_storage_file_system_tars) == 0:
-            raise FileNotFoundError(
-                f"Missing multi-storage-file-system tars in {str(multi_storage_file_system_artifacts)}!"
-            )
-        if len(multi_storage_file_system_zips) == 0:
-            raise FileNotFoundError(
-                f"Missing multi-storage-file-system zips in {str(multi_storage_file_system_artifacts)}!"
-            )
 
         for multi_storage_client_wheel in multi_storage_client_wheels:
             name, version, _, _ = packaging.utils.parse_wheel_filename(str(multi_storage_client_wheel.name))

--- a/multi-storage-file-system/Dockerfile.csi
+++ b/multi-storage-file-system/Dockerfile.csi
@@ -6,13 +6,13 @@
 # Stage 1: Build the MSFS binary
 FROM golang:1.25.4-bookworm AS msfs-builder
 ARG TARGETARCH
-ARG GIT_TAG=dev
+ARG VERSION=dev
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath \
-    -ldflags="-s -w -X main.GitTag=${GIT_TAG}" \
+    -ldflags="-s -w -X main.Version=${VERSION}" \
     -o /out/msfs .
 
 # Stage 2: Build the CSI driver binary

--- a/multi-storage-file-system/Makefile
+++ b/multi-storage-file-system/Makefile
@@ -2,9 +2,10 @@ quick: build
 
 all: fmt generate build lint test bench cover assets
 
-GIT_TAG := $(shell git describe --tags --always --dirty)
-BUILD_LDFLAGS := -ldflags="-X 'main.GitTag=$(GIT_TAG)'"
-TEST_LDFLAGS := -ldflags="-X 'github.com/NVIDIA/multi-storage-client/multi-storage-file-system/msfs.GitTag=$(GIT_TAG)'"
+VERSION := 0.100.0
+GIT_REVISION := $(shell git rev-parse HEAD)
+BUILD_LDFLAGS := -ldflags="-X 'main.Version=$(VERSION).$(GIT_REVISION)'"
+TEST_LDFLAGS := -ldflags="-X 'github.com/NVIDIA/multi-storage-client/multi-storage-file-system/msfs.VERSION=$(VERSION).$(GIT_REVISION)'"
 NATIVE_GOARCH := $(shell go env GOARCH)
 NATIVE_UNAMEM := $(shell uname -m)
 
@@ -119,7 +120,7 @@ assets: deb-packages rpm-packages
 
 # Debian package variables
 DEB_PACKAGE_NAME := msfs
-DEB_VERSION := $(GIT_TAG)
+DEB_VERSION := $(VERSION)
 DEB_MAINTAINER := NVIDIA <multi-storage-client@nvidia.com>
 DEB_DESCRIPTION := Multi-Storage-File-System
 DEB_BUILD_DIR := build/deb
@@ -192,8 +193,7 @@ clean-deb:
 
 # RPM package variables
 RPM_PACKAGE_NAME := msfs
-# RPM_VERSION := $(GIT_TAG)
-RPM_VERSION := $(shell echo $(GIT_TAG) | sed 's/-/_/g')
+RPM_VERSION := $(VERSION)
 RPM_RELEASE := 1
 RPM_MAINTAINER := NVIDIA <multi-storage-client@nvidia.com>
 RPM_SUMMARY := Multi-Storage-File-System

--- a/multi-storage-file-system/backend.go
+++ b/multi-storage-file-system/backend.go
@@ -234,8 +234,8 @@ func recordRequest(backendName, operation string) {
 		return
 	}
 
-	// Get version (matches Python's VERSION attribute)
-	version := GitTag
+	// Get version
+	version := Version
 	if version == "" {
 		version = "dev" // Fallback for development builds
 	}
@@ -262,8 +262,8 @@ func recordBackendMetrics(backendName, operation string, startTime time.Time, er
 	duration := time.Since(startTime)
 	success := (err == nil)
 
-	// Get version (matches Python's VERSION attribute)
-	version := GitTag
+	// Get version
+	version := Version
 	if version == "" {
 		version = "dev" // Fallback for development builds
 	}

--- a/multi-storage-file-system/globals.go
+++ b/multi-storage-file-system/globals.go
@@ -14,12 +14,7 @@ import (
 
 //go:generate go run ./tools/lockgen -dir .
 
-const (
-	GitTagPrefix = "P.01.00 (MSC "
-	GitTagSuffix = ")"
-)
-
-var GitTag string // This variable will be populated at build time
+var Version string // This variable will be populated at build time
 
 const (
 	MSFSVersionPythonCompatibility = uint64(0)
@@ -434,7 +429,7 @@ func initGlobals(osArgs []string) {
 
 	globals.logger = log.New(os.Stdout, "", log.Ldate|log.Ltime|log.Lmsgprefix) // |log.Lmicroseconds|log.Lshortfile
 
-	globals.logger.Printf("[INFO] starting %s version %s", osArgs[0], GitTagPrefix+GitTag+GitTagSuffix)
+	globals.logger.Printf("[INFO] starting %s version %s", osArgs[0], Version)
 
 	globals.backendsSkipped = make(map[string]struct{})
 

--- a/multi-storage-file-system/justfile
+++ b/multi-storage-file-system/justfile
@@ -4,9 +4,8 @@
 # https://just.systems/man/en
 #
 
-# MSFS matches the MSC version.
-version := `cd ../multi-storage-client && uv version --short`
-tag := `git describe --always --dirty`
+version := "0.100.0"
+git-revision := `git rev-parse HEAD`
 
 # List recipes.
 help:
@@ -34,7 +33,7 @@ compile:
     # Linux artifacts are a `/usr` directory overlay (e.g. `/usr/bin`, `/usr/share/man`, `/usr/lib/systemd`).
     set -e; \
     for ARCH in amd64 arm64; do \
-        CGO_ENABLED=0 GOARCH=${ARCH} GOOS=linux go build -ldflags "-X main.GitTag={{tag}}" -o build/generic/${ARCH}-linux/bin/msfs . && \
+        CGO_ENABLED=0 GOARCH=${ARCH} GOOS=linux go build -ldflags "-X main.Version='{{version}}.{{git-revision}}'" -o build/generic/${ARCH}-linux/bin/msfs . && \
         cp --target-directory build/generic/${ARCH}-linux/bin mount.msfs; \
     done
 

--- a/multi-storage-file-system/main.go
+++ b/multi-storage-file-system/main.go
@@ -75,7 +75,7 @@ func main() {
 		fmt.Printf("    ${XDG_CONFIG_DIRS:-/etc/xdg}/msc/config.{yaml|yml|json}\n")
 		fmt.Printf("    /etc/msc_config.{yaml|yml|json}\n")
 		fmt.Printf("version:\n")
-		fmt.Printf("  %s\n", GitTagPrefix+GitTag+GitTagSuffix)
+		fmt.Printf("  %s\n", Version)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
## Description

Decouple MSFS from MSC.

Extends https://github.com/NVIDIA/multi-storage-client/pull/85.

We no longer want to share the MSFS and MSC version numbers. MSFS will now use its own versioning scheme (`{version}.{Git revision}` for full version, `{version}` for DEB + RPM packages. For example, `0.100.0.2e9cefa4c9111961dd3efe06dbce7ff69214ff80` and `0.100.0`).

Since these version numbers are no longer bumped in lockstep, it doesn't make sense for the MSC GitHub releases to include MSFS. Dropping MSFS from the MSC GitHub releases but keeping its assets in CI/CD build artifacts.

Closes NGCDP-8978.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backend observability now records request/operation version using the unified build version (including the current revision) for more consistent metrics.

* **Chores**
  * Standardized MSFS build, packaging, and Docker version metadata to a fixed release version plus the current commit revision.
  * Updated CI caching and pipeline change-detection triggers to better match current build inputs.
  * Streamlined release publishing to focus on client artifacts only and avoid failing when MSFS artifacts are absent.

* **Documentation**
  * Refreshed the MSFS user guide with updated installation-from-artifacts instructions and default `/usr/bin` paths, plus corrected mount-helper references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->