### PR TITLE
fix(msfs): correct virt child-dir-entry-map SIGHUP immutability check

### DIFF
--- a/multi-storage-file-system/config.go
+++ b/multi-storage-file-system/config.go
@@ -2132,7 +2132,7 @@ func checkConfigFile() (err error) {
 		}
 
 		if globals.config.physChildDirEntryMapPageEvictLowLimit != config.physChildDirEntryMapPageEvictLowLimit {
-			err = errors.New("cannot change inode_eviction_queue_page_evict_low_limit via SIGHUP")
+			err = errors.New("cannot change phys_child_dir_entry_map_page_evict_low_limit via SIGHUP")
 			return
 		}
 
@@ -2156,7 +2156,7 @@ func checkConfigFile() (err error) {
 			return
 		}
 
-		if globals.config.physChildDirEntryMapPageEvictLowLimit != config.physChildDirEntryMapPageEvictLowLimit {
+		if globals.config.virtChildDirEntryMapPageEvictLowLimit != config.virtChildDirEntryMapPageEvictLowLimit {
 			err = errors.New("cannot change virt_child_dir_entry_map_page_evict_low_limit via SIGHUP")
 			return
 		}


### PR DESCRIPTION
The SIGHUP config-immutability guard for
virt_child_dir_entry_map_page_evict_low_limit compared the *phys* field (globals.config.physChildDirEntryMapPageEvictLowLimit) instead of the virt field, so changing the virt low-limit via SIGHUP was silently accepted and the phys low-limit was checked twice.

Also fix the adjacent phys_child_dir_entry_map_page_evict_low_limit guard, whose error message was mistakenly copied from the inode_eviction_queue block.

Found in merged MR !907.

## Description

_Change description._

_{Relates to/Closes} {Task ID}._

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration reload validation so updates to child directory entry eviction limits are detected reliably.
  * Corrected the mismatch reporting to reference the proper eviction low-limit setting.
  * Fixed the comparison logic for the virtual child directory entry eviction low limit to ensure it validates against the correct current configuration value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->