### PR TITLE
fix: correct user guide API examples

### DIFF
--- a/multi-storage-client-docs/src/references/configuration.rst
+++ b/multi-storage-client-docs/src/references/configuration.rst
@@ -664,7 +664,7 @@ than hardcoding them directly in configuration files. See `Environment Variables
 -----------------
 Static credentials provider for Amazon S3 and S3-compatible storage services.
 
-Options: See parameters in :py:class:`multistorageclient.providers.s3,StaticS3CredentialsProvider`.
+Options: See parameters in :py:class:`multistorageclient.providers.s3.StaticS3CredentialsProvider`.
 
 .. code-block:: yaml
    :caption: Example configuration.
@@ -951,9 +951,9 @@ Options:
 
   * Absolute filesystem path for storing cached files (optional, default: system temporary directory + ``"/msc_cache"``)
 
-* ``use_etag``
+* ``check_source_version``
 
-  * Use ETag for cache validation, it introduces a small overhead by checking the Etag agains the remote object on every read (optional, default: ``true``)
+  * Validate the remote object's source version before serving a cached copy (optional, default: ``true``). The legacy ``use_etag`` key is still accepted for backward compatibility, but ``check_source_version`` takes precedence when both are set.
 
 * ``prefetch_file``
 

--- a/multi-storage-client-docs/src/user_guide/cache.rst
+++ b/multi-storage-client-docs/src/user_guide/cache.rst
@@ -82,8 +82,8 @@ Partial file caching is automatically enabled when using ``client.read()`` with 
    from multistorageclient.types import Range
    
    # Create a storage client with configuration
-   config = StorageClientConfig.from_file()  # or from_dict()
-   client = StorageClient(config=config, profile="your_profile")
+   config = StorageClientConfig.from_file(profile="your-profile")  # or from_dict(..., profile="your-profile")
+   client = StorageClient(config=config)
    
    # This will only download the necessary chunks for the specified range
    data = client.read("path/to/large_file.bin", 

--- a/multi-storage-client-docs/src/user_guide/libraries.rst
+++ b/multi-storage-client-docs/src/user_guide/libraries.rst
@@ -78,8 +78,8 @@ This module provides ``load``, ``memmap``, and ``save`` methods for loading and 
 
    # Reuse the client for the data-s3-iad profile and save an array.
    msc.numpy.save(
-       numpy.array([1, 2, 3, 4, 5], dtype=numpy.int32),
-       "msc://data-s3-iad/numpy-arrays/ndarray-2.npz"
+       "msc://data-s3-iad/numpy-arrays/ndarray-2.npy",
+       numpy.array([1, 2, 3, 4, 5], dtype=numpy.int32)
    )
 
 *******
@@ -132,7 +132,7 @@ In addition to the ``load`` and ``save`` methods, the ``torch`` module provides 
 Xarray
 ******
 
-:py:mod:`multistorageclient.xz` aliases the :py:mod:`multistorageclient.contrib.xarray` module.
+:py:mod:`multistorageclient.xarray` aliases the :py:mod:`multistorageclient.contrib.xarray` module.
 
 This module provides ``open_zarr`` for reading Xarray datasets from Zarr files/objects.
 
@@ -142,7 +142,7 @@ This module provides ``open_zarr`` for reading Xarray datasets from Zarr files/o
    import multistorageclient as msc
 
    # Create a client for the data-s3-iad profile and load a Zarr array into an Xarray dataset.
-   xarray_dataset = msc.xz.open_zarr("msc://data-s3-iad/abc.zarr")
+   xarray_dataset = msc.xarray.open_zarr("msc://data-s3-iad/abc.zarr")
 
 Note: ``Xarray`` supports fsspec URLs natively, so you can use Xarray standard interface with ``msc://`` URLs.
 

--- a/multi-storage-client-docs/src/user_guide/manifests.rst
+++ b/multi-storage-client-docs/src/user_guide/manifests.rst
@@ -119,7 +119,7 @@ Referencing Manifests in Configuration
 
 When you set a profile's ``metadata_provider`` to ``type: manifest``, you must also provide the ``manifest_path`` option, which refers to manifest path relative to the storage profile's ``base_path``.
 
-You can also specify the ``format`` option to control the format used when writing new manifests (defaults to ``jsonl``):
+You can also specify the ``manifest_format`` option to control the format used when writing new manifests (defaults to ``jsonl``):
 
 .. code-block:: yaml
    :linenos:
@@ -134,7 +134,7 @@ You can also specify the ``format`` option to control the format used when writi
          type: manifest
          options:
            manifest_path: .msc_manifests
-           format: parquet  # Optional: jsonl (default) or parquet
+           manifest_format: parquet  # Optional: jsonl (default) or parquet
 
 You can also store manifests in a **different** profile than your data. In that case, the ``metadata_provider`` will refer to storage profile using the ``storage_provider_profile`` option. Here's an example:
 
@@ -153,12 +153,12 @@ You can also store manifests in a **different** profile than your data. In that 
          type: s3
          options:
            base_path: my-bucket
-         metadata_provider:
-           type: manifest
-           options:
-             # Refer to the storage profile for the manifests
-             storage_provider_profile: my-manifest-profile
-             # The real path of manifests in this will be manifest-bucket/.msc_manifests
-             manifest_path: .msc_manifests
+       metadata_provider:
+         type: manifest
+         options:
+           # Refer to the storage profile for the manifests
+           storage_provider_profile: my-manifest-profile
+           # The real path of manifests in this will be manifest-bucket/.msc_manifests
+           manifest_path: .msc_manifests
 
 Once configured, MSC automatically uses the manifests to speed up listing or retrieving metadata for objects whenever you perform MSC operations on that profile.

--- a/multi-storage-client-docs/src/user_guide/presigned_urls.rst
+++ b/multi-storage-client-docs/src/user_guide/presigned_urls.rst
@@ -24,7 +24,7 @@ You can also call ``generate_presigned_url`` directly on a :py:class:`~multistor
 
    from multistorageclient import StorageClient, StorageClientConfig
 
