### PR TITLE
fix(utils): compare numeric attribute-filter literals as strings

### DIFF
--- a/multi-storage-client/src/multistorageclient/utils.py
+++ b/multi-storage-client/src/multistorageclient/utils.py
@@ -567,7 +567,11 @@ class AttributeFilterEvaluator(Transformer):
 
     def number(self, n):
         """Handle numeric literals."""
-        return float(n[0])
+        # Return the literal as a string: equality/inequality compare against
+        # str(metadata[key]) (always a string), and the ordering operators coerce
+        # both sides with float(). Returning a float here would make '=' / '!=' on
+        # numeric literals never/always match string-typed metadata values.
+        return str(n[0])
 
     def parens(self, items):
         """Handle parenthesized expressions."""


### PR DESCRIPTION
In the attribute filter grammar, the number transformer returned a float, but compare() evaluates '=' / '!=' as
str(metadata[key]) <op> value. Comparing a string against a float made equality on an unquoted numeric literal always fail (and inequality always succeed) for string-typed metadata, e.g. 'priority = 10' never matched {'priority': '10'}. Return the literal as a string so equality works; ordering operators are unaffected since they coerce both operands with float().

Found in merged MR !500.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attribute-filter comparisons involving numeric metadata values.
  * Numeric filter values are now handled consistently as strings for equality and inequality checks, while ordering comparisons continue to work numerically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->