### PR TITLE
chore: Upgrade AIStore Nix package to 1.4.8.

### DIFF
--- a/nix/overlays/development/multi-storage-client/packages/aistore/package.nix
+++ b/nix/overlays/development/multi-storage-client/packages/aistore/package.nix
@@ -7,20 +7,20 @@
 # https://nixos.org/manual/nixpkgs/unstable#ssec-language-go
 buildGoModule (finalAttrs: {
   pname = "aistore";
-  version = "1.4.7";
+  version = "1.4.8";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "aistore";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wYHAN7h4tvRhUITk7Z5CUmf510tHddk8dsOKEBCp33w=";
+    hash = "sha256-u6MBpOQfQh+EuIYlN0jHMgByHPj1TKn/DTzAb1eRwcc=";
   };
 
-  vendorHash = "sha256-df7xiuAqbX7XAKVQyX/KWktnK+0ToNw0gJe8vroZe8Q=";
+  vendorHash = "sha256-lWsLLIx4YJcitNpHWl965VBRHJDRxw8EWTGBjiexQBE=";
 
   # Exclude `cmd/cli` and `cmd/ishard` which are separate Go modules.
   #
-  # https://github.com/NVIDIA/aistore/tree/v1.4.7/cmd
+  # https://github.com/NVIDIA/aistore/tree/v1.4.8/cmd
   subPackages = [
     "cmd/aisinit"
     "cmd/aisloader"
@@ -32,7 +32,7 @@ buildGoModule (finalAttrs: {
 
   # Needed for version strings.
   #
-  # https://github.com/NVIDIA/aistore/blob/v1.4.7/Makefile#L86
+  # https://github.com/NVIDIA/aistore/blob/v1.4.8/Makefile#L86
   ldflags = [
     "-X main.build=v${finalAttrs.version}"
     "-X main.buildtime=1970-01-01T00:00:00-00:00"
@@ -41,7 +41,7 @@ buildGoModule (finalAttrs: {
   tags = [
     # Monotonic time.
     #
-    # https://github.com/NVIDIA/aistore/blob/v1.4.7/Makefile#L98
+    # https://github.com/NVIDIA/aistore/blob/v1.4.8/Makefile#L98
     "mono"
   ];
 


### PR DESCRIPTION
## Description

Upgrade AIStore Nix package to 1.4.8.

Closes NGCDP-9295.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the AIStore package to version 1.4.8.
  * Refreshed package source and vendor references for the new release.
  * Updated associated build documentation links to reference version 1.4.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->