### PR TITLE
fix(rclone): match 'file' storage type by equality, not substring

### DIFF
--- a/multi-storage-client/src/multistorageclient/rclone.py
+++ b/multi-storage-client/src/multistorageclient/rclone.py
@@ -235,7 +235,7 @@ def _parse_config_section(section: configparser.SectionProxy) -> dict[str, Any]:
         storage_type = "oci"
     elif storage_type == "ais":
         storage_provider_options, credentials_provider = _parse_ais_storage_provider_config(section)
-    elif storage_type in ("file"):
+    elif storage_type == "file":
         # Gather all generic config keys for all other supported storage providers.
         storage_provider_options = {k: v for k, v in section.items()}
     else:


### PR DESCRIPTION
The rclone config parser used 'elif storage_type in ("file"):', where ("file") is a plain string rather than a tuple, so it performed a substring check. Any storage type that is a substring of "file" — most importantly an empty/missing type, since '' in 'file' is True — was incorrectly parsed as a 'file' provider instead of falling through to the 'else: return {}' branch. Compare by equality to match only 'file'.

Found in merged MR !329.

## Description

_Change description._

_{Relates to/Closes} {Task ID}._

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected storage type detection so only an exact `"file"` value is recognized.
  * Prevented unintended matches from similar or partial storage type values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->