### PR TITLE
fix(msfs): close S3 GetObject response body in readFile

### DIFF
--- a/multi-storage-file-system/backend_s3.go
+++ b/multi-storage-file-system/backend_s3.go
@@ -417,6 +417,7 @@ func (s3Context *s3ContextStruct) readFile(readFileInput *readFileInputStruct) (
 
 	s3GetObjectOutput, err = s3Context.s3Client.GetObject(context.Background(), s3GetObjectInput)
 	if err == nil {
+		defer s3GetObjectOutput.Body.Close()
 		readFileOutput = &readFileOutputStruct{}
 		if s3GetObjectOutput.ETag == nil {
 			readFileOutput.eTag = ""


### PR DESCRIPTION
readFile read the S3 GetObject response body with io.ReadAll but never closed it. io.ReadAll does not close the reader, and the aws-sdk-go-v2 GetObjectOutput.Body is an io.ReadCloser the caller must close, so every cache-line read leaked the HTTP response body/connection in the long-running FUSE daemon, preventing connection reuse and eventually exhausting file descriptors. Close the body once the GET succeeds.

Found in merged MR !647.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup when retrieving files from S3 storage by properly closing the download response body.
  * Helps prevent unmanaged connections and supports more reliable storage operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->