### PR TITLE
fix(msfs): interpret AIStore Atime as nanoseconds, not microseconds

### DIFF
--- a/multi-storage-file-system/backend_aistore.go
+++ b/multi-storage-file-system/backend_aistore.go
@@ -484,7 +484,7 @@ func (aisContext *aistoreContextStruct) statFile(statFileInput *statFileInputStr
 
 	statFileOutput = &statFileOutputStruct{
 		eTag:  props.Cksum.Value(),
-		mTime: time.UnixMicro(props.Atime),
+		mTime: time.Unix(0, props.Atime),
 		size:  uint64(props.Size),
 	}
 


### PR DESCRIPTION
AIStore's ObjAttrs.Atime is an int64 count of nanoseconds since the Unix epoch (per github.com/NVIDIA/aistore/cmn objattrs.go). statFile converted it with time.UnixMicro, treating the value as microseconds, which made every reported modification time ~1000x too large (tens of thousands of years in the future). Use time.Unix(0, props.Atime) to match the rest of the codebase.

https://github.com/NVIDIA/aistore/blob/main/cmn/objattrs.go#L84

Found in merged MR !733.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected file modification time handling for AIStore-backed files by adjusting how the stored timestamp is converted, improving timestamp accuracy and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->