### PR TITLE
fix(posix): materialize StringIO uploads as bytes before atomic_write

### DIFF
--- a/multi-storage-client/src/multistorageclient/providers/posix_file.py
+++ b/multi-storage-client/src/multistorageclient/providers/posix_file.py
@@ -431,7 +431,12 @@ class PosixFileStorageProvider(BaseStorageProvider):
         if isinstance(f, str):
             filesize = os.path.getsize(f)
         elif isinstance(f, StringIO):
-            filesize = len(f.getvalue().encode("utf-8"))
+            # atomic_write writes the source in binary mode; a StringIO would yield
+            # str from read() and raise TypeError on the binary write, so materialize
+            # the text as a bytes buffer here.
+            data = f.getvalue().encode("utf-8")
+            filesize = len(data)
+            f = BytesIO(data)
         else:
             filesize = len(f.getvalue())  # type: ignore
 

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_posix_file.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_posix_file.py
@@ -17,6 +17,7 @@
 import glob
 import os
 import tempfile
+from io import StringIO
 from unittest.mock import patch
 
 from multistorageclient.providers.posix_file import PosixFileStorageProvider
@@ -78,6 +79,22 @@ def test_list_objects_with_ascending_order():
         ]
         glob_file_keys.sort()
         assert file_keys == glob_file_keys, "Files not sorted"
+
+
+def test_upload_file_from_stringio_writes_utf8_bytes():
+    # atomic_write opens the destination in binary mode and writes source.read()
+    # chunks. A StringIO yields str from read(), so without materializing it to a
+    # bytes buffer first the binary write raises
+    # "TypeError: a bytes-like object is required, not 'str'".
+    with tempfile.TemporaryDirectory() as temp_dir:
+        provider = PosixFileStorageProvider(base_path=temp_dir)
+
+        text = "héllo, wörld"  # non-ASCII to also pin UTF-8 encoding
+        provider.upload_file("notes.txt", StringIO(text))
+
+        dest = os.path.join(temp_dir, "notes.txt")
+        with open(dest, "rb") as fp:
+            assert fp.read() == text.encode("utf-8")
 
 
 def test_make_symlink_creates_relative_symlink():


### PR DESCRIPTION
PosixFileStorageProvider._upload_file has an explicit StringIO branch, but it passed the StringIO straight to atomic_write(), which opens the destination in binary mode and writes source.read() chunks. For a StringIO, read() returns str, so uploading text via client.upload_file(path, StringIO(...)) to a POSIX backend raised TypeError: a bytes-like object is required, not 'str'. Encode the text to a BytesIO first (BytesIO is already imported).

Found in merged MR !220.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed uploads from text streams so non-ASCII content is correctly encoded as UTF-8 and written to storage.
  * Ensured reported file sizes match the encoded content size.

* **Tests**
  * Added coverage for uploading non-ASCII text and verifying the resulting file contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->