### PR TITLE
chore: enable API compatibility check

### DIFF
--- a/.github/workflows/.source.yml
+++ b/.github/workflows/.source.yml
@@ -109,12 +109,11 @@ jobs:
         run: |
           just python-binary=${{ matrix.python-binary }} build
           just python-binary=${{ matrix.python-binary }} run-minimal-verification
-      # TODO: Re-enable after MSC 1.0 is released and compare against the 1.0 tag.
-      # - if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
-      #   working-directory: multi-storage-client-scripts
-      #   run: |
-      #     git fetch --no-tags --prune origin main:refs/remotes/origin/main
-      #     uv run msc-scripts check-api-compat
+      - if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
+        working-directory: multi-storage-client-scripts
+        run: |
+          git fetch --no-tags --depth=1 origin tag 1.0.0
+          uv run msc-scripts check-api-compat
       - uses: actions/upload-artifact@v7
         with:
           if-no-files-found: error

--- a/multi-storage-client-scripts/src/multistorageclient_scripts/cli/check_python_api_compat/__init__.py
+++ b/multi-storage-client-scripts/src/multistorageclient_scripts/cli/check_python_api_compat/__init__.py
@@ -51,8 +51,7 @@ CONTRACT_FILES: Final[Mapping[str, pathlib.PurePosixPath]] = {
     ),
     "multistorageclient.schema": pathlib.PurePosixPath("multi-storage-client/src/multistorageclient/schema.py"),
 }
-# TODO: After MSC 1.0 is released, check compatibility against the 1.0 tag instead of origin/main.
-BASE_REVISION: Final[str] = "origin/main"
+BASE_REVISION: Final[str] = "1.0.0"
 HEAD_REVISION: Final[str] = "."
 
 

--- a/multi-storage-client-scripts/tests/test_multistorageclient_scripts/cli/test_check_python_api_compat.py
+++ b/multi-storage-client-scripts/tests/test_multistorageclient_scripts/cli/test_check_python_api_compat.py
@@ -39,6 +39,10 @@ def test_cli_uses_check_api_compat_command_name_without_revision_arguments() -> 
     assert not hasattr(arguments, "head")
 
 
+def test_check_api_compat_uses_1_0_release_tag_as_base_revision() -> None:
+    assert check_python_api_compat.BASE_REVISION == "1.0.0"
+
+
 def test_run_cli_returns_success_for_warn_only_compatibility_issues(monkeypatch) -> None:
     monkeypatch.setattr(
         "sys.argv",


### PR DESCRIPTION
## Description

Enable the Python API compatibility check in CI and pin its baseline to the released 1.0.0 tag.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API compatibility checks to compare against a fixed release baseline, helping catch breaking changes more reliably.
  * Updated the automated workflow to run the compatibility check when the build cache is missed.
* **Tests**
  * Added coverage to verify the compatibility check uses the expected release baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->