### PR TITLE
fix: reject deprecated cache use_etag config

### DIFF
--- a/multi-storage-client-docs/src/references/configuration.rst
+++ b/multi-storage-client-docs/src/references/configuration.rst
@@ -953,7 +953,7 @@ Options:
 
 * ``check_source_version``
 
-  * Validate the remote object's source version before serving a cached copy (optional, default: ``true``). The legacy ``use_etag`` key is still accepted for backward compatibility, but ``check_source_version`` takes precedence when both are set.
+  * Validate the remote object's source version before serving a cached copy (optional, default: ``true``). Configurations that still use ``use_etag`` will fail validation; replace that key with ``check_source_version``.
 
 * ``prefetch_file``
 

--- a/multi-storage-client-docs/src/user_guide/cache.rst
+++ b/multi-storage-client-docs/src/user_guide/cache.rst
@@ -37,12 +37,11 @@ an absolute filesystem path, and the size should be a positive integer with a un
      check_source_version: true   # validate remote object version before serving cached copy
      cache_line_size: 64M         # size of chunks for partial file caching
 
-``check_source_version`` replaces the older ``use_etag`` flag (still accepted
-for backward-compatibility).  The default is ``true`` (MSC validates the
-remote object’s current version — for example via ETag — before serving a
-cached copy).  Set it to ``false`` only if you want to skip that validation
-for performance reasons or when the storage backend lacks a versioning
-mechanism.
+The default is ``true`` (MSC validates the remote object's current version
+before serving a cached copy). Set it to ``false`` only if you want to skip
+that validation for performance reasons or when the storage backend lacks a
+versioning mechanism. Configurations that still use ``use_etag`` will fail
+validation; replace that key with ``check_source_version``.
 
 For detailed configuration options, see :doc:`/references/configuration`
 

--- a/multi-storage-client/.msc/config.yaml
+++ b/multi-storage-client/.msc/config.yaml
@@ -197,7 +197,7 @@ profiles:
         rust_client: {}
 cache:
   size: 20G
-  use_etag: true
+  check_source_version: true
   eviction_policy:
     policy: fifo
     refresh_interval: 300

--- a/multi-storage-client/src/multistorageclient/caching/README.md
+++ b/multi-storage-client/src/multistorageclient/caching/README.md
@@ -19,7 +19,7 @@ from multistorageclient.caching.eviction_policy import LRU, FIFO, RANDOM
 cache_config = CacheConfig(
     location="/path/to/cache",
     size_mb=1000,  # 1GB cache
-    use_etag=True,
+    check_source_version=True,
     eviction_policy=FIFO  # Default is "fifo", can also use "lru" or "random"
 )
 

--- a/multi-storage-client/src/multistorageclient/config.py
+++ b/multi-storage-client/src/multistorageclient/config.py
@@ -1064,18 +1064,7 @@ class StorageClientConfigLoader:
                 # Use cache_backend.cache_path only if location is not explicitly defined
                 location = cache_backend_path
 
-            # Resolve the effective flag while preserving explicit ``False``.
-            if "check_source_version" in self._cache_dict:
-                check_source_version = self._cache_dict["check_source_version"]
-            else:
-                check_source_version = self._cache_dict.get("use_etag", True)
-
-            # Warn if both keys are specified – the new one wins.
-            if "check_source_version" in self._cache_dict and "use_etag" in self._cache_dict:
-                logger.warning(
-                    "Both 'check_source_version' and 'use_etag' are defined in cache config. "
-                    "Using 'check_source_version' and ignoring 'use_etag'."
-                )
+            check_source_version = self._cache_dict.get("check_source_version", True)
 
             if not Path(location).is_absolute():
                 raise ValueError(f"Cache location must be an absolute path: {location}")

--- a/multi-storage-client/src/multistorageclient/schema.py
+++ b/multi-storage-client/src/multistorageclient/schema.py
@@ -60,7 +60,6 @@ CACHE_SCHEMA = {
         },
         "size_mb": {"type": "integer"},
         "location": {"type": "string"},
