### PR TITLE
fix(msfs): prepend backend prefix to startAfter in GCS/AIStore listOb…

### DIFF
--- a/multi-storage-file-system/backend_aistore.go
+++ b/multi-storage-file-system/backend_aistore.go
@@ -327,7 +327,7 @@ func (aisContext *aistoreContextStruct) listObjects(listObjectsInput *listObject
 
 	// Set start after if provided
 	if listObjectsInput.startAfter != "" {
-		lsmsg.StartAfter = listObjectsInput.startAfter
+		lsmsg.StartAfter = backend.prefix + listObjectsInput.startAfter
 	}
 
 	// Set continuation token if provided

--- a/multi-storage-file-system/backend_gcs.go
+++ b/multi-storage-file-system/backend_gcs.go
@@ -281,7 +281,7 @@ func (gcsContext *gcsContextStruct) listObjects(listObjectsInput *listObjectsInp
 
 	query = &storage.Query{
 		Prefix:      gcsContext.backend.prefix + listObjectsInput.prefix,
-		StartOffset: listObjectsInput.startAfter,
+		StartOffset: gcsContext.backend.prefix + listObjectsInput.startAfter,
 	}
 
 	objectIterator = bucketHandle.Objects(context.Background(), query)


### PR DESCRIPTION
…jects

The GCS and AIStore listObjects implementations set the paging start-bound (StartOffset / StartAfter) to the raw prefix-relative startAfter key, while the query Prefix is prefixed with backend.prefix and returned object paths are stripped of backend.prefix. When a backend prefix is configured, the start bound was therefore compared against full (prefixed) object names using a prefix-relative key, so the filter was effectively ignored and pagination/resume was broken. This matches the S3 backend, which correctly uses backend.prefix + startAfter.

Found in merged MR !927.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected paginated object listings for AIStore and GCS-backed storage.
  * Listings now continue from the correct position when a storage path uses a configured prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->