### PR TITLE
chore: release MSC 1.0.0

### DIFF
--- a/.release_notes/1.0.0.md
+++ b/.release_notes/1.0.0.md
@@ -1,0 +1,11 @@
+MSC 1.0 is the first stable release of the Python client API. Starting with this release, MSC follows a stricter semantic versioning contract for its stable public API: patch and minor releases should remain compatible, while incompatible API changes are reserved for future major releases.
+
+MSC will continue to evolve after 1.0 with new providers, performance improvements, and higher-level workflows built on top of this stable foundation.
+
+## Breaking Changes
+
+- Removed deprecated Python API compatibility shims:
+  - `StorageClient.list(prefix=...)` is no longer accepted. Use `StorageClient.list(path=...)` or pass the path positionally.
+  - `follow_symlinks` is no longer accepted by `StorageClient.list_recursive`, `StorageClient.sync_from`, `msc.list`, `msc.list_recursive`, or `msc.sync`. Use `symlink_handling=SymlinkHandling.FOLLOW`, `SymlinkHandling.SKIP`, or `SymlinkHandling.PRESERVE`.
+- Removed support for the deprecated cache config key `cache.use_etag`. Use `cache.check_source_version` instead.
+- Removed the retired cache experimental feature flags `experimental_features.cache_mru_eviction` and `experimental_features.cache_purge_factor`. MRU cache eviction and `eviction_policy.purge_factor` are now stable cache options and no longer require feature flags.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ just python-binary=python3.10 build
 
 ### Support
 
-- Level: Experimental
+- Level: Stable
 - How to get help: Issues/Discussions
 
 ## License

--- a/multi-storage-client/pyproject.toml
+++ b/multi-storage-client/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 
 [project]
 name = "multi-storage-client"
-version = "0.51.0"
+version = "1.0.0"
 description = "Unified high-performance Python client for object and file stores."
 authors = [
     { name = "NVIDIA Multi-Storage Client Team" }

--- a/uv.lock
+++ b/uv.lock
@@ -2110,7 +2110,7 @@ wheels = [
 
 [[package]]
 name = "multi-storage-client"
-version = "0.51.0"
+version = "1.0.0"
 source = { editable = "multi-storage-client" }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Description

Prepare the MSC 1.0.0 release.

Closes NGCDP-9151

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [x] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [x] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [x] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Released version **1.0.0** as the first **stable** Python client API with a stricter semantic versioning compatibility contract for patch and minor updates.
* **Breaking Changes**
  * Removed deprecated compatibility shims and outdated configuration options.
  * Updated listing/sync and symlink handling configuration to use the newer supported parameters.
  * Replaced legacy cache configuration (ETag-based) with source-version checking, and retired experimental cache feature flags.
* **Documentation**
  * Updated the README support level from **Experimental** to **Stable**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->