-        "use_etag": {"type": "boolean"},
         "check_source_version": {"type": "boolean"},
         "prefetch_file": {"type": "boolean"},
         "cache_line_size": {
@@ -240,7 +239,15 @@ BENCHMARK_SCHEMA = {
 }
 
 
+def _reject_deprecated_cache_keys(config_dict: dict[str, Any]) -> None:
+    cache_config = config_dict.get("cache")
+    if isinstance(cache_config, dict) and "use_etag" in cache_config:
+        raise ValueError("cache.use_etag is no longer supported. Use cache.check_source_version instead.")
+
+
 def validate_config(config_dict: dict[str, Any]) -> None:
+    _reject_deprecated_cache_keys(config_dict)
+
     try:
         validate(instance=config_dict, schema=CONFIG_SCHEMA)
     except Exception as e:

--- a/multi-storage-client/tests/test_multistorageclient/unit/mcp/test_mcp_integration.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/mcp/test_mcp_integration.py
@@ -65,7 +65,7 @@ def mcp_server_parametrized(request):
             cache_location = tempfile.mkdtemp()
             config_dict["cache"] = {
                 "size": "10M",
-                "use_etag": True,
+                "check_source_version": True,
                 "location": cache_location,
                 "eviction_policy": {
                     "policy": "random",
@@ -133,7 +133,7 @@ def mcp_server_with_replicas(request):
             cache_location = tempfile.mkdtemp()
             config_dict["cache"] = {
                 "size": "10M",
-                "use_etag": True,
+                "check_source_version": True,
                 "location": cache_location,
                 "eviction_policy": {
                     "policy": "random",

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_storage_providers.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_storage_providers.py
@@ -91,7 +91,7 @@ def test_storage_providers(temp_data_store_type: type[tempdatastore.TemporaryDat
             config_dict["cache"] = {
                 "size": "10M",
                 "cache_line_size": "1M",  # Set explicitly to avoid default 64M exceeding cache size
-                "use_etag": True,
+                "check_source_version": True,
                 "location": cache_location,
                 "eviction_policy": {
                     "policy": "random",

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_cache.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_cache.py
@@ -913,7 +913,7 @@ def create_legacy_cache_config(profile_config, tmpdir):
     """Helper function to create legacy cache config."""
     return {
         "profiles": {"s3-local": profile_config},
-        "cache": {"size_mb": 10, "use_etag": False, "location": str(tmpdir), "eviction_policy": "fifo"},
+        "cache": {"size_mb": 10, "check_source_version": False, "location": str(tmpdir), "eviction_policy": "fifo"},
     }
 
 
@@ -925,7 +925,7 @@ def create_new_cache_config(profile_config, tmpdir):
         "cache": {
             "size": "10M",
             "cache_line_size": "1M",  # Set explicitly to avoid default 64M exceeding cache size
-            "use_etag": False,
+            "check_source_version": False,
             "eviction_policy": {"policy": "random", "refresh_interval": 300},
         },
     }
@@ -935,7 +935,11 @@ def create_mixed_cache_config(profile_config, tmpdir):
     """Helper function to create mixed cache config."""
     return {
         "profiles": {"s3-local": profile_config},
-        "cache": {"size_mb": 10, "use_etag": False, "eviction_policy": {"policy": "random", "refresh_interval": 300}},
+        "cache": {
+            "size_mb": 10,
+            "check_source_version": False,
+            "eviction_policy": {"policy": "random", "refresh_interval": 300},
+        },
     }
 
 

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_config.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_config.py
@@ -1099,7 +1099,7 @@ def test_invalid_cache_config():
         },
         "cache": {
             "size": "invalid",  # Invalid size format
-            "use_etag": True,
+            "check_source_version": True,
             "location": "/tmp/msc_cache",
             "eviction_policy": {"policy": "lru", "refresh_interval": 300},
         },
@@ -1118,7 +1118,7 @@ def test_invalid_cache_config():
         },
         "cache": {
             "size": "200G",
-            "use_etag": True,
+            "check_source_version": True,
             "location": "relative/path",
         },
     }
@@ -1905,46 +1905,25 @@ def _minimal_cache_profile(cache_section: dict) -> dict:
     }
 
 
-def test_cache_config_both_flags_precedence() -> None:
-    """When both `check_source_version` and `use_etag` are set, the former wins."""
+def test_cache_config_rejects_use_etag_with_migration_message() -> None:
+    """cache.use_etag fails with a clear migration message."""
 
     with tempfile.TemporaryDirectory() as cache_dir:
         cfg_dict = _minimal_cache_profile(
             {
                 "size": "10M",
-                "cache_line_size": "1M",  # Set explicitly to avoid default 64M exceeding cache size
-                "location": cache_dir,
-                "check_source_version": False,
-                "use_etag": True,
-            }
-        )
-
-        sc_cfg = StorageClientConfig.from_dict(cfg_dict, profile="p")
-        assert sc_cfg.cache_config is not None
-        # Expect False because check_source_version overrides legacy value
-        assert sc_cfg.cache_config.check_source_version is False
-
-
-def test_cache_config_use_etag() -> None:
-    """only use_etag is set, check_source_version is not set"""
-
-    with tempfile.TemporaryDirectory() as cache_dir:
-        cfg_dict = _minimal_cache_profile(
-            {
-                "size": "10M",
-                "cache_line_size": "1M",  # Set explicitly to avoid default 64M exceeding cache size
+                "cache_line_size": "1M",
                 "location": cache_dir,
                 "use_etag": True,
             }
         )
 
-        sc_cfg = StorageClientConfig.from_dict(cfg_dict, profile="p")
-        assert sc_cfg.cache_config is not None
-        assert sc_cfg.cache_config.check_source_version is True
+        with pytest.raises(ValueError, match="cache.use_etag is no longer supported.*cache.check_source_version"):
+            StorageClientConfig.from_dict(cfg_dict, profile="p")
 
 
 def test_cache_config_check_source_version() -> None:
-    """only check_source_version is set, use_etag is not set, check_source_version is True"""
+    """check_source_version=True enables source version validation."""
 
     with tempfile.TemporaryDirectory() as cache_dir:
         cfg_dict = _minimal_cache_profile(
@@ -1962,7 +1941,7 @@ def test_cache_config_check_source_version() -> None:
 
 
 def test_cache_config_check_source_version_false() -> None:
-    """only check_source_version is set, use_etag is not set, check_source_version is False"""
+    """check_source_version=False disables source version validation."""
 
     with tempfile.TemporaryDirectory() as cache_dir:
         cfg_dict = _minimal_cache_profile(

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_replica_manager.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_replica_manager.py
@@ -80,7 +80,7 @@ def create_cache_config(base_config: ConfigDict) -> ConfigDict:
     config = base_config.copy()
     config["cache"] = {
         "size": "10M",
-        "use_etag": True,
+        "check_source_version": True,
         "location": tempfile.mkdtemp(),
         "eviction_policy": {
             "policy": "random",

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_schema.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_schema.py
@@ -189,7 +189,7 @@ def test_validate_cache():
             },
             "cache": {
                 "size": "50M",
-                "use_etag": True,
+                "check_source_version": True,
                 "location": "/path/to/cache",
                 "eviction_policy": {
                     "policy": "FIFO",
@@ -198,6 +198,20 @@ def test_validate_cache():
             },
         }
     )
+
+    with pytest.raises(ValueError, match="cache.use_etag is no longer supported.*cache.check_source_version"):
+        validate_config(
+            {
+                "profiles": {
+                    "default": default_storage_provider,
+                },
+                "cache": {
+                    "size": "50M",
+                    "use_etag": True,
+                    "location": "/path/to/cache",
+                },
+            }
+        )
 
     with pytest.raises(RuntimeError):
         validate_config(

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_shortcuts.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_shortcuts.py
@@ -836,7 +836,7 @@ def test_open_with_cache_config(temp_data_store_type: Type[tempdatastore.Tempora
     # Clear the instance cache to ensure that the config is not reused from the previous test
     msc.shortcuts._STORAGE_CLIENT_CACHE.clear()
     with temp_data_store_type() as temp_data_store:
-        # Test with cache enabled and use_etag=True
+        # Test with cache enabled and check_source_version=True
         profile_config = temp_data_store.profile_config_dict()
         profile_config["caching_enabled"] = True
 
@@ -848,7 +848,7 @@ def test_open_with_cache_config(temp_data_store_type: Type[tempdatastore.Tempora
                     },
                     "cache": {
                         "location": cache_dir,
-                        "use_etag": True,
+                        "check_source_version": True,
                         "eviction_policy": {
                             "policy": "no_eviction",
                         },
@@ -868,7 +868,7 @@ def test_open_with_cache_config(temp_data_store_type: Type[tempdatastore.Tempora
                 with msc.open(f"{MSC_PROTOCOL}test/{filepath}", "rb") as fp:
                     assert fp.read() == body
 
-                # Test with cache enabled and use_etag=False
+                # Test with cache enabled and check_source_version=False
                 profile_config = temp_data_store.profile_config_dict()
                 profile_config["caching_enabled"] = True
 
@@ -879,7 +879,7 @@ def test_open_with_cache_config(temp_data_store_type: Type[tempdatastore.Tempora
                         },
                         "cache": {
                             "location": cache_dir,
-                            "use_etag": False,
+                            "check_source_version": False,
                             "eviction_policy": {
                                 "policy": "no_eviction",
                             },


### PR DESCRIPTION
## Description

- Replace remaining cache config usage of `use_etag` with `check_source_version`.
- Reject `cache.use_etag` during config validation with a clear migration message.
- Update tests, e2e config, and docs to use/document `check_source_version`.

Relates to NGCDP-9151

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cache configuration now uses `check_source_version` consistently and rejects the legacy `use_etag` setting during validation.
  * Existing cache setups and examples were updated to reflect the new flag and default behavior.
  * Documentation now clearly explains when to keep source version checks enabled or disable them for cache usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->