### PR TITLE
fix(msfs): validate GCS retry_next_delay_multiplier against GCS config

### DIFF
--- a/multi-storage-file-system/config.go
+++ b/multi-storage-file-system/config.go
@@ -1426,7 +1426,7 @@ func checkConfigFile() (err error) {
 					}
 
 					backendConfigGCSAsStruct.retryNextDelayMultiplier, ok = parseFloat64(backendConfigGCSAsMap, "retry_next_delay_multiplier", defaultGCSRetryNextDelayMultiplier)
-					if !ok || (backendConfigS3AsStruct.retryNextDelayMultiplier < float64(1.0)) {
+					if !ok || (backendConfigGCSAsStruct.retryNextDelayMultiplier < float64(1.0)) {
 						err = fmt.Errorf("bad GCS.retry_next_delay_multiplier at backends[%v (\"%s\")]", backendsAsInterfaceSliceIndex, backendAsStructNew.dirName)
 						return
 					}


### PR DESCRIPTION
In the GCS backend config-parsing branch, the retry_next_delay_multiplier validation dereferenced backendConfigS3AsStruct instead of backendConfigGCSAsStruct. Because backendConfigS3AsStruct is a function-scoped pointer only assigned in the S3 branch, parsing a GCS backend when no S3 backend was processed earlier caused a nil-pointer dereference; otherwise it validated the stale S3 multiplier instead of the just-parsed GCS value.

Found in merged MR !864.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected validation of the GCS retry delay multiplier.
  * GCS configurations now properly reject multiplier values below 1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->