### PR TITLE
fix(gcs): pass byte_range object to Rust client get() for ranged reads

### DIFF
--- a/multi-storage-client/src/multistorageclient/providers/gcs.py
+++ b/multi-storage-client/src/multistorageclient/providers/gcs.py
@@ -444,9 +444,7 @@ class GoogleStorageProvider(BaseStorageProvider):
             blob = bucket_obj.blob(key)
             if byte_range:
                 if self._rust_client:
-                    return run_async_rust_client_method(
-                        self._rust_client, "get", key, byte_range.offset, byte_range.offset + byte_range.size - 1
-                    )
+                    return run_async_rust_client_method(self._rust_client, "get", key, byte_range)
                 else:
                     return blob.download_as_bytes(
                         start=byte_range.offset, end=byte_range.offset + byte_range.size - 1, single_shot_download=True


### PR DESCRIPTION
The GCS provider's ranged read called the Rust client's get() with three positional arguments (key, start, end), but the Rust get signature is get(path, range=None) and expects a single ByteRangeLike object. This raised a TypeError at runtime for every byte-range GCS read when the Rust client was enabled. Pass the byte_range object directly, matching the S3 provider.

Found in merged MRs !542 and !746.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved partial (byte-range) object retrieval when using the Rust-based Google Cloud Storage client.
  * Ensures requested byte ranges are forwarded correctly, resulting in more reliable partial downloads and fewer range-related inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->