### PR TITLE
fix(telemetry): set shutdown event before joining diperiodic daemons

### DIFF
--- a/multi-storage-client/src/multistorageclient/telemetry/metrics/readers/diperiodic_exporting.py
+++ b/multi-storage-client/src/multistorageclient/telemetry/metrics/readers/diperiodic_exporting.py
@@ -238,9 +238,14 @@ class DiperiodicExportingMetricReader(sdk_metrics_export.MetricReader):
 
         with self._shutdown_event_lock:
             if not self._shutdown_event.is_set():
+                # Signal the collect + export daemons to stop first. Their loops only
+                # exit once this event is set, and the export daemon performs a final
+                # collect + export on the way out. Joining before setting the event
+                # would block for the full timeout and then run that final export
+                # against an already-shut-down exporter.
+                self._shutdown_event.set()
                 if self._collect_daemon is not None:
                     self._collect_daemon.join(timeout=(deadline_ns - time.time_ns()) / 10**9)
                 if self._export_daemon is not None:
                     self._export_daemon.join(timeout=(deadline_ns - time.time_ns()) / 10**9)
                 self._exporter.shutdown(timeout_millis=(deadline_ns - time.time_ns()) / 10**6)
-                self._shutdown_event.set()


### PR DESCRIPTION
DiperiodicExportingMetricReader.shutdown() joined the collect and export daemon threads and shut down the exporter before setting self._shutdown_event. Because both daemon loops only exit once that event is set, the first join() blocked for the full timeout, and the export daemon's final collect + export (performed on loop exit) then ran against an already-shut-down exporter, losing the final metrics. Set the event first so the daemons stop and flush, join them, then shut down the exporter.

Found in merged MR !392.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry shutdown behavior by signaling background collection and export processes before waiting for them to finish.
  * Reduced delays during application shutdown while preserving existing timeout and exporter cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->