-   client = StorageClient(StorageClientConfig.from_file("my-s3-profile"))
+   client = StorageClient(StorageClientConfig.from_file(profile="my-s3-profile"))
    url = client.generate_presigned_url("datasets/model.bin")
 
 To generate a URL that allows the recipient to **upload** an object, pass ``method="PUT"``:

--- a/multi-storage-client-docs/src/user_guide/quickstart.rst
+++ b/multi-storage-client-docs/src/user_guide/quickstart.rst
@@ -123,7 +123,8 @@ The schema is the same as file-based configurations.
                    }
                }
            }
-       }
+       },
+       profile="my-profile",
    )
 
    client = StorageClient(config=config)
@@ -157,11 +158,11 @@ MSC checks for rclone-based configurations with the following priority:
 
 .. note::
 
-   MSC :ref:`file-based` configuration uses different configuration keys than rclone. For example, MSC uses ``endpoint_url`` for :py:class:`multistorageclient.StorageClient.S3StorageProvider` but rclone expects ``endpoint``. MSC aligns with rclone defaults so that if you have a rclone configuration, you can use it with MSC without any modifications on existing keys.
+   MSC :ref:`file-based` configuration uses different configuration keys than rclone. For example, MSC uses ``endpoint_url`` for :py:class:`multistorageclient.providers.s3.S3StorageProvider` but rclone expects ``endpoint``. MSC aligns with rclone defaults so that if you have a rclone configuration, you can use it with MSC without any modifications on existing keys.
 
 .. note::
 
-   Rclone configuration primarily focus on storage access. Some MSC features such as caching and observability cannot be enabled with a rclone configuration. Therefore, MSC allows to use a rclone-based configuration for storage acceess alongside with a built-in :ref:`file-based` configuration for additional features. You can also use the built-in file-based configuration to add extra parameters to an individual profile such as ``metadata_provider``.
+   Rclone configuration primarily focus on storage access. Some MSC features such as caching and observability cannot be enabled with a rclone configuration. Therefore, MSC allows to use a rclone-based configuration for storage access alongside with a built-in :ref:`file-based` configuration for additional features. You can also use the built-in file-based configuration to add extra parameters to an individual profile such as ``metadata_provider``.
 
 .. _operations:
 

--- a/multi-storage-client-docs/src/user_guide/telemetry.rst
+++ b/multi-storage-client-docs/src/user_guide/telemetry.rst
@@ -88,7 +88,7 @@ If the default telemetry provider creation doesn't behave as desired, you can ma
    client.open("file.txt")
 
    # Set the telemetry provider to use when MSC shortcuts create storage clients.
-   multistorageclient.set_telemetry(telemetry_provider=telemetry_provider)
+   multistorageclient.set_telemetry_provider(telemetry_provider=telemetry_provider)
 
    # Use an MSC shortcut to create a storage client for a profile and open an object/file.
    multistorageclient.open("msc://data/file.txt")


### PR DESCRIPTION
## Description

Fixes outdated MSC user guide examples.

Relates to NGCDP-9151

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guidance for storage credentials, cache validation options, and manifest settings.
  * Refreshed quickstart, cache, presigned URL, telemetry, and library examples for correct usage and naming.
  * Clarified profile-based setup patterns and improved explanations for rclone-based configuration.
  * Corrected example file formats and reference names in NumPy and Xarray documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->