### PR TITLE
feat: add assembly view design documents

### DIFF
--- a/specs/2026-07-21-assembly-view/assembly-workflow-user-guide.html
+++ b/specs/2026-07-21-assembly-view/assembly-workflow-user-guide.html
@@ -1,0 +1,541 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Assembly Module — Build Your Own Assembly Workflow</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg:#f5f8fb; --surface:#fff; --soft:#edf3f6; --text:#172033; --muted:#5f6b7c;
+      --border:#d6e0e8; --accent:#116b5a; --accent-soft:#e1f3ee; --warning:#8a5b00;
+      --warning-soft:#fff4d6; --danger:#9d3038; --danger-soft:#fdebed; --info:#426891;
+      --info-soft:#e8f0f8; --code:#101827; --code-text:#eef4ff; --shadow:0 8px 28px rgba(25,38,57,.08);
+      --max:1480px;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg:#0d131d; --surface:#141c29; --soft:#1c2635; --text:#e9eef6; --muted:#aab4c4;
+        --border:#2b384a; --accent:#6bd9bd; --accent-soft:#173a34; --warning:#ffd174;
+        --warning-soft:#3d321c; --danger:#ff9fa8; --danger-soft:#442328; --info:#9bc6f1;
+        --info-soft:#1b3047; --code:#080d14; --code-text:#eef4ff; --shadow:0 8px 28px rgba(0,0,0,.28);
+      }
+    }
+    * { box-sizing:border-box; }
+    html { scroll-behavior:smooth; }
+    body { margin:0; background:var(--bg); color:var(--text); font-family:Inter,ui-sans-serif,system-ui,sans-serif; line-height:1.62; }
+    a { color:var(--accent); text-underline-offset:.18em; }
+    code,pre { font-family:"SFMono-Regular",Consolas,monospace; }
+    code { padding:.1em .28em; border-radius:.3rem; background:var(--soft); font-size:.92em; overflow-wrap:anywhere; }
+    pre { margin:1rem 0; padding:1rem 1.1rem; overflow-x:auto; border-radius:.7rem; background:var(--code); color:var(--code-text); line-height:1.5; font-size:.85rem; }
+    pre code { padding:0; background:transparent; color:inherit; overflow-wrap:normal; }
+    h1,h2,h3 { line-height:1.24; letter-spacing:-.015em; }
+    h1 { margin:.35rem 0 .8rem; font-size:clamp(2rem,4.8vw,3.5rem); }
+    h2 { margin:0 0 1rem; font-size:clamp(1.4rem,2.5vw,2rem); }
+    h3 { margin:1.55rem 0 .65rem; font-size:1.16rem; }
+    p { margin:.6rem 0 1rem; }
+    ul,ol { padding-left:1.35rem; }
+    li+li { margin-top:.38rem; }
+    .hero { border-bottom:1px solid var(--border); background:radial-gradient(circle at 82% 10%,color-mix(in srgb,var(--accent) 16%,transparent),transparent 30rem),var(--surface); }
+    .hero-inner { max-width:var(--max); margin:0 auto; padding:4rem 2.2rem 3.3rem; }
+    .eyebrow { color:var(--accent); font-weight:700; letter-spacing:.08em; text-transform:uppercase; font-size:.8rem; }
+    .subtitle { max-width:1050px; margin:0; color:var(--muted); font-size:1.08rem; }
+    .meta,.doc-links { display:flex; flex-wrap:wrap; gap:.6rem 1.1rem; align-items:center; }
+    .meta { margin-top:1.4rem; color:var(--muted); font-size:.9rem; }
+    .doc-links { margin-top:1.25rem; }
+    .button { display:inline-block; padding:.55rem .8rem; border:1px solid var(--border); border-radius:.55rem; background:var(--surface); color:var(--text); text-decoration:none; font-weight:650; }
+    .button.primary { border-color:var(--accent); background:var(--accent); color:var(--bg); }
+    .layout { display:grid; grid-template-columns:minmax(220px,280px) minmax(0,1fr); gap:2rem; max-width:var(--max); margin:0 auto; padding:2rem 2.2rem 6rem; }
+    .toc { align-self:start; position:sticky; top:1.2rem; max-height:calc(100vh - 2.4rem); overflow:auto; padding:.8rem 0; font-size:.88rem; }
+    .toc strong { display:block; margin-bottom:.55rem; }
+    .toc a { display:block; padding:.32rem .6rem; border-left:2px solid transparent; color:var(--muted); text-decoration:none; }
+    .toc a:hover { border-left-color:var(--accent); color:var(--text); background:var(--accent-soft); }
+    main { min-width:0; }
+    section { margin-bottom:1.6rem; padding:1.8rem; border:1px solid var(--border); border-radius:.9rem; background:var(--surface); box-shadow:var(--shadow); scroll-margin-top:1.2rem; }
+    .decision,.callout { padding:1rem 1.1rem; border-radius:.7rem; }
+    .decision { border:1px solid color-mix(in srgb,var(--accent) 45%,var(--border)); background:var(--accent-soft); }
+    .callout { margin:1rem 0; border-left:4px solid var(--warning); background:var(--warning-soft); }
+    .callout.info { border-left-color:var(--info); background:var(--info-soft); }
+    .callout.danger { border-left-color:var(--danger); background:var(--danger-soft); }
+    .grid-2,.grid-3 { display:grid; gap:.9rem; margin:1rem 0; }
+    .grid-2 { grid-template-columns:repeat(2,minmax(0,1fr)); }
+    .grid-3 { grid-template-columns:repeat(3,minmax(0,1fr)); }
+    .card { padding:1rem; border:1px solid var(--border); border-radius:.7rem; background:var(--soft); }
+    .card h3 { margin-top:0; }
+    .label { display:block; margin-bottom:.25rem; color:var(--muted); font-size:.78rem; font-weight:700; letter-spacing:.05em; text-transform:uppercase; }
+    .value { display:block; font-size:1.12rem; font-weight:750; }
+    .small { color:var(--muted); font-size:.88rem; }
+    .table-wrap { max-width:100%; overflow-x:auto; margin:1rem 0; }
+    table { width:100%; border-collapse:collapse; font-size:.9rem; }
+    th,td { padding:.72rem; border-bottom:1px solid var(--border); text-align:left; vertical-align:top; }
+    th { background:var(--soft); }
+    .architecture { display:grid; gap:.7rem; margin:1.1rem 0; padding:1rem; border:1px dashed var(--border); border-radius:.8rem; background:color-mix(in srgb,var(--soft) 72%,transparent); }
+    .arch-row { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:.75rem; }
+    .arch-node { padding:.8rem; border:1px solid var(--border); border-radius:.6rem; background:var(--surface); text-align:center; }
+    .arch-node.user { background:var(--warning-soft); }
+    .arch-node.new { background:var(--accent-soft); }
+    .arch-node.existing { background:var(--info-soft); }
+    .arch-arrow { text-align:center; color:var(--muted); font-weight:700; }
+    .formula { padding:.85rem 1rem; border-radius:.65rem; background:var(--code); color:var(--code-text); font-family:monospace; overflow:auto; white-space:nowrap; }
+    .checklist { list-style:none; padding-left:0; }
+    .checklist li { position:relative; padding-left:1.5rem; }
+    .checklist li::before { content:"□"; position:absolute; left:0; color:var(--accent); font-weight:800; }
+    @media (max-width:1000px) { .layout { grid-template-columns:1fr; } .toc { position:static; max-height:none; } }
+    @media (max-width:760px) { .hero-inner,.layout { padding-left:1rem; padding-right:1rem; } section { padding:1.15rem; } .grid-2,.grid-3,.arch-row { grid-template-columns:1fr; } }
+    @media print { body { background:#fff; color:#111; } .toc,.doc-links { display:none; } .layout { display:block; padding:1rem; } section { box-shadow:none; } }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <div class="hero-inner">
+      <div class="eyebrow">User Guide · Extension and Composition</div>
+      <h1>Build Your Own Assembly Workflow</h1>
+      <p class="subtitle">
+        Implement the application-owned planning and service-extension points, bind existing StorageClients, construct an
+        AssemblyClient, and operate on one validated AssemblyView. This guide covers only public contracts and caller-visible
+        behavior.
+      </p>
+      <div class="meta">
+        <span>Spec date: 2026-07-21</span><span>Last revised: 2026-07-22</span><span>Status: Proposed API</span>
+        <span>Audience: application and platform integrators</span><span>Initial surface: synchronous, read-only</span>
+      </div>
+      <div class="doc-links">
+        <a class="button" href="high-level-design.html">High-Level Design</a>
+        <a class="button primary" href="assembly-workflow-user-guide.html">Workflow User Guide</a>
+        <a class="button" href="implementation-and-test-plan.html">Implementation &amp; Test Plan</a>
+      </div>
+    </div>
+  </header>
+
+  <div class="layout">
+    <nav class="toc" aria-label="Table of contents">
+      <strong>Contents</strong>
+      <a href="#ownership">1. What MSC and applications provide</a>
+      <a href="#provider">2. Provide descriptors and plans</a>
+      <a href="#plan">3. Build a complete plan</a>
+      <a href="#objects">4. Bind stored-object sources</a>
+      <a href="#services">5. Implement service execution</a>
+      <a href="#compose">6. Compose AssemblyClient</a>
+      <a href="#view">7. Use AssemblyView</a>
+      <a href="#freshness">8. Expiration and consistency</a>
+      <a href="#adoption">9. Troubleshooting and adoption</a>
+    </nav>
+
+    <main>
+      <section id="ownership">
+        <h2>1. What MSC provides—and what your application provides</h2>
+        <div class="callout info">
+          This guide describes a proposed <code>multistorageclient.assembly</code> API. It is an adoption contract, not a
+          description of a feature already available in a released package.
+        </div>
+
+        <div class="decision">
+          <strong>MSC provides the assembly types, orchestration, and validation. Your application provides the plan and every
+          application-specific implementation.</strong> Assembly remains a separate layer above existing StorageClients; it
+          is not a StorageClient subclass or a StorageProvider.
+        </div>
+
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Concern</th><th>MSC provides</th><th>Your application provides</th></tr></thead>
+            <tbody>
+              <tr><td>Planning</td><td><code>AssemblyPlanProvider</code> SPI and <code>StaticAssemblyListProvider</code>.</td><td>A provider implementation and instance, unless the static provider is sufficient.</td></tr>
+              <tr><td>Stored bytes</td><td><code>ObjectSourceBinding</code> and execution through the public StorageClient API.</td><td>A configured StorageClient and the binding instance created from it.</td></tr>
+              <tr><td>Synthesized bytes</td><td><code>ServiceSegmentExecutor</code> SPI and result validation.</td><td>The complete executor implementation and instance whenever a plan contains a <code>ServiceSegment</code>.</td></tr>
+              <tr><td>Literal bytes</td><td>Built-in handling for bounded <code>InlineSegment</code> values.</td><td>No binding.</td></tr>
+              <tr><td>User operations</td><td><code>AssemblyClient</code>, <code>AssemblyView</code>, and the read-only reader.</td><td>Dependency composition, lifecycle ownership, and calls to the public API.</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="architecture" role="img" aria-label="The application supplies a plan provider, configured object bindings, and service executor implementations. AssemblyClient validates and freezes them before returning AssemblyView.">
+          <div class="arch-row">
+            <div class="arch-node user"><strong>AssemblyPlanProvider</strong><br><span class="small">application implementation or MSC static adapter</span></div>
+            <div class="arch-node new"><strong>AssemblyClient.resolve()</strong><br><span class="small">resolve · validate · freeze · capabilities</span></div>
+            <div class="arch-node new"><strong>AssemblyView</strong><br><span class="small">one fixed executable generation</span></div>
+          </div>
+          <div class="arch-arrow">descriptor metadata → complete plan → validated frozen bindings + capabilities → view</div>
+          <div class="arch-row">
+            <div class="arch-node existing"><strong>ObjectSourceBinding</strong><br><span class="small">configured StorageClient</span></div>
+            <div class="arch-node user"><strong>ServiceSegmentExecutor</strong><br><span class="small">application implementation</span></div>
+            <div class="arch-node new"><strong>InlineSegment</strong><br><span class="small">MSC handling; no binding</span></div>
+          </div>
+        </div>
+
+        <div class="callout danger">
+          Plans contain aliases and declarative segment data only. Do not place clients, credentials, profiles, endpoints, or
+          executable objects in a plan, and do not access <code>StorageClient</code> private providers.
+        </div>
+
+        <p class="small">
+          Architectural rationale is in the <a href="high-level-design.html">High-Level Design</a>. Internal algorithms,
+          limits, error normalization, and the full verification matrix are in the
+          <a href="implementation-and-test-plan.html">Implementation &amp; Test Plan</a>.
+        </p>
+      </section>
+
+      <section id="provider">
+        <h2>2. Provide metadata first, then one complete plan</h2>
+        <p>
+          Implement <code>AssemblyPlanProvider</code> when plans come from an application-owned catalog. If your application
+          already has validated <code>assembly-list/v1</code> batches, use <code>StaticAssemblyListProvider</code> instead.
+        </p>
+
+        <pre><code>class AssemblyPlanProvider(ABC):
+    @abstractmethod
+    def resolve_descriptor(
+        self,
+        request: ResolveAssemblyRequest,
+    ) -> AssemblyDescriptor:
+        """Return metadata for one fixed, unexpired generation."""
+
+    @abstractmethod
+    def get_plan(
+        self,
+        descriptor: AssemblyDescriptor,
+        *,
+        deadline_monotonic: float | None = None,
+    ) -> AssemblyPlan:
+        """Return the complete ordered plan for that descriptor."""
+
+    @property
+    def supports_refresh(self) -> bool:
+        return False
+
+    def refresh(self, request: RefreshAssemblyRequest) -> AssemblyDescriptor:
+        raise AssemblyCapabilityError()
+
+    def close(self) -> None:
+        pass</code></pre>
+
+        <div class="grid-2">
+          <div class="card">
+            <h3>Application provider</h3>
+            <pre><code># MyAssemblyPlanProvider is application code.
+provider = MyAssemblyPlanProvider(...)</code></pre>
+            <p class="small">Your implementation maps application metadata into MSC descriptors and complete plans.</p>
+          </div>
+          <div class="card">
+            <h3>Portable static provider</h3>
+            <pre><code># StaticAssemblyListProvider is supplied by MSC.
+provider = StaticAssemblyListProvider.from_batches(batches)</code></pre>
+            <p class="small">Use this when the application already produces the portable list artifact.</p>
+          </div>
+        </div>
+
+        <ul>
+          <li><code>resolve_descriptor()</code> returns control-plane metadata only: reference, generation, size, expiration, and optional descriptive fields.</li>
+          <li>An <code>AssemblyDescriptor</code> has no <code>read</code>, <code>open</code>, or <code>materialize</code> operation.</li>
+          <li><code>get_plan()</code> receives that descriptor directly and returns every ordered segment for the complete logical object—never a range-specific fragment.</li>
+          <li>The plan must describe the same reference, generation, size, and expiration as the descriptor.</li>
+          <li>When refresh is supported, it returns metadata for a replacement generation; it never mutates the previous descriptor or view.</li>
+        </ul>
+      </section>
+
+      <section id="plan">
+        <h2>3. Build one complete, ordered AssemblyPlan</h2>
+        <p>
+          A plan is the ordered concatenation of three public segment kinds. MSC treats their contents as bytes and does not
+          interpret application formats.
+        </p>
+
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Segment</th><th>Use it for</th><th>Selected by</th></tr></thead>
+            <tbody>
+              <tr><td><code>ObjectSegment</code></td><td>A byte range from an existing stored object.</td><td><code>source_id</code> → local <code>ObjectSourceBinding</code>.</td></tr>
+              <tr><td><code>ServiceSegment</code></td><td>Bytes produced by an application-defined operation.</td><td><code>executor_id</code> → application-supplied <code>ServiceSegmentExecutor</code>.</td></tr>
+              <tr><td><code>InlineSegment</code></td><td>A small literal carried in the plan.</td><td>No alias or binding.</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <pre><code>plan = AssemblyPlan.create(
+    schema_version="assembly-plan/v1",
+    descriptor=descriptor,
+    segments=(
+        InlineSegment(kind="inline", data=b"HDR", length=3),
+        ObjectSegment(
+            kind="object",
+            source_id="raw",
+            resource="records/part-0001.bin",
+            byte_range=ByteRange(offset=0, size=4_194_304),
+            length=4_194_304,
+        ),
+        ServiceSegment(
+            kind="service",
+            executor_id="rewrite",
+            operation="build-metadata",
+            parameters=FrozenJsonObject.from_mapping({"layout": "v3"}),
+            length=16_384,
+            range_mode=ServiceRangeMode.WHOLE_RESULT,
+        ),
+    ),
+)</code></pre>
+
+        <ul>
+          <li>Tuple order is the logical byte order. Do not add a second ordering field.</li>
+          <li>The checked sum of segment lengths must equal <code>descriptor.size</code>.</li>
+          <li>Every <code>source_id</code> and <code>executor_id</code> must match a local binding supplied to <code>AssemblyClient</code>.</li>
+          <li>In v1, the client-only object binding rejects source selectors and <code>ENFORCE_DURING_READ</code> validators; <code>IDENTITY_ONLY</code> metadata does not pin bytes. MSC can instead verify a checksum over the complete object segment.</li>
+          <li>A service revision supports stronger consistency only when the selected executor advertises and enforces that revision kind; MSC can also verify a checksum over the complete service result.</li>
+          <li>MSC validates the complete plan before returning a view or performing byte I/O.</li>
+        </ul>
+
+        <div class="callout info">
+          <code>assembly-list/v1</code> is the portable representation of the same descriptor-and-plan model. Applications may
+          exchange or persist it, then construct <code>StaticAssemblyListProvider</code>. The exact artifact schema and limits
+          are documented in the <a href="implementation-and-test-plan.html#contracts">Implementation &amp; Test Plan</a>.
+        </div>
+      </section>
+
+      <section id="objects">
+        <h2>4. Bind stored-object aliases to existing StorageClients</h2>
+        <pre><code>raw_storage = StorageClient(
+    StorageClientConfig.from_file(profile="raw-data")
+)
+
+# ObjectSourceBinding is provided by MSC.
+raw_source = ObjectSourceBinding(
+    client=raw_storage,
+)
+
+object_sources = {
+    "raw": raw_source,  # matches ObjectSegment.source_id
+}</code></pre>
+
+        <ul>
+          <li>Configure credentials, account, endpoint, root, and provider through the normal StorageClient APIs.</li>
+          <li>The plan selects only the alias <code>raw</code>; it cannot select or reconfigure the underlying authority.</li>
+          <li>The binding must be able to interpret every <code>resource</code> assigned to its alias.</li>
+          <li>StorageClients remain application-owned and are always borrowed by AssemblyClient; manage them through their existing public APIs.</li>
+          <li>Request stronger consistency only when every non-inline segment has enforceable evidence; in v1, an object segment needs a verified complete checksum.</li>
+        </ul>
+      </section>
+
+      <section id="services">
+        <h2>5. Implement ServiceSegmentExecutor for application-produced bytes</h2>
+        <div class="decision">
+          <strong>MSC provides only the <code>ServiceSegmentExecutor</code> SPI. It provides no concrete executor.</strong>
+          Your application owns the complete implementation, constructor, dependencies, and fulfillment behavior.
+        </div>
+
+        <p>The required implementation surface is intentionally small:</p>
+
+        <pre><code>class ServiceSegmentExecutor(ABC):
+    @property
+    @abstractmethod
+    def range_modes(self) -> frozenset[ServiceRangeMode]: ...
+
+    @abstractmethod
+    def execute(
+        self,
+        request: ServiceExecutionRequest,
+        *,
+        context: SourceReadContext,
+    ) -> ServiceResultStream:
+        """Return bytes for exactly one ServiceSegment request."""</code></pre>
+
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Input or result</th><th>User-facing meaning</th></tr></thead>
+            <tbody>
+              <tr><td><code>ServiceExecutionRequest.segment</code></td><td>The single <code>ServiceSegment</code> selected by MSC.</td></tr>
+              <tr><td><code>requested_range</code></td><td>A subrange only when the executor advertises <code>STABLE_SUBRANGES</code>; otherwise absent.</td></tr>
+              <tr><td><code>SourceReadContext</code></td><td>The operation deadline, cancellation signal, and maximum output-chunk size.</td></tr>
+              <tr><td><code>ServiceResultStream</code></td><td>A closeable stream of byte chunks for this one request.</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Executor obligations</h3>
+        <ul>
+          <li>Process one <code>ServiceExecutionRequest</code>; never require the complete <code>AssemblyPlan</code>.</li>
+          <li>Do not choose segment ordering or read another plan alias.</li>
+          <li>Return exactly the declared complete length or requested subrange, according to the advertised range mode.</li>
+          <li>Honor the supplied deadline and cancellation signal, emit bounded byte chunks, and make the result stream closeable.</li>
+          <li>Keep advertised capability values stable for the executor's injected lifetime, and preserve stable-subrange behavior throughout each operation.</li>
+        </ul>
+
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Range mode</th><th>What your executor promises</th></tr></thead>
+            <tbody>
+              <tr><td><code>WHOLE_RESULT</code></td><td>Return the complete declared result for the segment. MSC validates it before exposing a requested slice.</td></tr>
+              <tr><td><code>STABLE_SUBRANGES</code></td><td>Return exactly the requested subrange, and ensure all subranges refer to one stable logical result during the operation.</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <p>
+          <code>RetrySafety.NEVER</code> is the safe default. Declare <code>RetrySafety.SAFE</code> only when your implementation
+          can repeat the operation without changing its meaning. Internal scheduling and retry mechanics are specified in the
+          <a href="implementation-and-test-plan.html#sources">Implementation &amp; Test Plan</a>.
+        </p>
+
+        <div class="callout info">
+          This guide deliberately does not show a concrete executor class or prescribe how an executor produces bytes. The
+          application supplies an already constructed object that satisfies this SPI.
+        </div>
+      </section>
+
+      <section id="compose">
+        <h2>6. Compose AssemblyClient at the application boundary</h2>
+        <p>
+          Treat dependencies as inputs to your composition function. This keeps it explicit that the executor implementation
+          comes from the application rather than MSC.
+        </p>
+
+        <pre><code>def create_assembly_client(
+    *,
+    plan_provider: AssemblyPlanProvider,
+    raw_storage: StorageClient,
+    service_executors: Mapping[str, ServiceSegmentExecutor],
+) -> AssemblyClient:
+    return AssemblyClient(
+        plan_provider=plan_provider,
+        object_sources={
+            "raw": ObjectSourceBinding(client=raw_storage),
+        },
+        service_executors=service_executors,
+    )
+
+
+# Every dependency instance comes from the application composition root.
+assembly = create_assembly_client(
+    plan_provider=plan_provider,
+    raw_storage=raw_storage,
+    service_executors={
+        "rewrite": service_executor,
+    },
+)</code></pre>
+
+        <ul>
+          <li><code>raw</code> must match every intended <code>ObjectSegment.source_id</code>.</li>
+          <li><code>rewrite</code> must match every intended <code>ServiceSegment.executor_id</code>.</li>
+          <li>If no plan contains service segments, pass an empty <code>service_executors</code> mapping and implement no executor.</li>
+          <li>Injected dependencies are borrowed by default; the application remains responsible for their lifecycle.</li>
+          <li>Unknown aliases, incomplete plans, and unsupported capabilities fail before <code>resolve()</code> returns a view.</li>
+        </ul>
+      </section>
+
+      <section id="view">
+        <h2>7. Resolve once, then operate on AssemblyView</h2>
+        <div class="formula">resolve_descriptor(request) → descriptor → get_plan(descriptor) → validate + freeze + capabilities → AssemblyView</div>
+
+        <pre><code>reference = AssemblyReference.from_mapping(
+    namespace="exports",
+    key="run-42.bin",
+    parameters={"variant": "training"},
+)
+
+with assembly.resolve(reference) as view:
+    descriptor = view.metadata
+    assert descriptor.generation == "g-193"
+
+    tail = view.read(
+        ByteRange(offset=descriptor.size - 8192, size=8192)
+    )
+
+    with view.open() as reader:
+        if reader.seekable():
+            reader.seek(descriptor.size - 4)
+            trailer = reader.read(4)
+
+    view.materialize("/tmp/run-42.bin", overwrite=False)</code></pre>
+
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Operation</th><th>Caller-visible behavior</th></tr></thead>
+            <tbody>
+              <tr><td><code>resolve</code></td><td>Returns only after descriptor lookup, complete-plan validation, binding freeze, and capability computation all succeed.</td></tr>
+              <tr><td><code>metadata</code></td><td>Returns the view's immutable <code>AssemblyDescriptor</code>; the descriptor itself is not executable.</td></tr>
+              <tr><td><code>read</code></td><td>Returns one logical byte range from the fixed view generation.</td></tr>
+              <tr><td><code>open</code></td><td>Returns a read-only stream over the same validated generation and plan; call <code>seekable()</code> before seeking.</td></tr>
+              <tr><td><code>materialize</code></td><td>Publishes the complete logical object to a local path without exposing a partial successful result.</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <ul>
+          <li>A view contains its descriptor, complete validated plan, frozen bindings, computed consistency/capabilities, and lifecycle state.</li>
+          <li>The view never resolves a different generation implicitly.</li>
+          <li>Closing a view prevents new operations through that view; it does not mutate another view.</li>
+          <li>Manage the parent <code>AssemblyClient</code> and application-owned dependencies at the composition boundary.</li>
+        </ul>
+      </section>
+
+      <section id="freshness">
+        <h2>8. Handle expiration, refresh, and consistency explicitly</h2>
+        <div class="grid-2">
+          <div class="card">
+            <h3>Expiration</h3>
+            <ul>
+              <li>Every descriptor has a mandatory future <code>expires_at</code>.</li>
+              <li>A new operation on an expired view raises <code>AssemblyExpiredError</code>.</li>
+              <li>An operation admitted while valid may finish after expiration.</li>
+              <li>There is no implicit refresh or generation fall-forward.</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Consistency</h3>
+            <ul>
+              <li><code>EXPIRATION_ONLY</code> is the default and does not promise immutable source bytes.</li>
+              <li><code>SNAPSHOT_PINNED</code> is opt-in. In v1, every object segment needs a verified complete checksum; each service segment needs an executor-enforced revision or a verified complete checksum.</li>
+              <li>Unsupported stronger consistency fails before byte I/O.</li>
+            </ul>
+          </div>
+        </div>
+
+        <pre><code>old_view = assembly.resolve(reference)
+
+try:
+    data = old_view.read()
+except AssemblyExpiredError:
+    new_view = assembly.refresh(old_view)
+    assert new_view is not old_view
+    data = new_view.read()</code></pre>
+
+        <p>
+          Refresh returns a newly resolved and validated view. It never mutates the old one. If refresh fails, the old view
+          remains unchanged; whether it is usable still depends on its original expiration and lifecycle state.
+        </p>
+      </section>
+
+      <section id="adoption">
+        <h2>9. Troubleshooting and adoption checklist</h2>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>What you observe</th><th>What to check</th></tr></thead>
+            <tbody>
+              <tr><td><code>AssemblyExpiredError</code></td><td>Resolve or refresh explicitly; do not extend or mutate the old view.</td></tr>
+              <tr><td>Resolve returns no view</td><td>Check descriptor echo, expiration, complete-plan length, aliases, and requested consistency.</td></tr>
+              <tr><td>Unknown object alias</td><td>Ensure <code>ObjectSegment.source_id</code> matches a configured <code>object_sources</code> key.</td></tr>
+              <tr><td>Unknown service alias</td><td>Ensure <code>ServiceSegment.executor_id</code> matches an application-supplied executor.</td></tr>
+              <tr><td>Service length or protocol failure</td><td>Check the executor's advertised range mode, returned length, chunk contract, deadline, and cancellation behavior.</td></tr>
+              <tr><td>Stronger consistency is rejected</td><td>Confirm every object segment has a complete checksum and every service segment has either an executor-enforced revision or a complete checksum.</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Before adopting the feature</h3>
+        <ul class="checklist">
+          <li>Choose a custom provider or <code>StaticAssemblyListProvider</code>.</li>
+          <li>Return metadata-only descriptors and complete ordered plans.</li>
+          <li>Configure every StorageClient outside the plan and bind it by a local alias.</li>
+          <li>Implement and inject <code>ServiceSegmentExecutor</code> only when service segments are present.</li>
+          <li>Keep credentials, dependency objects, and executable behavior out of portable plans.</li>
+          <li>Exercise full-object, partial-range, open-reader, materialization, expiration, and refresh flows.</li>
+          <li>Request only consistency guarantees that the plan evidence, Assembly core, and selected executors can enforce together.</li>
+          <li>Close AssemblyClient, views, and readers predictably, and manage application-owned providers, executors, StorageClients, and related resources through their own public APIs.</li>
+        </ul>
+
+        <div class="callout info">
+          The reusable provider/executor conformance suites and the complete failure, performance, and security test matrix
+          belong to the <a href="implementation-and-test-plan.html#test-architecture">Implementation &amp; Test Plan</a>.
+        </div>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/specs/2026-07-21-assembly-view/assembly-workflow-user-guide.html
+++ b/specs/2026-07-21-assembly-view/assembly-workflow-user-guide.html
@@ -96,8 +96,8 @@
         behavior.
       </p>
       <div class="meta">
-        <span>Spec date: 2026-07-21</span><span>Last revised: 2026-07-22</span><span>Status: Proposed API</span>
-        <span>Audience: application and platform integrators</span><span>Initial surface: synchronous, read-only</span>
+        <span>Spec date: 2026-07-21</span><span>Last revised: 2026-08-25</span><span>Status: Proposed API</span>
+        <span>Audience: application and platform integrators</span><span>Initial surface: exact, read-only views with bounded concurrent execution</span>
       </div>
       <div class="doc-links">
         <a class="button" href="high-level-design.html">High-Level Design</a>
@@ -111,10 +111,10 @@
     <nav class="toc" aria-label="Table of contents">
       <strong>Contents</strong>
       <a href="#ownership">1. What MSC and applications provide</a>
-      <a href="#provider">2. Provide descriptors and plans</a>
+      <a href="#provider">2. Provide one complete plan</a>
       <a href="#plan">3. Build a complete plan</a>
       <a href="#objects">4. Bind stored-object sources</a>
-      <a href="#services">5. Implement service execution</a>
+      <a href="#services">5. Implement service fetching</a>
       <a href="#compose">6. Compose AssemblyClient</a>
       <a href="#view">7. Use AssemblyView</a>
       <a href="#freshness">8. Expiration and consistency</a>
@@ -141,30 +141,31 @@
             <tbody>
               <tr><td>Planning</td><td><code>AssemblyPlanProvider</code> SPI and <code>StaticAssemblyListProvider</code>.</td><td>A provider implementation and instance, unless the static provider is sufficient.</td></tr>
               <tr><td>Stored bytes</td><td><code>ObjectSourceBinding</code> and execution through the public StorageClient API.</td><td>A configured StorageClient and the binding instance created from it.</td></tr>
-              <tr><td>Synthesized bytes</td><td><code>ServiceSegmentExecutor</code> SPI and result validation.</td><td>The complete executor implementation and instance whenever a plan contains a <code>ServiceSegment</code>.</td></tr>
+              <tr><td>Service bytes</td><td><code>ServiceSegmentFetcher</code> SPI and result validation.</td><td>The complete fetcher implementation and instance whenever a plan contains a <code>ServiceSegment</code>.</td></tr>
               <tr><td>Literal bytes</td><td>Built-in handling for bounded <code>InlineSegment</code> values.</td><td>No binding.</td></tr>
               <tr><td>User operations</td><td><code>AssemblyClient</code>, <code>AssemblyView</code>, and the read-only reader.</td><td>Dependency composition, lifecycle ownership, and calls to the public API.</td></tr>
             </tbody>
           </table>
         </div>
 
-        <div class="architecture" role="img" aria-label="The application supplies a plan provider, configured object bindings, and service executor implementations. AssemblyClient validates and freezes them before returning AssemblyView.">
+        <div class="architecture" role="img" aria-label="The application supplies a plan provider, configured object bindings, and service fetcher implementations. AssemblyClient validates and freezes them before returning AssemblyView.">
           <div class="arch-row">
             <div class="arch-node user"><strong>AssemblyPlanProvider</strong><br><span class="small">application implementation or MSC static adapter</span></div>
             <div class="arch-node new"><strong>AssemblyClient.resolve()</strong><br><span class="small">resolve · validate · freeze · capabilities</span></div>
             <div class="arch-node new"><strong>AssemblyView</strong><br><span class="small">one fixed executable generation</span></div>
           </div>
-          <div class="arch-arrow">descriptor metadata → complete plan → validated frozen bindings + capabilities → view</div>
+          <div class="arch-arrow">metadata-bearing complete plan → validated frozen bindings + capabilities → exact view</div>
           <div class="arch-row">
             <div class="arch-node existing"><strong>ObjectSourceBinding</strong><br><span class="small">configured StorageClient</span></div>
-            <div class="arch-node user"><strong>ServiceSegmentExecutor</strong><br><span class="small">application implementation</span></div>
+            <div class="arch-node user"><strong>ServiceSegmentFetcher</strong><br><span class="small">application implementation</span></div>
             <div class="arch-node new"><strong>InlineSegment</strong><br><span class="small">MSC handling; no binding</span></div>
           </div>
         </div>
 
         <div class="callout danger">
-          Plans contain aliases and declarative segment data only. Do not place clients, credentials, profiles, endpoints, or
-          executable objects in a plan, and do not access <code>StorageClient</code> private providers.
+          Plans contain aliases and declarative segment data only. Do not place clients, credentials, profiles, unrestricted
+          endpoints, or executable objects in a plan, and do not access <code>StorageClient</code> private providers.
+          Service <code>operation</code> and <code>parameters</code> are interpreted only by the locally selected fetcher under application policy.
         </div>
 
         <p class="small">
@@ -175,7 +176,7 @@
       </section>
 
       <section id="provider">
-        <h2>2. Provide metadata first, then one complete plan</h2>
+        <h2>2. Provide one complete plan</h2>
         <p>
           Implement <code>AssemblyPlanProvider</code> when plans come from an application-owned catalog. If your application
           already has validated <code>assembly-list/v1</code> batches, use <code>StaticAssemblyListProvider</code> instead.
@@ -183,27 +184,11 @@
 
         <pre><code>class AssemblyPlanProvider(ABC):
     @abstractmethod
-    def resolve_descriptor(
-        self,
-        request: ResolveAssemblyRequest,
-    ) -> AssemblyDescriptor:
-        """Return metadata for one fixed, unexpired generation."""
-
-    @abstractmethod
     def get_plan(
         self,
-        descriptor: AssemblyDescriptor,
-        *,
-        deadline_monotonic: float | None = None,
+        request: ResolveAssemblyRequest,
     ) -> AssemblyPlan:
-        """Return the complete ordered plan for that descriptor."""
-
-    @property
-    def supports_refresh(self) -> bool:
-        return False
-
-    def refresh(self, request: RefreshAssemblyRequest) -> AssemblyDescriptor:
-        raise AssemblyCapabilityError()
+        """Return descriptor metadata and the complete ordered plan."""
 
     def close(self) -> None:
         pass</code></pre>
@@ -213,7 +198,7 @@
             <h3>Application provider</h3>
             <pre><code># MyAssemblyPlanProvider is application code.
 provider = MyAssemblyPlanProvider(...)</code></pre>
-            <p class="small">Your implementation maps application metadata into MSC descriptors and complete plans.</p>
+            <p class="small">Your implementation maps one logical request into a metadata-bearing complete plan.</p>
           </div>
           <div class="card">
             <h3>Portable static provider</h3>
@@ -224,11 +209,11 @@ provider = StaticAssemblyListProvider.from_batches(batches)</code></pre>
         </div>
 
         <ul>
-          <li><code>resolve_descriptor()</code> returns control-plane metadata only: reference, generation, size, expiration, and optional descriptive fields.</li>
-          <li>An <code>AssemblyDescriptor</code> has no <code>read</code>, <code>open</code>, or <code>materialize</code> operation.</li>
-          <li><code>get_plan()</code> receives that descriptor directly and returns every ordered segment for the complete logical object—never a range-specific fragment.</li>
-          <li>The plan must describe the same reference, generation, size, and expiration as the descriptor.</li>
-          <li>When refresh is supported, it returns metadata for a replacement generation; it never mutates the previous descriptor or view.</li>
+          <li><code>get_plan()</code> returns descriptor metadata—reference, generation, size, expiration, and optional descriptive fields—together with every ordered segment.</li>
+          <li>An embedded <code>AssemblyDescriptor</code> has no <code>read</code>, <code>open</code>, or <code>materialize</code> operation.</li>
+          <li>The response always describes the complete logical object—never a range-specific fragment.</li>
+          <li>The plan and embedded descriptor must agree on reference, generation, size, and expiration.</li>
+          <li>The provider exposes no separate refresh operation. A replacement is another <code>get_plan()</code> result reached through <code>AssemblyClient.resolve()</code>.</li>
         </ul>
       </section>
 
@@ -244,7 +229,7 @@ provider = StaticAssemblyListProvider.from_batches(batches)</code></pre>
             <thead><tr><th>Segment</th><th>Use it for</th><th>Selected by</th></tr></thead>
             <tbody>
               <tr><td><code>ObjectSegment</code></td><td>A byte range from an existing stored object.</td><td><code>source_id</code> → local <code>ObjectSourceBinding</code>.</td></tr>
-              <tr><td><code>ServiceSegment</code></td><td>Bytes produced by an application-defined operation.</td><td><code>executor_id</code> → application-supplied <code>ServiceSegmentExecutor</code>.</td></tr>
+              <tr><td><code>ServiceSegment</code></td><td>Bytes fetched from an application-defined service operation.</td><td><code>fetcher_id</code> → application-supplied <code>ServiceSegmentFetcher</code>.</td></tr>
               <tr><td><code>InlineSegment</code></td><td>A small literal carried in the plan.</td><td>No alias or binding.</td></tr>
             </tbody>
           </table>
@@ -252,6 +237,7 @@ provider = StaticAssemblyListProvider.from_batches(batches)</code></pre>
 
         <pre><code>plan = AssemblyPlan.create(
     schema_version="assembly-plan/v1",
+    result_semantics="exact",
     descriptor=descriptor,
     segments=(
         InlineSegment(kind="inline", data=b"HDR", length=3),
@@ -264,7 +250,7 @@ provider = StaticAssemblyListProvider.from_batches(batches)</code></pre>
         ),
         ServiceSegment(
             kind="service",
-            executor_id="rewrite",
+            fetcher_id="rewrite",
             operation="build-metadata",
             parameters=FrozenJsonObject.from_mapping({"layout": "v3"}),
             length=16_384,
@@ -276,9 +262,9 @@ provider = StaticAssemblyListProvider.from_batches(batches)</code></pre>
         <ul>
           <li>Tuple order is the logical byte order. Do not add a second ordering field.</li>
           <li>The checked sum of segment lengths must equal <code>descriptor.size</code>.</li>
-          <li>Every <code>source_id</code> and <code>executor_id</code> must match a local binding supplied to <code>AssemblyClient</code>.</li>
+          <li>Every <code>source_id</code> and <code>fetcher_id</code> must match a local binding supplied to <code>AssemblyClient</code>.</li>
           <li>In v1, the client-only object binding rejects source selectors and <code>ENFORCE_DURING_READ</code> validators; <code>IDENTITY_ONLY</code> metadata does not pin bytes. MSC can instead verify a checksum over the complete object segment.</li>
-          <li>A service revision supports stronger consistency only when the selected executor advertises and enforces that revision kind; MSC can also verify a checksum over the complete service result.</li>
+          <li>A service revision supports stronger consistency only when the selected fetcher advertises and enforces that revision kind; MSC can also verify a checksum over the complete service result.</li>
           <li>MSC validates the complete plan before returning a view or performing byte I/O.</li>
         </ul>
 
@@ -287,6 +273,18 @@ provider = StaticAssemblyListProvider.from_batches(batches)</code></pre>
           exchange or persist it, then construct <code>StaticAssemblyListProvider</code>. The exact artifact schema and limits
           are documented in the <a href="implementation-and-test-plan.html#contracts">Implementation &amp; Test Plan</a>.
         </div>
+
+        <div class="callout">
+          <strong>V1 always means exact final bytes.</strong> Every valid composition of object, service, and inline segments
+          must produce the caller's complete logical object. Informational application annotations cannot turn the result into
+          a semantic superset that requires format-specific projection. Such a contract would require a new plan version and
+          an explicitly supported capability.
+        </div>
+
+        <p class="small">
+          Treat plan and SPI versions as compatibility boundaries. Unknown plan versions or required capabilities are rejected;
+          published provider and fetcher SPIs will not gain new required abstract methods within the same version.
+        </p>
       </section>
 
       <section id="objects">
@@ -314,23 +312,23 @@ object_sources = {
       </section>
 
       <section id="services">
-        <h2>5. Implement ServiceSegmentExecutor for application-produced bytes</h2>
+        <h2>5. Implement ServiceSegmentFetcher for application-produced bytes</h2>
         <div class="decision">
-          <strong>MSC provides only the <code>ServiceSegmentExecutor</code> SPI. It provides no concrete executor.</strong>
+          <strong>MSC provides only the <code>ServiceSegmentFetcher</code> SPI. It provides no concrete fetcher.</strong>
           Your application owns the complete implementation, constructor, dependencies, and fulfillment behavior.
         </div>
 
         <p>The required implementation surface is intentionally small:</p>
 
-        <pre><code>class ServiceSegmentExecutor(ABC):
+        <pre><code>class ServiceSegmentFetcher(ABC):
     @property
     @abstractmethod
     def range_modes(self) -> frozenset[ServiceRangeMode]: ...
 
     @abstractmethod
-    def execute(
+    def fetch(
         self,
-        request: ServiceExecutionRequest,
+        request: ServiceFetchRequest,
         *,
         context: SourceReadContext,
     ) -> ServiceResultStream:
@@ -340,26 +338,28 @@ object_sources = {
           <table>
             <thead><tr><th>Input or result</th><th>User-facing meaning</th></tr></thead>
             <tbody>
-              <tr><td><code>ServiceExecutionRequest.segment</code></td><td>The single <code>ServiceSegment</code> selected by MSC.</td></tr>
-              <tr><td><code>requested_range</code></td><td>A subrange only when the executor advertises <code>STABLE_SUBRANGES</code>; otherwise absent.</td></tr>
+              <tr><td><code>ServiceFetchRequest.segment</code></td><td>The single <code>ServiceSegment</code> selected by MSC.</td></tr>
+              <tr><td><code>requested_range</code></td><td>A subrange only when the fetcher advertises <code>STABLE_SUBRANGES</code>; otherwise absent.</td></tr>
               <tr><td><code>SourceReadContext</code></td><td>The operation deadline, cancellation signal, and maximum output-chunk size.</td></tr>
               <tr><td><code>ServiceResultStream</code></td><td>A closeable stream of byte chunks for this one request.</td></tr>
             </tbody>
           </table>
         </div>
 
-        <h3>Executor obligations</h3>
+        <h3>Fetcher obligations</h3>
         <ul>
-          <li>Process one <code>ServiceExecutionRequest</code>; never require the complete <code>AssemblyPlan</code>.</li>
+          <li>Process one <code>ServiceFetchRequest</code>; never require the complete <code>AssemblyPlan</code>.</li>
           <li>Do not choose segment ordering or read another plan alias.</li>
           <li>Return exactly the declared complete length or requested subrange, according to the advertised range mode.</li>
           <li>Honor the supplied deadline and cancellation signal, emit bounded byte chunks, and make the result stream closeable.</li>
-          <li>Keep advertised capability values stable for the executor's injected lifetime, and preserve stable-subrange behavior throughout each operation.</li>
+          <li>Keep advertised capability values stable for the fetcher's injected lifetime, and preserve stable-subrange behavior throughout each operation.</li>
+          <li>Treat each request as independently executable; do not require sticky sessions or hidden ordering state.</li>
+          <li>Interpret <code>operation</code> and <code>parameters</code> under local allowlist, authentication, and routing policy. Never accept credentials from the plan.</li>
         </ul>
 
         <div class="table-wrap">
           <table>
-            <thead><tr><th>Range mode</th><th>What your executor promises</th></tr></thead>
+            <thead><tr><th>Range mode</th><th>What your fetcher promises</th></tr></thead>
             <tbody>
               <tr><td><code>WHOLE_RESULT</code></td><td>Return the complete declared result for the segment. MSC validates it before exposing a requested slice.</td></tr>
               <tr><td><code>STABLE_SUBRANGES</code></td><td>Return exactly the requested subrange, and ensure all subranges refer to one stable logical result during the operation.</td></tr>
@@ -374,7 +374,7 @@ object_sources = {
         </p>
 
         <div class="callout info">
-          This guide deliberately does not show a concrete executor class or prescribe how an executor produces bytes. The
+          This guide deliberately does not show a concrete fetcher class or prescribe how a fetcher obtains bytes. The
           application supplies an already constructed object that satisfies this SPI.
         </div>
       </section>
@@ -382,7 +382,7 @@ object_sources = {
       <section id="compose">
         <h2>6. Compose AssemblyClient at the application boundary</h2>
         <p>
-          Treat dependencies as inputs to your composition function. This keeps it explicit that the executor implementation
+          Treat dependencies as inputs to your composition function. This keeps it explicit that the fetcher implementation
           comes from the application rather than MSC.
         </p>
 
@@ -390,14 +390,14 @@ object_sources = {
     *,
     plan_provider: AssemblyPlanProvider,
     raw_storage: StorageClient,
-    service_executors: Mapping[str, ServiceSegmentExecutor],
+    service_fetchers: Mapping[str, ServiceSegmentFetcher],
 ) -> AssemblyClient:
     return AssemblyClient(
         plan_provider=plan_provider,
         object_sources={
             "raw": ObjectSourceBinding(client=raw_storage),
         },
-        service_executors=service_executors,
+        service_fetchers=service_fetchers,
     )
 
 
@@ -405,15 +405,15 @@ object_sources = {
 assembly = create_assembly_client(
     plan_provider=plan_provider,
     raw_storage=raw_storage,
-    service_executors={
-        "rewrite": service_executor,
+    service_fetchers={
+        "rewrite": service_fetcher,
     },
 )</code></pre>
 
         <ul>
           <li><code>raw</code> must match every intended <code>ObjectSegment.source_id</code>.</li>
-          <li><code>rewrite</code> must match every intended <code>ServiceSegment.executor_id</code>.</li>
-          <li>If no plan contains service segments, pass an empty <code>service_executors</code> mapping and implement no executor.</li>
+          <li><code>rewrite</code> must match every intended <code>ServiceSegment.fetcher_id</code>.</li>
+          <li>If no plan contains service segments, pass an empty <code>service_fetchers</code> mapping and implement no fetcher.</li>
           <li>Injected dependencies are borrowed by default; the application remains responsible for their lifecycle.</li>
           <li>Unknown aliases, incomplete plans, and unsupported capabilities fail before <code>resolve()</code> returns a view.</li>
         </ul>
@@ -421,7 +421,7 @@ assembly = create_assembly_client(
 
       <section id="view">
         <h2>7. Resolve once, then operate on AssemblyView</h2>
-        <div class="formula">resolve_descriptor(request) → descriptor → get_plan(descriptor) → validate + freeze + capabilities → AssemblyView</div>
+        <div class="formula">get_plan(request) → descriptor metadata + complete plan → validate + freeze + capabilities → exact AssemblyView</div>
 
         <pre><code>reference = AssemblyReference.from_mapping(
     namespace="exports",
@@ -448,7 +448,7 @@ with assembly.resolve(reference) as view:
           <table>
             <thead><tr><th>Operation</th><th>Caller-visible behavior</th></tr></thead>
             <tbody>
-              <tr><td><code>resolve</code></td><td>Returns only after descriptor lookup, complete-plan validation, binding freeze, and capability computation all succeed.</td></tr>
+              <tr><td><code>resolve</code></td><td>Returns only after the single provider call, complete-plan validation, binding freeze, and capability computation all succeed.</td></tr>
               <tr><td><code>metadata</code></td><td>Returns the view's immutable <code>AssemblyDescriptor</code>; the descriptor itself is not executable.</td></tr>
               <tr><td><code>read</code></td><td>Returns one logical byte range from the fixed view generation.</td></tr>
               <tr><td><code>open</code></td><td>Returns a read-only stream over the same validated generation and plan; call <code>seekable()</code> before seeking.</td></tr>
@@ -466,7 +466,7 @@ with assembly.resolve(reference) as view:
       </section>
 
       <section id="freshness">
-        <h2>8. Handle expiration, refresh, and consistency explicitly</h2>
+        <h2>8. Handle expiration, replacement, and consistency explicitly</h2>
         <div class="grid-2">
           <div class="card">
             <h3>Expiration</h3>
@@ -474,14 +474,14 @@ with assembly.resolve(reference) as view:
               <li>Every descriptor has a mandatory future <code>expires_at</code>.</li>
               <li>A new operation on an expired view raises <code>AssemblyExpiredError</code>.</li>
               <li>An operation admitted while valid may finish after expiration.</li>
-              <li>There is no implicit refresh or generation fall-forward.</li>
+              <li>There is no public refresh method or implicit generation fall-forward in the proposed v1 policy.</li>
             </ul>
           </div>
           <div class="card">
             <h3>Consistency</h3>
             <ul>
               <li><code>EXPIRATION_ONLY</code> is the default and does not promise immutable source bytes.</li>
-              <li><code>SNAPSHOT_PINNED</code> is opt-in. In v1, every object segment needs a verified complete checksum; each service segment needs an executor-enforced revision or a verified complete checksum.</li>
+              <li><code>SNAPSHOT_PINNED</code> is opt-in. In v1, every object segment needs a verified complete checksum; each service segment needs a fetcher-enforced revision or a verified complete checksum.</li>
               <li>Unsupported stronger consistency fails before byte I/O.</li>
             </ul>
           </div>
@@ -492,13 +492,14 @@ with assembly.resolve(reference) as view:
 try:
     data = old_view.read()
 except AssemblyExpiredError:
-    new_view = assembly.refresh(old_view)
+    new_view = assembly.resolve(old_view.metadata.reference)
     assert new_view is not old_view
     data = new_view.read()</code></pre>
 
         <p>
-          Refresh returns a newly resolved and validated view. It never mutates the old one. If refresh fails, the old view
-          remains unchanged; whether it is usable still depends on its original expiration and lifecycle state.
+          Another resolve returns a newly resolved and validated view. It never mutates the old one. If replacement resolution
+          fails, the old view remains unchanged and expired. A future automatic re-resolution policy requires separate approval;
+          an expired plan may never begin new work.
         </p>
       </section>
 
@@ -508,12 +509,12 @@ except AssemblyExpiredError:
           <table>
             <thead><tr><th>What you observe</th><th>What to check</th></tr></thead>
             <tbody>
-              <tr><td><code>AssemblyExpiredError</code></td><td>Resolve or refresh explicitly; do not extend or mutate the old view.</td></tr>
-              <tr><td>Resolve returns no view</td><td>Check descriptor echo, expiration, complete-plan length, aliases, and requested consistency.</td></tr>
+              <tr><td><code>AssemblyExpiredError</code></td><td>Resolve the same reference again; do not extend or mutate the old view.</td></tr>
+              <tr><td>Resolve returns no view</td><td>Check descriptor/plan agreement, expiration, complete-plan length, aliases, and requested consistency.</td></tr>
               <tr><td>Unknown object alias</td><td>Ensure <code>ObjectSegment.source_id</code> matches a configured <code>object_sources</code> key.</td></tr>
-              <tr><td>Unknown service alias</td><td>Ensure <code>ServiceSegment.executor_id</code> matches an application-supplied executor.</td></tr>
-              <tr><td>Service length or protocol failure</td><td>Check the executor's advertised range mode, returned length, chunk contract, deadline, and cancellation behavior.</td></tr>
-              <tr><td>Stronger consistency is rejected</td><td>Confirm every object segment has a complete checksum and every service segment has either an executor-enforced revision or a complete checksum.</td></tr>
+              <tr><td>Unknown service alias</td><td>Ensure <code>ServiceSegment.fetcher_id</code> matches an application-supplied fetcher.</td></tr>
+              <tr><td>Service length or protocol failure</td><td>Check the fetcher's advertised range mode, returned length, chunk contract, deadline, and cancellation behavior.</td></tr>
+              <tr><td>Stronger consistency is rejected</td><td>Confirm every object segment has a complete checksum and every service segment has either a fetcher-enforced revision or a complete checksum.</td></tr>
             </tbody>
           </table>
         </div>
@@ -521,17 +522,17 @@ except AssemblyExpiredError:
         <h3>Before adopting the feature</h3>
         <ul class="checklist">
           <li>Choose a custom provider or <code>StaticAssemblyListProvider</code>.</li>
-          <li>Return metadata-only descriptors and complete ordered plans.</li>
+          <li>Return descriptor metadata and the complete ordered plan from one <code>get_plan()</code> call.</li>
           <li>Configure every StorageClient outside the plan and bind it by a local alias.</li>
-          <li>Implement and inject <code>ServiceSegmentExecutor</code> only when service segments are present.</li>
+          <li>Implement and inject <code>ServiceSegmentFetcher</code> only when service segments are present.</li>
           <li>Keep credentials, dependency objects, and executable behavior out of portable plans.</li>
-          <li>Exercise full-object, partial-range, open-reader, materialization, expiration, and refresh flows.</li>
-          <li>Request only consistency guarantees that the plan evidence, Assembly core, and selected executors can enforce together.</li>
-          <li>Close AssemblyClient, views, and readers predictably, and manage application-owned providers, executors, StorageClients, and related resources through their own public APIs.</li>
+          <li>Exercise full-object, partial-range, open-reader, materialization, expiration, and replacement-resolution flows.</li>
+          <li>Request only consistency guarantees that the plan evidence, Assembly core, and selected fetchers can enforce together.</li>
+          <li>Close AssemblyClient, views, and readers predictably, and manage application-owned providers, fetchers, StorageClients, and related resources through their own public APIs.</li>
         </ul>
 
         <div class="callout info">
-          The reusable provider/executor conformance suites and the complete failure, performance, and security test matrix
+          The reusable provider/fetcher conformance suites and the complete failure, performance, and security test matrix
           belong to the <a href="implementation-and-test-plan.html#test-architecture">Implementation &amp; Test Plan</a>.
         </div>
       </section>

--- a/specs/2026-07-21-assembly-view/assembly-workflow-user-guide.html
+++ b/specs/2026-07-21-assembly-view/assembly-workflow-user-guide.html
@@ -151,10 +151,10 @@
         <div class="architecture" role="img" aria-label="The application supplies a plan provider, configured object bindings, and service fetcher implementations. AssemblyClient validates and freezes them before returning AssemblyView.">
           <div class="arch-row">
             <div class="arch-node user"><strong>AssemblyPlanProvider</strong><br><span class="small">application implementation or MSC static adapter</span></div>
-            <div class="arch-node new"><strong>AssemblyClient.resolve()</strong><br><span class="small">resolve · validate · freeze · capabilities</span></div>
+            <div class="arch-node new"><strong>AssemblyClient.resolve()</strong><br><span class="small">resolve · validate · freeze</span></div>
             <div class="arch-node new"><strong>AssemblyView</strong><br><span class="small">one fixed executable generation</span></div>
           </div>
-          <div class="arch-arrow">metadata-bearing complete plan → validated frozen bindings + capabilities → exact view</div>
+          <div class="arch-arrow">metadata-bearing complete plan → validated frozen bindings → exact view</div>
           <div class="arch-row">
             <div class="arch-node existing"><strong>ObjectSourceBinding</strong><br><span class="small">configured StorageClient</span></div>
             <div class="arch-node user"><strong>ServiceSegmentFetcher</strong><br><span class="small">application implementation</span></div>
@@ -188,10 +188,7 @@
         self,
         request: ResolveAssemblyRequest,
     ) -> AssemblyPlan:
-        """Return descriptor metadata and the complete ordered plan."""
-
-    def close(self) -> None:
-        pass</code></pre>
+        """Return descriptor metadata and the complete ordered plan."""</code></pre>
 
         <div class="grid-2">
           <div class="card">
@@ -215,6 +212,12 @@ provider = StaticAssemblyListProvider.from_batches(batches)</code></pre>
           <li>The plan and embedded descriptor must agree on reference, generation, size, and expiration.</li>
           <li>The provider exposes no separate refresh operation. A replacement is another <code>get_plan()</code> result reached through <code>AssemblyClient.resolve()</code>.</li>
         </ul>
+
+        <div class="callout info">
+          <strong><code>AssemblyListBatch</code> is a portable artifact, not a browsing API.</strong> One or more batches carry
+          a version, list ID, expiration, batch position, and object definitions. MSC's static provider validates the batch
+          set and builds an exact-reference lookup. It does not expose pagination, <code>list()</code>, or <code>glob()</code>.
+        </div>
       </section>
 
       <section id="plan">
@@ -252,7 +255,7 @@ provider = StaticAssemblyListProvider.from_batches(batches)</code></pre>
             kind="service",
             fetcher_id="rewrite",
             operation="build-metadata",
-            parameters=FrozenJsonObject.from_mapping({"layout": "v3"}),
+            parameters={"layout": "v3"},
             length=16_384,
             range_mode=ServiceRangeMode.WHOLE_RESULT,
         ),
@@ -263,8 +266,7 @@ provider = StaticAssemblyListProvider.from_batches(batches)</code></pre>
           <li>Tuple order is the logical byte order. Do not add a second ordering field.</li>
           <li>The checked sum of segment lengths must equal <code>descriptor.size</code>.</li>
           <li>Every <code>source_id</code> and <code>fetcher_id</code> must match a local binding supplied to <code>AssemblyClient</code>.</li>
-          <li>In v1, the client-only object binding rejects source selectors and <code>ENFORCE_DURING_READ</code> validators; <code>IDENTITY_ONLY</code> metadata does not pin bytes. MSC can instead verify a checksum over the complete object segment.</li>
-          <li>A service revision supports stronger consistency only when the selected fetcher advertises and enforces that revision kind; MSC can also verify a checksum over the complete service result.</li>
+          <li>V1 does not model source selectors, validators, revisions, or checksums. The provider and local bindings own any stronger consistency policy.</li>
           <li>MSC validates the complete plan before returning a view or performing byte I/O.</li>
         </ul>
 
@@ -278,11 +280,11 @@ provider = StaticAssemblyListProvider.from_batches(batches)</code></pre>
           <strong>V1 always means exact final bytes.</strong> Every valid composition of object, service, and inline segments
           must produce the caller's complete logical object. Informational application annotations cannot turn the result into
           a semantic superset that requires format-specific projection. Such a contract would require a new plan version and
-          an explicitly supported capability.
+          an explicitly versioned contract.
         </div>
 
         <p class="small">
-          Treat plan and SPI versions as compatibility boundaries. Unknown plan versions or required capabilities are rejected;
+          Treat plan and SPI versions as compatibility boundaries. Unknown plan versions, segment kinds, or fields are rejected;
           published provider and fetcher SPIs will not gain new required abstract methods within the same version.
         </p>
       </section>
@@ -307,7 +309,7 @@ object_sources = {
           <li>The plan selects only the alias <code>raw</code>; it cannot select or reconfigure the underlying authority.</li>
           <li>The binding must be able to interpret every <code>resource</code> assigned to its alias.</li>
           <li>StorageClients remain application-owned and are always borrowed by AssemblyClient; manage them through their existing public APIs.</li>
-          <li>Request stronger consistency only when every non-inline segment has enforceable evidence; in v1, an object segment needs a verified complete checksum.</li>
+          <li>The v1 binding validates returned length but does not enforce an object version or checksum. Apply stronger identity policy inside application-owned dependencies when required.</li>
         </ul>
       </section>
 
@@ -352,9 +354,10 @@ object_sources = {
           <li>Do not choose segment ordering or read another plan alias.</li>
           <li>Return exactly the declared complete length or requested subrange, according to the advertised range mode.</li>
           <li>Honor the supplied deadline and cancellation signal, emit bounded byte chunks, and make the result stream closeable.</li>
-          <li>Keep advertised capability values stable for the fetcher's injected lifetime, and preserve stable-subrange behavior throughout each operation.</li>
+          <li>Keep <code>range_modes</code> stable for the fetcher's injected lifetime, and preserve stable-subrange behavior throughout each operation.</li>
           <li>Treat each request as independently executable; do not require sticky sessions or hidden ordering state.</li>
           <li>Interpret <code>operation</code> and <code>parameters</code> under local allowlist, authentication, and routing policy. Never accept credentials from the plan.</li>
+          <li>MSC serializes calls to one fetcher instance in v1. Different fetcher instances may run concurrently under the client's global limit.</li>
         </ul>
 
         <div class="table-wrap">
@@ -368,9 +371,9 @@ object_sources = {
         </div>
 
         <p>
-          <code>RetrySafety.NEVER</code> is the safe default. Declare <code>RetrySafety.SAFE</code> only when your implementation
-          can repeat the operation without changing its meaning. Internal scheduling and retry mechanics are specified in the
-          <a href="implementation-and-test-plan.html#sources">Implementation &amp; Test Plan</a>.
+          Assembly invokes <code>fetch()</code> once for each planned service operation and adds no outer retry. A fetcher may
+          implement its own retry policy behind the SPI, provided it remains within the supplied deadline and preserves the
+          operation's application-defined semantics.
         </p>
 
         <div class="callout info">
@@ -398,6 +401,8 @@ object_sources = {
             "raw": ObjectSourceBinding(client=raw_storage),
         },
         service_fetchers=service_fetchers,
+        max_concurrency=16,
+        timeout_seconds=300,
     )
 
 
@@ -414,16 +419,17 @@ assembly = create_assembly_client(
           <li><code>raw</code> must match every intended <code>ObjectSegment.source_id</code>.</li>
           <li><code>rewrite</code> must match every intended <code>ServiceSegment.fetcher_id</code>.</li>
           <li>If no plan contains service segments, pass an empty <code>service_fetchers</code> mapping and implement no fetcher.</li>
-          <li>Injected dependencies are borrowed by default; the application remains responsible for their lifecycle.</li>
-          <li>Unknown aliases, incomplete plans, and unsupported capabilities fail before <code>resolve()</code> returns a view.</li>
+          <li>Injected dependencies are borrowed; the application remains responsible for their lifecycle.</li>
+          <li><code>max_concurrency</code> and <code>timeout_seconds</code> are the only public execution knobs in v1; other safety limits are private MSC constants.</li>
+          <li>Unknown aliases and incomplete or malformed plans fail before <code>resolve()</code> returns a view.</li>
         </ul>
       </section>
 
       <section id="view">
         <h2>7. Resolve once, then operate on AssemblyView</h2>
-        <div class="formula">get_plan(request) → descriptor metadata + complete plan → validate + freeze + capabilities → exact AssemblyView</div>
+        <div class="formula">get_plan(request) → descriptor metadata + complete plan → validate + freeze → exact AssemblyView</div>
 
-        <pre><code>reference = AssemblyReference.from_mapping(
+        <pre><code>reference = AssemblyReference(
     namespace="exports",
     key="run-42.bin",
     parameters={"variant": "training"},
@@ -438,9 +444,8 @@ with assembly.resolve(reference) as view:
     )
 
     with view.open() as reader:
-        if reader.seekable():
-            reader.seek(descriptor.size - 4)
-            trailer = reader.read(4)
+        prefix = reader.read(4096)
+        next_chunk = reader.read(4096)  # forward-only in v1
 
     view.materialize("/tmp/run-42.bin", overwrite=False)</code></pre>
 
@@ -448,17 +453,17 @@ with assembly.resolve(reference) as view:
           <table>
             <thead><tr><th>Operation</th><th>Caller-visible behavior</th></tr></thead>
             <tbody>
-              <tr><td><code>resolve</code></td><td>Returns only after the single provider call, complete-plan validation, binding freeze, and capability computation all succeed.</td></tr>
+              <tr><td><code>resolve</code></td><td>Returns only after the single provider call, complete-plan validation, and binding freeze all succeed.</td></tr>
               <tr><td><code>metadata</code></td><td>Returns the view's immutable <code>AssemblyDescriptor</code>; the descriptor itself is not executable.</td></tr>
               <tr><td><code>read</code></td><td>Returns one logical byte range from the fixed view generation.</td></tr>
-              <tr><td><code>open</code></td><td>Returns a read-only stream over the same validated generation and plan; call <code>seekable()</code> before seeking.</td></tr>
+              <tr><td><code>open</code></td><td>Returns a forward-only read stream over the same validated generation and plan. Use <code>view.read(range)</code> for random range access.</td></tr>
               <tr><td><code>materialize</code></td><td>Publishes the complete logical object to a local path without exposing a partial successful result.</td></tr>
             </tbody>
           </table>
         </div>
 
         <ul>
-          <li>A view contains its descriptor, complete validated plan, frozen bindings, computed consistency/capabilities, and lifecycle state.</li>
+          <li>A view contains its descriptor, complete validated plan, frozen bindings, and lifecycle state.</li>
           <li>The view never resolves a different generation implicitly.</li>
           <li>Closing a view prevents new operations through that view; it does not mutate another view.</li>
           <li>Manage the parent <code>AssemblyClient</code> and application-owned dependencies at the composition boundary.</li>
@@ -466,7 +471,7 @@ with assembly.resolve(reference) as view:
       </section>
 
       <section id="freshness">
-        <h2>8. Handle expiration, replacement, and consistency explicitly</h2>
+        <h2>8. Handle expiration, replacement, and the MVP consistency boundary explicitly</h2>
         <div class="grid-2">
           <div class="card">
             <h3>Expiration</h3>
@@ -474,15 +479,15 @@ with assembly.resolve(reference) as view:
               <li>Every descriptor has a mandatory future <code>expires_at</code>.</li>
               <li>A new operation on an expired view raises <code>AssemblyExpiredError</code>.</li>
               <li>An operation admitted while valid may finish after expiration.</li>
-              <li>There is no public refresh method or implicit generation fall-forward in the proposed v1 policy.</li>
+              <li>There is no public refresh method or implicit generation fall-forward in v1.</li>
             </ul>
           </div>
           <div class="card">
-            <h3>Consistency</h3>
+            <h3>Consistency boundary</h3>
             <ul>
-              <li><code>EXPIRATION_ONLY</code> is the default and does not promise immutable source bytes.</li>
-              <li><code>SNAPSHOT_PINNED</code> is opt-in. In v1, every object segment needs a verified complete checksum; each service segment needs a fetcher-enforced revision or a verified complete checksum.</li>
-              <li>Unsupported stronger consistency fails before byte I/O.</li>
+              <li>V1 plans contain no selectors, validators, operation revisions, or checksums.</li>
+              <li>MSC validates exact returned lengths and surfaces storage or service transport failures.</li>
+              <li>Same-length source mutation may be undetectable. Dataset or sample snapshot semantics remain the application's responsibility.</li>
             </ul>
           </div>
         </div>
@@ -498,8 +503,8 @@ except AssemblyExpiredError:
 
         <p>
           Another resolve returns a newly resolved and validated view. It never mutates the old one. If replacement resolution
-          fails, the old view remains unchanged and expired. A future automatic re-resolution policy requires separate approval;
-          an expired plan may never begin new work.
+          fails, the old view remains unchanged and expired. V1 performs no automatic re-resolution, and an expired plan may
+          never begin new work.
         </p>
       </section>
 
@@ -510,11 +515,10 @@ except AssemblyExpiredError:
             <thead><tr><th>What you observe</th><th>What to check</th></tr></thead>
             <tbody>
               <tr><td><code>AssemblyExpiredError</code></td><td>Resolve the same reference again; do not extend or mutate the old view.</td></tr>
-              <tr><td>Resolve returns no view</td><td>Check descriptor/plan agreement, expiration, complete-plan length, aliases, and requested consistency.</td></tr>
+              <tr><td>Resolve returns no view</td><td>Check descriptor/plan agreement, expiration, complete-plan length, segment kinds, and aliases.</td></tr>
               <tr><td>Unknown object alias</td><td>Ensure <code>ObjectSegment.source_id</code> matches a configured <code>object_sources</code> key.</td></tr>
               <tr><td>Unknown service alias</td><td>Ensure <code>ServiceSegment.fetcher_id</code> matches an application-supplied fetcher.</td></tr>
               <tr><td>Service length or protocol failure</td><td>Check the fetcher's advertised range mode, returned length, chunk contract, deadline, and cancellation behavior.</td></tr>
-              <tr><td>Stronger consistency is rejected</td><td>Confirm every object segment has a complete checksum and every service segment has either a fetcher-enforced revision or a complete checksum.</td></tr>
             </tbody>
           </table>
         </div>
@@ -527,7 +531,7 @@ except AssemblyExpiredError:
           <li>Implement and inject <code>ServiceSegmentFetcher</code> only when service segments are present.</li>
           <li>Keep credentials, dependency objects, and executable behavior out of portable plans.</li>
           <li>Exercise full-object, partial-range, open-reader, materialization, expiration, and replacement-resolution flows.</li>
-          <li>Request only consistency guarantees that the plan evidence, Assembly core, and selected fetchers can enforce together.</li>
+          <li>Do not treat the v1 view itself as a dataset snapshot contract; enforce stronger identity inside application-owned dependencies when required.</li>
           <li>Close AssemblyClient, views, and readers predictably, and manage application-owned providers, fetchers, StorageClients, and related resources through their own public APIs.</li>
         </ul>
 

--- a/specs/2026-07-21-assembly-view/high-level-design.html
+++ b/specs/2026-07-21-assembly-view/high-level-design.html
@@ -1,0 +1,1187 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Assembly Module — High-Level Design</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f6f8fb;
+      --surface: #ffffff;
+      --surface-soft: #eef3f7;
+      --text: #172033;
+      --muted: #5f6b7c;
+      --border: #d8e0e8;
+      --accent: #116b5a;
+      --accent-soft: #e1f3ee;
+      --accent-text: #0b5043;
+      --warning: #8a5b00;
+      --warning-soft: #fff4d6;
+      --danger: #9d3038;
+      --danger-soft: #fdebed;
+      --object: #5d7fa8;
+      --code-bg: #101827;
+      --code-text: #eef4ff;
+      --shadow: 0 8px 28px rgba(25, 38, 57, 0.08);
+      --max: 1480px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0d131d;
+        --surface: #141c29;
+        --surface-soft: #1c2635;
+        --text: #e9eef6;
+        --muted: #aab4c4;
+        --border: #2b384a;
+        --accent: #6bd9bd;
+        --accent-soft: #173a34;
+        --accent-text: #acf0df;
+        --warning: #ffd174;
+        --warning-soft: #3d321c;
+        --danger: #ff9fa8;
+        --danger-soft: #442328;
+        --object: #91b7df;
+        --code-bg: #080d14;
+        --code-text: #eef4ff;
+        --shadow: 0 8px 28px rgba(0, 0, 0, 0.28);
+      }
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.62;
+    }
+    a { color: var(--accent); text-underline-offset: 0.18em; }
+    code, pre { font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace; }
+    code {
+      padding: 0.1em 0.28em;
+      border-radius: 0.3rem;
+      background: var(--surface-soft);
+      font-size: 0.92em;
+      overflow-wrap: anywhere;
+    }
+    pre {
+      margin: 1rem 0;
+      padding: 1rem 1.1rem;
+      overflow-x: auto;
+      border-radius: 0.7rem;
+      background: var(--code-bg);
+      color: var(--code-text);
+      line-height: 1.5;
+      font-size: 0.88rem;
+    }
+    pre code { padding: 0; background: transparent; color: inherit; overflow-wrap: normal; }
+    h1, h2, h3, h4 { line-height: 1.24; letter-spacing: -0.015em; }
+    h1 { margin: 0.35rem 0 0.8rem; font-size: clamp(2rem, 4.8vw, 3.5rem); }
+    h2 { margin: 0 0 1rem; font-size: clamp(1.4rem, 2.5vw, 2rem); }
+    h3 { margin: 1.55rem 0 0.65rem; font-size: 1.16rem; }
+    h4 { margin: 1.15rem 0 0.45rem; font-size: 1rem; }
+    p { margin: 0.6rem 0 1rem; }
+    ul, ol { padding-left: 1.35rem; }
+    li + li { margin-top: 0.38rem; }
+
+    .hero {
+      border-bottom: 1px solid var(--border);
+      background:
+        radial-gradient(circle at 82% 10%, color-mix(in srgb, var(--accent) 16%, transparent), transparent 30rem),
+        var(--surface);
+    }
+    .hero-inner { max-width: var(--max); margin: 0 auto; padding: 4rem 2.2rem 3.3rem; }
+    .eyebrow {
+      color: var(--accent);
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      font-size: 0.8rem;
+    }
+    .subtitle { max-width: 980px; margin: 0; color: var(--muted); font-size: 1.08rem; }
+    .meta, .doc-links { display: flex; flex-wrap: wrap; gap: 0.6rem 1.1rem; align-items: center; }
+    .meta { margin-top: 1.4rem; color: var(--muted); font-size: 0.9rem; }
+    .doc-links { margin-top: 1.25rem; }
+    .button {
+      display: inline-block;
+      padding: 0.55rem 0.8rem;
+      border: 1px solid var(--border);
+      border-radius: 0.55rem;
+      background: var(--surface);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 650;
+    }
+    .button.primary { border-color: var(--accent); background: var(--accent); color: var(--bg); }
+
+    .layout {
+      display: grid;
+      grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+      gap: 2rem;
+      max-width: var(--max);
+      margin: 0 auto;
+      padding: 2rem 2.2rem 6rem;
+    }
+    .toc {
+      align-self: start;
+      position: sticky;
+      top: 1.2rem;
+      max-height: calc(100vh - 2.4rem);
+      overflow-y: auto;
+      padding: 0.8rem 0;
+      font-size: 0.88rem;
+    }
+    .toc strong { display: block; margin-bottom: 0.55rem; }
+    .toc a {
+      display: block;
+      padding: 0.32rem 0.6rem;
+      border-left: 2px solid transparent;
+      color: var(--muted);
+      text-decoration: none;
+    }
+    .toc a:hover { border-left-color: var(--accent); color: var(--text); background: var(--accent-soft); }
+    main { min-width: 0; }
+    section {
+      margin-bottom: 1.6rem;
+      padding: 1.8rem;
+      border: 1px solid var(--border);
+      border-radius: 0.9rem;
+      background: var(--surface);
+      box-shadow: var(--shadow);
+      scroll-margin-top: 1.2rem;
+    }
+    .decision {
+      padding: 1.1rem 1.2rem;
+      border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
+      border-radius: 0.7rem;
+      background: var(--accent-soft);
+    }
+    .decision strong { color: var(--accent-text); }
+    .callout {
+      margin: 1rem 0;
+      padding: 0.9rem 1rem;
+      border-left: 4px solid var(--warning);
+      background: var(--warning-soft);
+    }
+    .callout.danger { border-left-color: var(--danger); background: var(--danger-soft); }
+    .callout.info { border-left-color: var(--accent); background: var(--accent-soft); }
+    .grid-2, .grid-3, .summary-grid {
+      display: grid;
+      gap: 0.9rem;
+      margin: 1rem 0;
+    }
+    .grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .grid-3, .summary-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .card {
+      padding: 1rem;
+      border: 1px solid var(--border);
+      border-radius: 0.7rem;
+      background: var(--surface-soft);
+    }
+    .card h3, .card h4 { margin-top: 0; }
+    .label {
+      display: block;
+      margin-bottom: 0.25rem;
+      color: var(--muted);
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+    .value { display: block; font-size: 1.12rem; font-weight: 750; }
+    .small { color: var(--muted); font-size: 0.88rem; }
+    .tag {
+      display: inline-block;
+      margin: 0.15rem 0.25rem 0.15rem 0;
+      padding: 0.2rem 0.5rem;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      background: var(--surface-soft);
+      font-size: 0.8rem;
+    }
+    .yes { color: var(--accent-text); font-weight: 700; }
+    .no { color: var(--danger); font-weight: 700; }
+    .maybe { color: var(--warning); font-weight: 700; }
+    .table-wrap { max-width: 100%; overflow-x: auto; margin: 1rem 0; }
+    table { width: 100%; border-collapse: collapse; font-size: 0.91rem; }
+    th, td { padding: 0.72rem; border-bottom: 1px solid var(--border); text-align: left; vertical-align: top; }
+    th { background: var(--surface-soft); font-size: 0.82rem; letter-spacing: 0.02em; }
+    tr:last-child td { border-bottom: 0; }
+
+    .architecture {
+      display: grid;
+      gap: 0.75rem;
+      margin: 1.1rem 0;
+      padding: 1rem;
+      border: 1px dashed var(--border);
+      border-radius: 0.8rem;
+      background: color-mix(in srgb, var(--surface-soft) 72%, transparent);
+    }
+    .arch-row { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.75rem; align-items: stretch; }
+    .arch-node {
+      padding: 0.8rem;
+      border: 1px solid var(--border);
+      border-radius: 0.6rem;
+      background: var(--surface);
+      text-align: center;
+    }
+    .arch-node.new { border-color: color-mix(in srgb, var(--accent) 65%, var(--border)); background: var(--accent-soft); }
+    .arch-node.user { border-color: color-mix(in srgb, var(--warning) 60%, var(--border)); background: var(--warning-soft); }
+    .arch-node.existing { border-color: color-mix(in srgb, var(--object) 58%, var(--border)); }
+    .arch-arrow { text-align: center; color: var(--muted); font-weight: 700; }
+    .arch-legend { display: flex; flex-wrap: wrap; gap: 0.7rem; color: var(--muted); font-size: 0.84rem; }
+
+    .boundary-list { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.8rem; }
+    .boundary { padding-top: 0.75rem; border-top: 3px solid var(--border); }
+    .boundary:nth-child(1) { border-top-color: var(--accent); }
+    .boundary:nth-child(2) { border-top-color: var(--warning); }
+    .boundary:nth-child(3) { border-top-color: var(--object); }
+    .boundary h3 { margin-top: 0; }
+
+    .sample-flow {
+      display: grid;
+      gap: 0.9rem;
+      margin: 1.1rem 0 0;
+      padding: 1rem;
+      border: 1px dashed var(--border);
+      border-radius: 0.8rem;
+      background: color-mix(in srgb, var(--surface-soft) 72%, transparent);
+    }
+    .sample-caption { color: var(--muted); font-size: 0.88rem; font-weight: 700; }
+    .sample-stage {
+      padding: 1rem;
+      border: 1px solid var(--border);
+      border-radius: 0.7rem;
+      background: var(--surface);
+    }
+    .sample-plan { border-color: color-mix(in srgb, var(--warning) 55%, var(--border)); }
+    .sample-view {
+      border-color: color-mix(in srgb, var(--accent) 65%, var(--border));
+      background: var(--accent-soft);
+    }
+    .view-state-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 0.65rem;
+      margin-top: 0.85rem;
+    }
+    .view-state {
+      padding: 0.75rem;
+      border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border));
+      border-radius: 0.55rem;
+      background: var(--surface);
+    }
+    .view-state strong { display: block; margin-bottom: 0.25rem; }
+    .view-state .small { display: block; }
+    .sample-stage-heading, .sample-object-heading, .sample-output {
+      display: flex;
+      justify-content: space-between;
+      gap: 1rem;
+      align-items: center;
+    }
+    .sample-object-heading { margin: 0.9rem 0 0.65rem; padding-top: 0.8rem; border-top: 1px solid var(--border); }
+    .byte-map {
+      display: grid;
+      grid-template-columns: minmax(82px, 0.55fr) minmax(145px, 1.3fr) minmax(145px, 1.3fr) minmax(120px, 0.95fr) minmax(150px, 1.2fr) minmax(82px, 0.55fr);
+      gap: 0.35rem;
+    }
+    .byte-segment {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 0.22rem;
+      min-height: 8.8rem;
+      padding: 0.75rem;
+      border: 1px solid var(--border);
+      border-top-width: 4px;
+      border-radius: 0.55rem;
+      background: var(--surface-soft);
+    }
+    .byte-segment.inline { border-top-color: var(--accent); }
+    .byte-segment.object { border-top-color: var(--object); }
+    .byte-segment.service { border-top-color: var(--warning); }
+    .segment-number {
+      display: grid;
+      place-items: center;
+      width: 1.45rem;
+      height: 1.45rem;
+      border-radius: 50%;
+      background: var(--surface);
+      color: var(--muted);
+      font-size: 0.75rem;
+      font-weight: 750;
+    }
+    .byte-scale { display: flex; justify-content: space-between; margin-top: 0.35rem; color: var(--muted); font-size: 0.78rem; }
+    .sample-arrow { padding: 0.25rem 1rem; color: var(--muted); text-align: center; font-weight: 650; }
+    .sample-owner-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.75rem; }
+    .sample-owner {
+      padding: 0.9rem;
+      border: 1px solid var(--border);
+      border-top: 4px solid var(--border);
+      border-radius: 0.65rem;
+      background: var(--surface);
+    }
+    .sample-owner p { margin-bottom: 0; color: var(--muted); font-size: 0.88rem; }
+    .sample-owner.inline { border-top-color: var(--accent); }
+    .sample-owner.object { border-top-color: var(--object); }
+    .sample-owner.service { border-top-color: var(--warning); }
+    .sample-output {
+      padding: 1rem;
+      border: 1px solid color-mix(in srgb, var(--accent) 65%, var(--border));
+      border-radius: 0.7rem;
+      background: var(--accent-soft);
+    }
+    .sample-output p { margin-bottom: 0; }
+    .sample-actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 0.45rem; }
+
+    .sequence { margin: 1rem 0; counter-reset: seq; }
+    .sequence-item { position: relative; margin-left: 1.1rem; padding: 0 0 1rem 1.5rem; border-left: 2px solid var(--border); }
+    .sequence-item::before {
+      counter-increment: seq;
+      content: counter(seq);
+      position: absolute;
+      left: -0.85rem;
+      top: -0.05rem;
+      width: 1.55rem;
+      height: 1.55rem;
+      display: grid;
+      place-items: center;
+      border-radius: 50%;
+      background: var(--accent);
+      color: var(--bg);
+      font-weight: 700;
+      font-size: 0.78rem;
+    }
+    .sequence-item:last-child { padding-bottom: 0; border-left-color: transparent; }
+    .sequence-item strong { display: block; }
+    .formula {
+      padding: 0.85rem 1rem;
+      border-radius: 0.65rem;
+      background: var(--code-bg);
+      color: var(--code-text);
+      font-family: "SFMono-Regular", Consolas, monospace;
+      overflow-x: auto;
+      white-space: nowrap;
+    }
+
+    @media (max-width: 1120px) {
+      .byte-map { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    }
+    @media (max-width: 1000px) {
+      .layout { grid-template-columns: 1fr; padding-top: 1rem; }
+      .toc { position: static; max-height: none; display: flex; flex-wrap: wrap; gap: 0.25rem; border-bottom: 1px solid var(--border); }
+      .toc strong { width: 100%; }
+      .toc a { border-left: 0; border-bottom: 2px solid transparent; }
+      .toc a:hover { border-bottom-color: var(--accent); }
+    }
+    @media (max-width: 760px) {
+      .hero-inner, .layout { padding-left: 1rem; padding-right: 1rem; }
+      section { padding: 1.15rem; }
+      .grid-2, .grid-3, .summary-grid, .arch-row, .boundary-list, .byte-map, .sample-owner-grid, .view-state-grid { grid-template-columns: 1fr; }
+      .button { width: 100%; text-align: center; }
+      .byte-segment { min-height: auto; }
+      .byte-scale { display: none; }
+      .sample-stage-heading, .sample-object-heading, .sample-output { align-items: flex-start; flex-direction: column; }
+      .sample-actions { justify-content: flex-start; }
+    }
+    @media print {
+      body { background: #fff; color: #111; }
+      .hero { background: #fff; }
+      .toc, .doc-links { display: none; }
+      .layout { display: block; padding: 1rem; }
+      section { box-shadow: none; break-inside: avoid; }
+      a { color: inherit; }
+    }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <div class="hero-inner">
+      <div class="eyebrow">High-Level Design · Draft for Review</div>
+      <h1>Assembly Module</h1>
+      <p class="subtitle">
+        Decision and public API overview for a generic, read-only object assembly layer under
+        <code>multistorageclient.assembly</code>. This document explains what we are building, why it is parallel to
+        StorageClient, and where application-owned planning ends and MSC-owned byte execution begins.
+      </p>
+      <div class="meta">
+        <span>Spec date: 2026-07-21</span>
+        <span>Last revised: 2026-07-22</span>
+        <span>Status: Proposed</span>
+        <span>Compatibility: Additive</span>
+        <span>Reading time: approximately 10 minutes</span>
+      </div>
+      <div class="doc-links">
+        <a class="button primary" href="high-level-design.html">High-Level Design</a>
+        <a class="button" href="assembly-workflow-user-guide.html">Workflow User Guide</a>
+        <a class="button" href="implementation-and-test-plan.html">Implementation &amp; Test Plan</a>
+      </div>
+    </div>
+  </header>
+
+  <div class="layout">
+    <nav class="toc" aria-label="Table of contents">
+      <strong>Contents</strong>
+      <a href="#decision">1. Executive decision</a>
+      <a href="#scope">2. Goals and scope</a>
+      <a href="#placement">3. Why a separate module</a>
+      <a href="#architecture">4. Architecture</a>
+      <a href="#public-api">5. Public API</a>
+      <a href="#sample-composition">6. Parquet example</a>
+      <a href="#extension-model">7. Extension model</a>
+      <a href="#guarantees">8. Behavioral guarantees</a>
+      <a href="#compatibility">9. Compatibility</a>
+      <a href="#open-decisions">10. Open decisions</a>
+      <a href="#appendix">11. Traceability and references</a>
+    </nav>
+
+    <main>
+      <section id="decision">
+        <h2>1. Executive decision</h2>
+        <div class="decision">
+          <strong>Build a separate <code>multistorageclient.assembly</code> module.</strong> Applications construct an
+          <code>AssemblyClient</code> with a user-supplied <code>AssemblyPlanProvider</code>, local object-source bindings, and
+          service executors. Resolving a logical name returns a fixed, expiring <code>AssemblyView</code>. The module neither
+          subclasses <code>StorageClient</code> nor registers an assembled backend as a <code>StorageProvider</code>.
+        </div>
+
+        <div class="summary-grid">
+          <div class="card">
+            <span class="label">What users receive</span>
+            <span class="value">One logical byte object</span>
+            <p class="small">Range reads, a read-only stream, metadata, and atomic local materialization.</p>
+          </div>
+          <div class="card">
+            <span class="label">What users provide</span>
+            <span class="value">Planning and bindings</span>
+            <p class="small">A plan provider plus locally trusted storage and service implementations.</p>
+          </div>
+          <div class="card">
+            <span class="label">What remains unchanged</span>
+            <span class="value">MSC storage core</span>
+            <p class="small">Existing clients, providers, profiles, paths, and mutation APIs retain their behavior.</p>
+          </div>
+        </div>
+
+        <p>
+          This preserves MSC's original purpose—unified access to physical storage—while adding an application-layer view
+          that composes bytes already available through that access. The assembly service is an application capability, not
+          a new storage backend and not necessarily an HTTP service.
+        </p>
+        <div class="formula">descriptor metadata → complete plan → validation + frozen bindings → executable AssemblyView</div>
+      </section>
+
+      <section id="scope">
+        <h2>2. Goals, scope, and non-goals</h2>
+        <p>
+          A logical object is the ordered concatenation of three explicit segment kinds. Keeping the kinds visible makes the
+          contract understandable and prevents application semantics from leaking into MSC.
+        </p>
+
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Segment</th><th>Meaning</th><th>Executed by</th></tr></thead>
+            <tbody>
+              <tr><td><code>ObjectSegment</code></td><td>An exact byte range from an existing physical object.</td><td>A locally configured <code>StorageClient</code> binding.</td></tr>
+              <tr><td><code>ServiceSegment</code></td><td>Opaque bytes generated or transformed by an application service.</td><td>A user-defined, locally configured <code>ServiceSegmentExecutor</code>.</td></tr>
+              <tr><td><code>InlineSegment</code></td><td>A small, strictly bounded literal carried in the plan.</td><td>The assembly module without external I/O.</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="grid-2">
+          <div class="card">
+            <h3>Goals</h3>
+            <ul>
+              <li>Expose one read-only logical byte stream over ordered multi-source segments.</li>
+              <li>Resolve a complete plan with mandatory expiration and caller-controlled refresh.</li>
+              <li>Support exact ranges, streaming, metadata, and bounded local materialization.</li>
+              <li>Allow any planning backend through an in-process provider interface.</li>
+              <li>Keep credentials, endpoints, and executable bindings under local application control.</li>
+              <li>Preserve truthful consistency: expiration by default, stronger pinning only when enforceable.</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Non-goals</h3>
+            <ul>
+              <li>Define a universal HTTP or gRPC API for the planning service.</li>
+              <li>Teach MSC about specific file formats, media containers, schemas, rows, or samples.</li>
+              <li>Add write, delete, copy, sync, or presign semantics to assembled views.</li>
+              <li>Make the feature automatically appear in every existing MSC, FUSE, CLI, or fsspec path.</li>
+              <li>Let a remote plan choose credentials, profiles, arbitrary endpoints, or Python objects.</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="callout info">
+          <strong>Requirements versus defensive design.</strong> The requirements explicitly call for configured sources and
+          services, direct storage reads for object segments, transport-neutral service segments, optional source
+          versions/validators, bounded execution, and no breaking changes to existing providers. They do not require public
+          binding-revision or resource-policy hooks, a built-in network executor, an MSC-defined external service API, or
+          format-specific executors. If implementation work proposes those additional safeguards or conveniences, they remain
+          separately reviewable defensive design—not requirements.
+        </div>
+      </section>
+
+      <section id="placement">
+        <h2>3. Why a separate Assembly module</h2>
+        <p>
+          The decisive question is substitutability: can assembly honestly satisfy the existing abstraction without special
+          cases? It cannot. Assembly is a derived view over several authorities, while the existing types model unified
+          access to physical storage authorities.
+        </p>
+
+        <div class="grid-2">
+          <div class="card">
+            <h3>Why not StorageProvider</h3>
+            <ul>
+              <li>A provider is a leaf authority for one physical namespace; assembly orchestrates several authorities.</li>
+              <li>The provider interface includes mutations that have no coherent meaning for a derived view.</li>
+              <li>Only StorageClient currently owns providers. A provider that owns other providers would reverse MSC's dependency and lifecycle model.</li>
+              <li>Logical identity and expiration come from the plan provider, not from any physical backend.</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Why not StorageClient</h3>
+            <ul>
+              <li>StorageClient unifies storage access; it should not acquire application-specific content orchestration.</li>
+              <li>A special case in <code>read</code> would spread into info, open, list, cache, download, sync, and error behavior.</li>
+              <li>Assembly needs fixed generations, expiration, service execution, and multi-source atomicity—concepts absent from the storage façade.</li>
+              <li>A parallel module can expose honest read-only capabilities without pretending to support the entire mutable client surface.</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="callout info">
+          <strong>Provider pattern is not StorageProvider inheritance.</strong> <code>AssemblyPlanProvider</code> is a narrow
+          application extension point that returns logical descriptors and plans. Existing <code>StorageProvider</code>
+          implementations continue to perform physical I/O behind StorageClient.
+        </div>
+
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Decision driver</th><th>StorageProvider</th><th>StorageClient</th><th>Assembly module</th></tr></thead>
+            <tbody>
+              <tr><td>Abstraction fit</td><td><span class="no">Weak</span>: derived content is not a backend</td><td><span class="maybe">Mixed</span>: access fits; content planning does not</td><td><span class="yes">Strong</span>: explicit derived view</td></tr>
+              <tr><td>Ownership direction</td><td><span class="no">Reversed</span> if it owns sources</td><td>Requires pervasive special routing</td><td><span class="yes">Application composes peers</span></td></tr>
+              <tr><td>Read-only truthfulness</td><td>Conflicts with mutable contract</td><td>Conflicts with broad façade</td><td><span class="yes">Native</span></td></tr>
+              <tr><td>Compatibility risk</td><td>High</td><td>High</td><td><span class="yes">Low and additive</span></td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="architecture">
+        <h2>4. Architecture and ownership boundaries</h2>
+        <div class="architecture" role="img" aria-label="AssemblyClient resolves descriptor metadata, obtains and validates a complete plan, freezes local bindings, and only then returns an executable AssemblyView.">
+          <div class="arch-row">
+            <div></div>
+            <div class="arch-node"><strong>Application</strong><br><span class="small">constructs dependencies and asks for a logical object</span></div>
+            <div></div>
+          </div>
+          <div class="arch-arrow">↓</div>
+          <div class="arch-row">
+            <div class="arch-node user"><strong>AssemblyPlanProvider</strong><br><span class="small"><code>resolve_descriptor()</code> → metadata<br><code>get_plan()</code> → complete plan</span></div>
+            <div class="arch-node new"><strong>AssemblyClient.resolve()</strong><br><span class="small">coordinate · validate · freeze · compute capabilities</span></div>
+            <div class="arch-node"><strong>Local binding registry</strong><br><span class="small">StorageClient sources · user-owned service executors</span></div>
+          </div>
+          <div class="arch-arrow">↓ descriptor metadata → complete plan → validation + frozen alias snapshot</div>
+          <div class="arch-row">
+            <div></div>
+            <div class="arch-node new"><strong>AssemblyView</strong><br><span class="small"><code>metadata</code> = descriptor · validated plan · frozen bindings · lifecycle</span></div>
+            <div></div>
+          </div>
+          <div class="arch-arrow">↓ dispatch by explicit segment kind</div>
+          <div class="arch-row">
+            <div class="arch-node existing"><strong>ObjectSegment</strong><br><span class="small">existing StorageClient → StorageProvider</span></div>
+            <div class="arch-node user"><strong>ServiceSegment</strong><br><span class="small">user-owned ServiceSegmentExecutor</span></div>
+            <div class="arch-node new"><strong>InlineSegment</strong><br><span class="small">bounded plan bytes</span></div>
+          </div>
+          <div class="arch-legend">
+            <span><span class="tag">Green</span> assembly module</span>
+            <span><span class="tag">Gold</span> application extension</span>
+            <span><span class="tag">Blue outline</span> existing MSC core</span>
+          </div>
+        </div>
+
+        <div class="boundary-list">
+          <div class="boundary">
+            <h3>Assembly module owns</h3>
+            <ul>
+              <li>Descriptor-to-plan resolution and executable-view construction.</li>
+              <li>Plan validation and logical range calculation.</li>
+              <li>Expiration, consistency, and view lifecycle.</li>
+              <li>Bounded execution, ordering, and atomic publication.</li>
+              <li>Stable public behavior independent of backend transport.</li>
+            </ul>
+          </div>
+          <div class="boundary">
+            <h3>Application owns</h3>
+            <ul>
+              <li>Logical namespace and file-format meaning.</li>
+              <li>Plan-provider implementation and backend protocol.</li>
+              <li>Source bindings and service-executor implementations wired at construction.</li>
+              <li>Credential, endpoint, and dependency lifecycle choices.</li>
+            </ul>
+          </div>
+          <div class="boundary">
+            <h3>Bindings own</h3>
+            <ul>
+              <li>Physical object or service-operation interpretation.</li>
+              <li>Authentication and connection management.</li>
+              <li>Transport-specific validation and bounded retries.</li>
+              <li>Resource safety and any stable identity enforcement they advertise.</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section id="public-api">
+        <h2>5. Public API at a glance</h2>
+        <p>
+          The common workflow is intentionally small: inject dependencies once, resolve one generation, then operate on its
+          view. Detailed signatures, configuration fields, limits, and typed-error construction live in the
+          <a href="implementation-and-test-plan.html#contracts">Implementation &amp; Test Plan</a>.
+        </p>
+
+        <p>
+          An object source wraps an already configured <code>StorageClient</code>. A service executor is a concrete
+          user-owned implementation of <code>ServiceSegmentExecutor</code>. MSC defines the in-process behavior of that SPI,
+          not the application's external protocol.
+        </p>
+
+        <pre><code># Imports are omitted. Configure physical storage through ordinary MSC APIs.
+raw_storage = StorageClient(
+    StorageClientConfig.from_file(profile="raw-data")
+)
+
+# Existing physical storage is exposed through a normal MSC client.
+raw_source = ObjectSourceBinding(
+    client=raw_storage,
+)
+
+# User code implements MSC's ServiceSegmentExecutor SPI.
+rewrite_service = MyServiceExecutor(
+    client=my_service_client,
+)
+
+# User code also implements the control-plane provider SPI.
+catalog = MyAssemblyPlanProvider(client=my_catalog_client)
+
+assembly = AssemblyClient(
+    plan_provider=catalog,
+    object_sources={
+        "raw": raw_source,          # selected by ObjectSegment.source_id
+    },
+    service_executors={
+        "rewrite": rewrite_service, # selected by ServiceSegment.executor_id
+    },
+)
+
+# resolve() obtains descriptor metadata and a complete plan. It returns only
+# after plan validation, binding freeze, and capability computation succeed.
+view = assembly.resolve(
+    AssemblyReference(namespace="exports", key="run-42.bin")
+)
+
+# metadata is the AssemblyDescriptor for this fixed generation.
+descriptor = view.metadata
+
+# Execute one logical range or publish the whole object locally.
+footer = view.read(ByteRange(offset=footer_offset, size=8192))
+view.materialize("/tmp/run-42.bin")
+
+# Refresh creates a replacement view; the original never changes.
+new_view = assembly.refresh(view)</code></pre>
+
+        <div class="callout info">
+          <strong><code>MyServiceExecutor</code> is application code, not an MSC built-in type.</strong> It translates one
+          <code>ServiceExecutionRequest</code> into the application's HTTP, gRPC, SDK, or local-service call. It never receives
+          the complete <code>AssemblyPlan</code>, never chooses segment order, and returns only the byte stream for one
+          <code>ServiceSegment</code> under the declared length, range mode, deadline, and cancellation contract.
+        </div>
+
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Operation</th><th>What the caller gets</th><th>Important behavior</th></tr></thead>
+            <tbody>
+              <tr><td><code>resolve</code></td><td>A fixed, expiring <code>AssemblyView</code>.</td><td>Resolve metadata, acquire and validate the complete plan, freeze bindings, compute capabilities, then return; no executable view is exposed earlier.</td></tr>
+              <tr><td><code>read</code></td><td>Exactly one logical byte window.</td><td>Map the requested offsets through the view's validated plan and dispatch only intersecting segments.</td></tr>
+              <tr><td><code>open</code></td><td>A read-only stream.</td><td>The reader stays on the same generation and plan; seek is advertised only when that plan supports it safely.</td></tr>
+              <tr><td><code>metadata</code></td><td>The view's <code>AssemblyDescriptor</code>.</td><td>Control-plane metadata includes its reference, generation, size, and expiration; the descriptor itself cannot read, open, or materialize bytes.</td></tr>
+              <tr><td><code>materialize</code></td><td>A complete local file.</td><td>Walk the same plan in bounded windows and atomically publish; no-replace by default.</td></tr>
+              <tr><td><code>refresh</code></td><td>A new view.</td><td>Optional provider capability; the old view remains unchanged.</td></tr>
+              <tr><td><code>list</code> / <code>glob</code></td><td>Logical descriptors.</td><td>Optional browsing capability, separate from executable plan batches.</td></tr>
+              <tr><td>write / delete / copy / sync</td><td>Not supported.</td><td>Assembled views are deliberately read-only.</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>What AssemblyView encapsulates</h3>
+        <p>
+          <code>AssemblyView</code> is more than metadata: it is the immutable execution context for one resolved generation.
+          It keeps the identity and plan stable while delegating heavy scheduling and I/O to client-owned machinery.
+        </p>
+        <div class="grid-3">
+          <div class="card">
+            <span class="label">Frozen identity</span>
+            <strong>Descriptor metadata</strong>
+            <p class="small"><code>view.metadata</code> returns the control-plane descriptor: logical reference, generation, size, expiration, and optional application metadata.</p>
+          </div>
+          <div class="card">
+            <span class="label">Executable snapshot</span>
+            <strong>Validated plan and bindings</strong>
+            <p class="small">The complete ordered AssemblyPlan and a frozen alias-to-binding snapshot validated before the view is returned.</p>
+          </div>
+          <div class="card">
+            <span class="label">Operation façade</span>
+            <strong>Logical ranges to bytes</strong>
+            <p class="small">Maps reads and materialization windows to plan segments, then delegates admission, dispatch, staging, cancellation, and assembly.</p>
+          </div>
+        </div>
+        <p class="small">
+          An <code>AssemblyDescriptor</code> is metadata only and has no byte operations. The executable view never owns a
+          StorageProvider, replans the object, or refreshes itself. <code>open()</code> creates a reader pinned to the same
+          descriptor and plan; <code>refresh()</code> creates another view. Client-wide scheduling, reader state, staging,
+          and atomic publication are detailed in
+          <a href="implementation-and-test-plan.html#executor">Executor, AssemblyView, reader, and materialization</a>.
+        </p>
+
+        <div class="callout">
+          Plans contain only the aliases <code>raw</code> and <code>rewrite</code>; credentials, service URLs, authentication,
+          and lifecycle stay in the local bindings. Dependencies are borrowed by default. The exact façade is documented in
+          <a href="implementation-and-test-plan.html#public-facade-reference">the API reference subsection</a>, and error
+          construction in <a href="implementation-and-test-plan.html#exceptions">the implementation error contract</a>.
+          Custom executor details are in <a href="implementation-and-test-plan.html#sources">the executor SPI</a>.
+        </div>
+      </section>
+
+      <section id="sample-composition">
+        <h2>6. Worked example: assembling a Parquet object</h2>
+        <p>
+          Parquet makes the byte flow concrete, but it is only an example. The planning application understands page and
+          footer semantics; the assembly module sees an ordered list of opaque byte segments, declared lengths, and local
+          bindings.
+        </p>
+
+        <figure class="sample-flow" aria-labelledby="parquet-example-caption">
+          <figcaption id="parquet-example-caption" class="sample-caption">
+            Descriptor metadata → complete plan → validated executable view → one logical byte stream
+          </figcaption>
+
+          <div class="sample-stage sample-plan">
+            <div class="sample-stage-heading">
+              <div>
+                <span class="label">1 · Resolve control-plane metadata</span>
+                <strong><code>AssemblyPlanProvider.resolve_descriptor(request)</code></strong>
+              </div>
+              <span class="tag">returns metadata only</span>
+            </div>
+
+            <div class="sample-object-heading">
+              <div>
+                <span class="label">AssemblyDescriptor g-193</span>
+                <code>AssemblyDescriptor("exports/run-42.parquet")</code>
+              </div>
+              <span class="small">generation <code>g-193</code> · logical size · mandatory expiration</span>
+            </div>
+            <p class="small">The descriptor cannot read, open, or materialize bytes.</p>
+          </div>
+
+          <div class="sample-arrow">
+            ↓ <code>AssemblyPlanProvider.get_plan(descriptor)</code> returns the complete <code>AssemblyPlan</code> for exactly
+            <code>g-193</code>—never a range-specific fragment
+          </div>
+
+          <div class="sample-stage sample-plan">
+            <div class="sample-stage-heading">
+              <div>
+                <span class="label">2 · Complete AssemblyPlan</span>
+                <strong>Six ordered logical byte segments</strong>
+              </div>
+              <span class="tag">logical size = checked segment-length sum</span>
+            </div>
+
+            <div class="sample-object-heading">
+              <div>
+                <span class="label">Plan identity</span>
+                <code>exports/run-42.parquet · g-193</code>
+              </div>
+              <span class="small">aliases only: <code>raw</code> and <code>rewrite</code></span>
+            </div>
+
+            <div class="byte-map" aria-label="Ordered logical Parquet byte layout">
+              <div class="byte-segment inline">
+                <span class="segment-number">1</span>
+                <strong>File header</strong>
+                <code>PAR1</code>
+                <span class="small">InlineSegment</span>
+              </div>
+              <div class="byte-segment object">
+                <span class="segment-number">2</span>
+                <strong>Row-group pages A</strong>
+                <code>part-001 · exact range</code>
+                <span class="small">ObjectSegment · <code>source_id="raw"</code></span>
+              </div>
+              <div class="byte-segment object">
+                <span class="segment-number">3</span>
+                <strong>Row-group pages B</strong>
+                <code>part-002 · exact range</code>
+                <span class="small">ObjectSegment · <code>source_id="raw"</code></span>
+              </div>
+              <div class="byte-segment service">
+                <span class="segment-number">4</span>
+                <strong>Page indexes</strong>
+                <code>build-indexes</code>
+                <span class="small">ServiceSegment · <code>executor_id="rewrite"</code></span>
+              </div>
+              <div class="byte-segment service">
+                <span class="segment-number">5</span>
+                <strong>Metadata + length</strong>
+                <code>FileMetaData</code>
+                <span class="small">ServiceSegment · <code>executor_id="rewrite"</code></span>
+              </div>
+              <div class="byte-segment inline">
+                <span class="segment-number">6</span>
+                <strong>Trailing magic</strong>
+                <code>PAR1</code>
+                <span class="small">InlineSegment</span>
+              </div>
+            </div>
+            <div class="byte-scale">
+              <span>logical offset 0</span>
+              <span>concatenation order →</span>
+              <span>EOF</span>
+            </div>
+          </div>
+
+          <div class="sample-arrow">
+            ↓ <code>AssemblyClient</code> validates the complete union, lengths, expiration, aliases, and requested
+            consistency; then freezes the local bindings and computes capabilities
+          </div>
+
+          <div class="sample-stage sample-view">
+            <div class="sample-stage-heading">
+              <div>
+                <span class="label">3 · Returned execution façade</span>
+                <strong><code>AssemblyClient.resolve()</code> returns <code>AssemblyView[g-193]</code></strong>
+              </div>
+              <span class="tag">fixed until caller-controlled refresh</span>
+            </div>
+            <div class="view-state-grid">
+              <div class="view-state">
+                <strong>Descriptor state</strong>
+                <span class="small"><code>view.metadata</code> is the resolved <code>AssemblyDescriptor</code></span>
+              </div>
+              <div class="view-state">
+                <strong>Validated plan</strong>
+                <span class="small">the same six ordered segments and their logical offset boundaries</span>
+              </div>
+              <div class="view-state">
+                <strong>Frozen bindings</strong>
+                <span class="small"><code>raw</code> → ObjectSourceBinding · <code>rewrite</code> → user-owned MyServiceExecutor</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="sample-arrow">
+            ↓ <code>AssemblyView</code> maps the requested logical offsets through its plan; the client's shared executor
+            dispatches only the intersecting slices
+          </div>
+
+          <div class="sample-owner-grid">
+            <div class="sample-owner inline">
+              <span class="label">Inline bytes</span>
+              <strong>Assembly module</strong>
+              <p>Emits the two bounded <code>PAR1</code> literals carried by the plan. No external I/O is needed.</p>
+            </div>
+            <div class="sample-owner object">
+              <span class="label">Stored page ranges</span>
+              <strong><code>ObjectSourceBinding</code> → existing <code>StorageClient</code></strong>
+              <p>Reads exact ranges from <code>part-001</code> and <code>part-002</code> with locally configured storage credentials.</p>
+            </div>
+            <div class="sample-owner service">
+              <span class="label">Generated bytes</span>
+              <strong>User-owned <code>MyServiceExecutor</code></strong>
+              <p>Fulfills one service segment through the application's own protocol; it does not receive or order the complete plan.</p>
+            </div>
+          </div>
+
+          <div>
+            <span class="label">How the same view reuses the plan</span>
+            <div class="grid-3">
+              <div class="card">
+                <strong><code>view.read(footer_range)</code></strong>
+                <p class="small">Maps the logical offsets through the plan, touches only segments 5–6, invokes <code>rewrite</code>, then appends the inline trailing magic.</p>
+              </div>
+              <div class="card">
+                <strong><code>view.open()</code></strong>
+                <p class="small">Maps every cursor read against the same generation and six-segment plan without resolving again.</p>
+              </div>
+              <div class="card">
+                <strong><code>view.materialize(...)</code></strong>
+                <p class="small">Walks the complete plan in bounded windows and atomically publishes the local file.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="sample-arrow">
+            ↓ The view preserves plan order while the client engine validates and concatenates results; neither interprets
+            their Parquet meaning
+          </div>
+
+          <div class="sample-output">
+            <div>
+              <span class="label">Result</span>
+              <strong>One valid logical Parquet object</strong>
+              <p class="small">The caller sees one continuous byte sequence assembled from stored, generated, and inline bytes.</p>
+            </div>
+            <div class="sample-actions" aria-label="Available public operations">
+              <code>view.read(range)</code>
+              <code>view.open()</code>
+              <code>view.materialize(...)</code>
+            </div>
+          </div>
+        </figure>
+
+        <div class="callout">
+          <strong>The format boundary is intentional.</strong> If a different application assembles JSONL, a media file, or
+          an unknown future format, the AssemblyClient algorithm is unchanged. Only the plan provider and service executors
+          know why each byte range belongs in that position.
+        </div>
+      </section>
+
+      <section id="extension-model">
+        <h2>7. Extension model</h2>
+        <p>
+          Application-owned planning enters MSC through a provider-style in-process interface. Users may back this interface
+          with HTTP, gRPC, a database, a local manifest, or an existing SDK without changing AssemblyClient.
+        </p>
+
+        <pre><code>class AssemblyPlanProvider(ABC):
+    def resolve_descriptor(
+        self, request: ResolveAssemblyRequest
+    ) -> AssemblyDescriptor: ...
+
+    def get_plan(
+        self,
+        descriptor: AssemblyDescriptor,
+        *,
+        deadline_monotonic: float | None = None,
+    ) -> AssemblyPlan: ...
+
+    # Optional: advertise support and return a replacement generation.
+    def refresh(self, request: RefreshAssemblyRequest) -> AssemblyDescriptor: ...
+
+    def close(self) -> None: ...</code></pre>
+
+        <div class="grid-2">
+          <div class="card">
+            <h3>The provider promises</h3>
+            <ul>
+              <li><code>resolve_descriptor()</code> returns metadata only: one exact reference, generation, size, and future expiration.</li>
+              <li><code>get_plan()</code> returns that descriptor's complete ordered object plan, never a range-specific fragment.</li>
+              <li>Canonical bounded models and stable public failure classifications.</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>AssemblyClient promises</h3>
+            <ul>
+              <li>Expose no <code>AssemblyView</code> before complete-plan validation and binding freeze succeed.</li>
+              <li>Perform no source or service byte I/O while resolving or validating the plan.</li>
+              <li>Never silently substitute a generation or downgrade consistency.</li>
+              <li>Resolve aliases only through the frozen local registries.</li>
+              <li>Supply a reusable conformance suite for custom implementations.</li>
+            </ul>
+          </div>
+        </div>
+
+        <h3>No universal control-plane network API</h3>
+        <div class="callout info">
+          MSC does not define endpoints such as <code>POST /assemblies:resolve</code>. Network shape, authentication, and retry
+          policy belong to the provider implementation. The same rule applies to service fulfillment: MSC defines the
+          in-process SPI, not server endpoints, payloads, or authentication. MSC also standardizes the optional
+          language-neutral <code>assembly-list/v1</code> artifact.
+        </div>
+
+        <h3>Planning and byte fulfillment are separate roles</h3>
+        <p>
+          <code>AssemblyPlanProvider</code> says <em>which bytes form the object</em>.
+          A user-owned <code>ServiceSegmentExecutor</code> produces bytes for exactly one service segment under its declared
+          length, range, deadline, and cancellation contract. It receives neither the complete plan nor authority to order
+          segments. One backend may support both concerns, but the application injects separate adapters so the paths can
+          have different authorization, scaling, retry, and lifecycle policies.
+        </p>
+
+        <h3>Core adoption has no network-adapter dependency</h3>
+        <p>
+          Custom providers and service executors are sufficient for the core feature. A reusable network convenience adapter
+          would be a separately approved follow-up with its own generic transport contract; it is not a prerequisite for the
+          Assembly engine or its end-to-end tests.
+        </p>
+      </section>
+
+      <section id="guarantees">
+        <h2>8. Key behavioral guarantees</h2>
+        <p>
+          These are the guarantees an API reviewer needs to evaluate. Their exact algorithms, limits, exception hierarchy,
+          and test cases are specified in the <a href="implementation-and-test-plan.html">Implementation &amp; Test Plan</a>.
+        </p>
+
+        <div class="grid-2">
+          <div class="card">
+            <h3>Fixed and expiring views</h3>
+            <p>A view holds its descriptor, one complete plan, frozen bindings, computed capabilities, and lifecycle state. Expiration is checked before each new operation. Refresh creates another view and never mutates the old one.</p>
+          </div>
+          <div class="card">
+            <h3>Truthful consistency</h3>
+            <p><code>EXPIRATION_ONLY</code> is the default and does not promise immutable source bytes. <code>SNAPSHOT_PINNED</code> is available only when every non-inline segment has enforceable stable identity.</p>
+          </div>
+          <div class="card">
+            <h3>Complete-plan validation</h3>
+            <p>MSC validates the segment union, aliases, expiration, per-segment lengths, and checked global sum before any byte I/O or view exposure. Invalid or unknown input fails closed.</p>
+          </div>
+          <div class="card">
+            <h3>Bounded execution</h3>
+            <p>Concurrency, memory, staging, inline data, result sizes, and deadlines are client-wide bounded. Whole-result services stage once per operation and are sliced locally.</p>
+          </div>
+          <div class="card">
+            <h3>Atomic public operations</h3>
+            <p>A one-shot read and each reader call publish no partial result on failure. Materialization publishes atomically; earlier successful streaming calls remain an already-observed prefix.</p>
+          </div>
+          <div class="card">
+            <h3>Local trust boundary</h3>
+            <p>Plans carry aliases, never credentials or arbitrary endpoints. Public errors are typed and redacted so backend messages, resources, and secrets do not cross the boundary.</p>
+          </div>
+        </div>
+
+        <div class="sequence" aria-label="Runtime sequence">
+          <div class="sequence-item"><strong>Resolve descriptor</strong><code>resolve_descriptor()</code> selects metadata for one fixed generation; it exposes no byte operations.</div>
+          <div class="sequence-item"><strong>Acquire complete plan</strong><code>get_plan(descriptor)</code> returns all ordered segments for that generation.</div>
+          <div class="sequence-item"><strong>Validate and freeze</strong>MSC checks freshness, limits, aliases, segment kinds, and total length, then freezes bindings and computes capabilities.</div>
+          <div class="sequence-item"><strong>Return the view</strong>Only now does <code>AssemblyClient.resolve()</code> expose an executable <code>AssemblyView</code>.</div>
+          <div class="sequence-item"><strong>Map and dispatch</strong>Only logical slices intersecting the request become work, under one deadline and cancellation scope.</div>
+          <div class="sequence-item"><strong>Publish</strong>Validated bytes are concatenated in plan order and returned or atomically materialized.</div>
+        </div>
+
+        <div class="callout danger">
+          <strong>No implied snapshot from expiration alone.</strong> A fixed plan does not make an unversioned mutable source
+          immutable. Callers requiring stable bytes must request <code>SNAPSHOT_PINNED</code>; resolution fails before I/O if
+          the complete plan and bindings cannot enforce it.
+        </div>
+      </section>
+
+      <section id="compatibility">
+        <h2>9. Compatibility and implementation direction</h2>
+        <div class="grid-2">
+          <div class="card">
+            <h3>Unchanged</h3>
+            <ul>
+              <li><code>StorageClient</code> constructor and public methods.</li>
+              <li><code>StorageProvider</code> ABC, factories, and third-party providers.</li>
+              <li>Existing storage profile schema and <code>msc://</code> behavior.</li>
+              <li>Current pathlib, fsspec, CLI, sync, and FUSE behavior.</li>
+              <li>Go components in the initial release.</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Additive</h3>
+            <ul>
+              <li><code>multistorageclient.assembly</code> package and explicit construction.</li>
+              <li>Provider and service-executor SPIs plus an adopter conformance suite.</li>
+              <li>Versioned <code>assembly-list/v1</code> artifact and golden vectors.</li>
+              <li>Python client, view, reader, models, and stable error contract.</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="callout">
+          <strong>Explicit trade-off:</strong> a clean parallel module is not automatically transparent to every existing
+          StorageClient consumer. Consumers accepting binary streams can use <code>AssemblyReader</code>; consumers requiring
+          a local path can use <code>materialize</code>. Storage-shaped or filesystem adapters are follow-up decisions driven
+          by concrete demand.
+        </div>
+
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Layer</th><th>Initial responsibility</th></tr></thead>
+            <tbody>
+              <tr><td>Language-neutral</td><td><code>assembly-list/v1</code>, canonical JSON behavior, and cross-runtime golden vectors.</td></tr>
+              <tr><td>Python</td><td>Public SPIs, orchestration, validation, view/reader behavior, static-list adapter, and custom extensibility.</td></tr>
+              <tr><td>Rust</td><td>No changes. This design proposes no Rust implementation or FFI path for Assembly or <code>ServiceSegmentExecutor</code>.</td></tr>
+              <tr><td>Go / FUSE</td><td>No initial change; future support can consume the portable artifact or completed materialization.</td></tr>
+              <tr><td>Configuration</td><td>No new storage profile type; explicit constructor injection in v1.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="open-decisions">
+        <h2>10. Open decisions and approval gates</h2>
+        <p>
+          The architecture is implementable, but these product choices affect public scope or the performance envelope and
+          should be agreed before implementation is committed.
+        </p>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Decision</th><th>Proposed v1 position</th><th>Why it matters</th></tr></thead>
+            <tbody>
+              <tr><td>Product scale envelope</td><td><strong>Blocking input:</strong> define object count, segments/bytes, lookup-versus-traversal mix, latency, and memory/disk ceilings.</td><td>Determines batch and index representations and conformance fixtures.</td></tr>
+              <tr><td>Provider concurrency model</td><td>Synchronous and thread-safe, matching current MSC public style.</td><td>A simultaneous async surface would double the initial API and test matrix.</td></tr>
+              <tr><td>Phase-one browsing</td><td>Optional capability; not required for resolve/read/open.</td><td>Some applications already know exact names and have no directory model.</td></tr>
+              <tr><td>Mutable sources</td><td>Allowed under <code>EXPIRATION_ONLY</code>; enforceable identity required for <code>SNAPSHOT_PINNED</code>.</td><td>Supports baseline requirements without making false stability claims.</td></tr>
+              <tr><td>Defensive binding extensions</td><td>Keep the common binding client-only; any cache identity is optional or derived, and a public <code>resource_policy</code> requires separate approval.</td><td>Preserves cache and authority safety without presenting non-requirement fields as mandatory API.</td></tr>
+              <tr><td>Convenience transport adapter</td><td>Separate follow-up only after approval of a generic transport contract and user-provided protocol translation.</td><td>Keeps the core SPI independent of any server API, authentication scheme, or transport implementation.</td></tr>
+              <tr><td>Portable-list hard ceilings</td><td>Conservative inline and decode limits; applications may lower them.</td><td>Prevents the control artifact from becoming an unbounded bulk-data path.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="appendix">
+        <h2>11. Appendix: requirements traceability and references</h2>
+        <h3>Requirement-to-design traceability</h3>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Requirement theme</th><th>Design response</th></tr></thead>
+            <tbody>
+              <tr><td>Direct storage bytes where possible</td><td><code>ObjectSegment</code> delegates exact ranges through existing StorageClient bindings.</td></tr>
+              <tr><td>Synthesized structure or fully generated results</td><td><code>ServiceSegment</code> supports service-produced bytes without teaching MSC the file format.</td></tr>
+              <tr><td>Small literal structure</td><td><code>InlineSegment</code> supports strictly bounded bytes with no external I/O.</td></tr>
+              <tr><td>Unambiguous complete ordering and length</td><td>The provider returns a complete ordered plan; MSC checks the global segment-length sum before I/O.</td></tr>
+              <tr><td>Versioned language-neutral assembly list</td><td><code>assembly-list/v1</code> provides canonical batches and cross-language golden vectors.</td></tr>
+              <tr><td>Expiration and refresh</td><td>Expiration is mandatory; started work may finish; refresh returns a distinct generation and view.</td></tr>
+              <tr><td>Optional revisions and checksums</td><td>Baseline expiration-only semantics remain valid; callers may require computed snapshot-pinned consistency.</td></tr>
+              <tr><td>No universal service transport</td><td>Planning and fulfillment use separate in-process SPIs; service fulfillment is supplied by user code and MSC defines no server contract.</td></tr>
+              <tr><td>Existing MSC behavior unchanged</td><td>The feature is a parallel package using existing StorageClient instances as dependencies.</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Current MSC evidence</h3>
+        <ul>
+          <li><code>StorageClient</code> owns and delegates to storage clients/providers; providers are leaf physical backends.</li>
+          <li>The current <code>StorageProvider</code> contract includes broad read and mutation operations, so it is not a truthful assembled-view interface.</li>
+          <li>Existing range readers issue physical range requests but do not provide the fixed multi-source generation semantics required here.</li>
+        </ul>
+
+        <h3>Public standards</h3>
+        <ul>
+          <li><a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110 — HTTP Semantics</a></li>
+          <li><a href="https://www.rfc-editor.org/rfc/rfc8785.html">RFC 8785 — JSON Canonicalization Scheme</a></li>
+        </ul>
+
+        <p class="small">
+          This document defines the architecture and reader-facing public API shape. See the
+          <a href="assembly-workflow-user-guide.html">Workflow User Guide</a> for adopter wiring and the
+          <a href="implementation-and-test-plan.html">Implementation &amp; Test Plan</a> for exact models, signatures,
+          configuration, exceptions, algorithms, tests, and delivery sequencing.
+        </p>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/specs/2026-07-21-assembly-view/high-level-design.html
+++ b/specs/2026-07-21-assembly-view/high-level-design.html
@@ -434,8 +434,7 @@
       <a href="#extension-model">7. Extension model</a>
       <a href="#guarantees">8. Behavioral guarantees</a>
       <a href="#compatibility">9. Compatibility</a>
-      <a href="#open-decisions">10. Open decisions</a>
-      <a href="#appendix">11. Traceability and references</a>
+      <a href="#appendix">10. Traceability and references</a>
     </nav>
 
     <main>
@@ -502,7 +501,7 @@
               <li>Support exact ranges, streaming, metadata, and bounded local materialization.</li>
               <li>Allow any planning backend through an in-process provider interface.</li>
               <li>Keep credentials, endpoints, and executable bindings under local application control.</li>
-              <li>Preserve truthful consistency: expiration by default, stronger pinning only when enforceable.</li>
+              <li>Enforce mandatory expiration, exact declared lengths, and bounded execution.</li>
             </ul>
           </div>
           <div class="card">
@@ -514,17 +513,17 @@
               <li>Add write, delete, copy, sync, or presign semantics to assembled views.</li>
               <li>Make the feature automatically appear in every existing MSC, FUSE, CLI, or fsspec path.</li>
               <li>Let a remote plan choose credentials, profiles, arbitrary endpoints, or Python objects.</li>
+              <li>Browse or glob logical assemblies, seek within an open reader, or enforce source revisions and checksums in v1.</li>
             </ul>
           </div>
         </div>
 
         <div class="callout info">
           <strong>Requirements versus defensive design.</strong> The requirements explicitly call for configured sources and
-          services, direct storage reads for object segments, transport-neutral service segments, optional source
-          versions/validators, bounded execution, and no breaking changes to existing providers. They do not require public
-          binding-revision or resource-policy hooks, a built-in network fetcher, an MSC-defined external service API, or
-          format-specific projection handlers. If implementation work proposes those additional safeguards or conveniences, they remain
-          separately reviewable defensive design—not requirements.
+          services, direct storage reads for object segments, transport-neutral service segments, a versioned assembly-list
+          representation, bounded execution, and no breaking changes to existing providers. Optional revisions and
+          validators are deliberately deferred from the MVP. A built-in network fetcher, an MSC-defined external service
+          API, and format-specific projection handlers are also outside this release.
         </div>
       </section>
 
@@ -552,7 +551,7 @@
               <li>StorageClient unifies storage access; it should not acquire application-specific content orchestration.</li>
               <li>A special case in <code>read</code> would spread into info, open, list, cache, download, sync, and error behavior.</li>
               <li>Assembly needs fixed generations, expiration, service execution, and multi-source atomicity—concepts absent from the storage façade.</li>
-              <li>A parallel module can expose honest read-only capabilities without pretending to support the entire mutable client surface.</li>
+              <li>A parallel module can expose an honest, deliberately small read-only API without pretending to support the mutable client surface.</li>
             </ul>
           </div>
         </div>
@@ -587,10 +586,10 @@
           <div class="arch-arrow">↓</div>
           <div class="arch-row">
             <div class="arch-node user"><strong>AssemblyPlanProvider</strong><br><span class="small"><code>get_plan(request)</code> → descriptor metadata + complete plan</span></div>
-            <div class="arch-node new"><strong>AssemblyClient.resolve()</strong><br><span class="small">coordinate · validate · freeze · compute capabilities</span></div>
+            <div class="arch-node new"><strong>AssemblyClient.resolve()</strong><br><span class="small">coordinate · validate · freeze</span></div>
             <div class="arch-node"><strong>Local binding registry</strong><br><span class="small">StorageClient sources · user-owned service fetchers</span></div>
           </div>
-          <div class="arch-arrow">↓ metadata-bearing complete plan → validation + frozen alias snapshot</div>
+          <div class="arch-arrow">↓ metadata-bearing complete plan → validation + frozen alias mapping</div>
           <div class="arch-row">
             <div></div>
             <div class="arch-node new"><strong>AssemblyView</strong><br><span class="small"><code>metadata</code> = descriptor · validated plan · frozen bindings · lifecycle</span></div>
@@ -615,7 +614,7 @@
             <ul>
               <li>Descriptor-to-plan resolution and executable-view construction.</li>
               <li>Plan validation and logical range calculation.</li>
-              <li>Expiration, consistency, and view lifecycle.</li>
+              <li>Expiration, exact-length validation, and view lifecycle.</li>
               <li>Bounded execution, ordering, and atomic publication.</li>
               <li>Stable public behavior independent of backend transport.</li>
             </ul>
@@ -634,8 +633,8 @@
             <ul>
               <li>Physical object or service-operation interpretation.</li>
               <li>Authentication and connection management.</li>
-              <li>Transport-specific validation and bounded retries.</li>
-              <li>Resource safety and any stable identity enforcement they advertise.</li>
+              <li>Transport-specific request construction and error translation.</li>
+              <li>Resource safety and any retry policy hidden inside the application adapter.</li>
             </ul>
           </div>
         </div>
@@ -645,7 +644,7 @@
         <h2>5. Public API at a glance</h2>
         <p>
           The common workflow is intentionally small: inject dependencies once, resolve one generation, then operate on its
-          view. Detailed signatures, configuration fields, limits, and typed-error construction live in the
+          view. Exact signatures, internal safety limits, and typed-error construction live in the
           <a href="implementation-and-test-plan.html#contracts">Implementation &amp; Test Plan</a>.
         </p>
 
@@ -681,10 +680,12 @@ assembly = AssemblyClient(
     service_fetchers={
         "rewrite": rewrite_service, # selected by ServiceSegment.fetcher_id
     },
+    max_concurrency=16,
+    timeout_seconds=300,
 )
 
 # resolve() obtains descriptor metadata and a complete plan. It returns only
-# after plan validation, binding freeze, and capability computation succeed.
+# after plan validation and binding freeze succeed.
 view = assembly.resolve(
     AssemblyReference(namespace="exports", key="run-42.bin")
 )
@@ -711,13 +712,12 @@ replacement = assembly.resolve(descriptor.reference)</code></pre>
           <table>
             <thead><tr><th>Operation</th><th>What the caller gets</th><th>Important behavior</th></tr></thead>
             <tbody>
-              <tr><td><code>resolve</code></td><td>An exact, expiring <code>AssemblyView</code>.</td><td>Acquire descriptor metadata and the complete plan in one provider call, validate it, freeze bindings, compute capabilities, then return; no executable view is exposed earlier.</td></tr>
+              <tr><td><code>resolve</code></td><td>An exact, expiring <code>AssemblyView</code>.</td><td>Acquire descriptor metadata and the complete plan in one provider call, validate it, freeze bindings, then return; no executable view is exposed earlier.</td></tr>
               <tr><td><code>read</code></td><td>Exactly one logical byte window.</td><td>Map the requested offsets through the view's validated plan and dispatch only intersecting segments.</td></tr>
-              <tr><td><code>open</code></td><td>A read-only stream.</td><td>The reader stays on the same generation and plan; seek is advertised only when that plan supports it safely.</td></tr>
+              <tr><td><code>open</code></td><td>A forward-only read stream.</td><td>The reader stays on the same generation and plan. Seeking is not part of the v1 contract.</td></tr>
               <tr><td><code>metadata</code></td><td>The view's <code>AssemblyDescriptor</code>.</td><td>Control-plane metadata includes its reference, generation, size, and expiration; the descriptor itself cannot read, open, or materialize bytes.</td></tr>
               <tr><td><code>materialize</code></td><td>A complete local file.</td><td>Walk the same plan in bounded windows and atomically publish; no-replace by default.</td></tr>
-              <tr><td>replacement resolution</td><td>A new view from another <code>resolve</code> call.</td><td>The public API has no separate refresh operation; expiration and any automatic re-resolution policy are described below.</td></tr>
-              <tr><td><code>list</code> / <code>glob</code></td><td>Logical descriptors.</td><td>Optional browsing capability, separate from executable plan batches.</td></tr>
+              <tr><td>replacement resolution</td><td>A new view from another <code>resolve</code> call.</td><td>The public API has no separate refresh operation, and v1 never re-resolves automatically.</td></tr>
               <tr><td>write / delete / copy / sync</td><td>Not supported.</td><td>Assembled views are deliberately read-only.</td></tr>
             </tbody>
           </table>
@@ -735,9 +735,9 @@ replacement = assembly.resolve(descriptor.reference)</code></pre>
             <p class="small"><code>view.metadata</code> returns the control-plane descriptor: logical reference, generation, size, expiration, and optional application metadata.</p>
           </div>
           <div class="card">
-            <span class="label">Executable snapshot</span>
+            <span class="label">Frozen execution state</span>
             <strong>Validated plan and bindings</strong>
-            <p class="small">The complete ordered AssemblyPlan and a frozen alias-to-binding snapshot validated before the view is returned.</p>
+            <p class="small">The complete ordered AssemblyPlan and frozen alias-to-binding mapping validated before the view is returned.</p>
           </div>
           <div class="card">
             <span class="label">Operation façade</span>
@@ -747,7 +747,7 @@ replacement = assembly.resolve(descriptor.reference)</code></pre>
         </div>
         <p class="small">
           An <code>AssemblyDescriptor</code> is metadata only and has no byte operations. The executable view never owns a
-          StorageProvider, replans the object, or refreshes itself. <code>open()</code> creates a reader pinned to the same
+          StorageProvider, replans the object, or refreshes itself. <code>open()</code> creates a reader bound to the same
           descriptor and plan; resolving the reference again creates another view. Client-wide scheduling, reader state, staging,
           and atomic publication are detailed in
           <a href="implementation-and-test-plan.html#executor">Execution, AssemblyView, reader, and materialization</a>.
@@ -755,7 +755,7 @@ replacement = assembly.resolve(descriptor.reference)</code></pre>
 
         <div class="callout">
           Plans contain only the aliases <code>raw</code> and <code>rewrite</code>; credentials, service URLs, authentication,
-          and lifecycle stay in the local bindings. Dependencies are borrowed by default. The exact façade is documented in
+          and lifecycle stay in the local bindings. Dependencies are borrowed; the application owns their lifecycle. The exact façade is documented in
           <a href="implementation-and-test-plan.html#public-facade-reference">the API reference subsection</a>, and error
           construction in <a href="implementation-and-test-plan.html#exceptions">the implementation error contract</a>.
           Custom fetcher details are in <a href="implementation-and-test-plan.html#sources">the fetcher SPI</a>.
@@ -857,8 +857,8 @@ replacement = assembly.resolve(descriptor.reference)</code></pre>
           </div>
 
           <div class="sample-arrow">
-            ↓ <code>AssemblyClient</code> validates the complete union, lengths, expiration, aliases, and requested
-            consistency; then freezes the local bindings and computes capabilities
+            ↓ <code>AssemblyClient</code> validates the complete union, lengths, expiration, aliases, and optional
+            source and fetcher aliases; then freezes the local bindings
           </div>
 
           <div class="sample-stage sample-view">
@@ -867,7 +867,7 @@ replacement = assembly.resolve(descriptor.reference)</code></pre>
                 <span class="label">2 · Returned execution façade</span>
                 <strong><code>AssemblyClient.resolve()</code> returns <code>AssemblyView[g-193]</code></strong>
               </div>
-              <span class="tag">exact and fixed until expiration</span>
+              <span class="tag">exact plan · fixed generation until expiration</span>
             </div>
             <div class="view-state-grid">
               <div class="view-state">
@@ -963,9 +963,7 @@ replacement = assembly.resolve(descriptor.reference)</code></pre>
     def get_plan(
         self,
         request: ResolveAssemblyRequest,
-    ) -> AssemblyPlan: ...
-
-    def close(self) -> None: ...</code></pre>
+    ) -> AssemblyPlan: ...</code></pre>
 
         <div class="grid-2">
           <div class="card">
@@ -973,7 +971,7 @@ replacement = assembly.resolve(descriptor.reference)</code></pre>
             <ul>
               <li><code>get_plan()</code> returns one metadata-bearing, complete ordered object plan, never a range-specific fragment.</li>
               <li>The embedded descriptor identifies the exact reference, generation, size, and future expiration represented by the plan.</li>
-              <li>Canonical bounded models and stable public failure classifications.</li>
+              <li>Bounded, versioned models and stable public failure classifications.</li>
             </ul>
           </div>
           <div class="card">
@@ -981,7 +979,7 @@ replacement = assembly.resolve(descriptor.reference)</code></pre>
             <ul>
               <li>Expose no <code>AssemblyView</code> before complete-plan validation and binding freeze succeed.</li>
               <li>Perform no source or service byte I/O while resolving or validating the plan.</li>
-              <li>Never silently substitute a generation or downgrade consistency.</li>
+              <li>Never silently substitute a generation or accept a malformed or expired plan.</li>
               <li>Resolve aliases only through the frozen local registries.</li>
               <li>Supply a reusable conformance suite for custom implementations.</li>
             </ul>
@@ -1004,11 +1002,16 @@ replacement = assembly.resolve(descriptor.reference)</code></pre>
           segments. One backend may support both concerns, but the application injects separate adapters so the paths can
           have different authorization, scaling, retry, and lifecycle policies.
         </p>
+        <p>
+          The public façade and <code>ServiceSegmentFetcher.fetch()</code> are synchronous. Assembly may overlap independent
+          calls through bounded internal concurrency. Calls to the same fetcher instance are always serialized in v1, so
+          fetcher authors do not need to implement a thread-safety declaration.
+        </p>
 
         <h3>Core adoption has no network-adapter dependency</h3>
         <p>
           Custom providers and service fetchers are sufficient for the core feature. A reusable network convenience adapter
-          would be a separately approved follow-up with its own generic transport contract; it is not a prerequisite for the
+          would be a separately designed and reviewed follow-up with its own generic transport contract; it is not a prerequisite for the
           Assembly engine or its end-to-end tests.
         </p>
       </section>
@@ -1023,11 +1026,11 @@ replacement = assembly.resolve(descriptor.reference)</code></pre>
         <div class="grid-2">
           <div class="card">
             <h3>Exact and expiring views</h3>
-            <p>A v1 view holds descriptor metadata, one complete exact-result plan, frozen bindings, computed capabilities, and lifecycle state. Expiration is checked before each new operation. The public API has no separate refresh method; another <code>resolve</code> call creates another view.</p>
+            <p>A v1 view holds descriptor metadata, one complete exact-result plan, frozen bindings, and lifecycle state. Expiration is checked before each new operation. The public API has no separate refresh method; another <code>resolve</code> call creates another view.</p>
           </div>
           <div class="card">
-            <h3>Truthful consistency</h3>
-            <p><code>EXPIRATION_ONLY</code> is the default and does not promise immutable source bytes. <code>SNAPSHOT_PINNED</code> is available only when every non-inline segment has enforceable stable identity.</p>
+            <h3>Deliberate MVP consistency boundary</h3>
+            <p>V1 validates plan expiration and returned lengths but does not model source selectors, revisions, validators, or checksums. Applications that require snapshot-grade identity must enforce it inside their provider and bindings until a later additive contract is designed.</p>
           </div>
           <div class="card">
             <h3>Complete-plan validation</h3>
@@ -1039,26 +1042,26 @@ replacement = assembly.resolve(descriptor.reference)</code></pre>
           </div>
           <div class="card">
             <h3>Atomic public operations</h3>
-            <p>A one-shot read and each reader call publish no partial result on failure. Materialization publishes atomically; earlier successful streaming calls remain an already-observed prefix.</p>
+            <p>Each view read and reader call publishes no partial result on failure. Materialization publishes atomically; earlier successful streaming calls remain an already-observed prefix.</p>
           </div>
           <div class="card">
             <h3>Local trust boundary</h3>
-            <p>Plans select locally registered aliases and carry only bounded declarative service operations and parameters. If a future locator is approved, the selected fetcher validates its target under local policy; credentials remain local. Public errors are typed and redacted.</p>
+            <p>Plans select locally registered aliases and carry only bounded declarative service operations and parameters. If a future locator is introduced through a versioned design, the selected fetcher validates its target under local policy; credentials remain local. Public errors are typed and redacted.</p>
           </div>
         </div>
 
         <div class="sequence" aria-label="Runtime sequence">
           <div class="sequence-item"><strong>Acquire complete plan</strong><code>get_plan(request)</code> returns descriptor metadata and all ordered segments for one generation.</div>
-          <div class="sequence-item"><strong>Validate and freeze</strong>MSC checks freshness, limits, aliases, segment kinds, and total length, then freezes bindings and computes capabilities.</div>
+          <div class="sequence-item"><strong>Validate and freeze</strong>MSC checks freshness, limits, aliases, segment kinds, and total length, then freezes bindings.</div>
           <div class="sequence-item"><strong>Return the view</strong>Only now does <code>AssemblyClient.resolve()</code> expose an executable <code>AssemblyView</code>.</div>
           <div class="sequence-item"><strong>Map and dispatch</strong>Only logical slices intersecting the request become work, under one deadline and cancellation scope.</div>
           <div class="sequence-item"><strong>Publish</strong>Validated bytes are concatenated in plan order and returned or atomically materialized.</div>
         </div>
 
         <div class="callout danger">
-          <strong>No implied snapshot from expiration alone.</strong> A fixed plan does not make an unversioned mutable source
-          immutable. Callers requiring stable bytes must request <code>SNAPSHOT_PINNED</code>; resolution fails before I/O if
-          the complete plan and bindings cannot enforce it.
+          <strong>Dataset snapshot semantics remain above MSC.</strong> A fixed plan and its expiration do not turn
+          <code>AssemblyView</code> into a dataset- or sample-snapshot contract. The plan provider and application own that
+          meaning; MVP Assembly validates structure, expiration, and byte counts only.
         </div>
       </section>
 
@@ -1080,17 +1083,17 @@ replacement = assembly.resolve(descriptor.reference)</code></pre>
             <ul>
               <li><code>multistorageclient.assembly</code> package and explicit construction.</li>
               <li>Provider and service-fetcher SPIs plus an adopter conformance suite.</li>
-              <li>Versioned <code>assembly-list/v1</code> artifact and golden vectors.</li>
+              <li>Versioned <code>assembly-list/v1</code> batches and golden decode/encode vectors.</li>
               <li>Python client, view, reader, models, and stable error contract.</li>
-              <li>Explicit <code>exact</code> v1 result semantics; future semantic-projection plans require a new version and capability.</li>
+              <li>Explicit <code>exact</code> v1 result semantics; future semantic-projection plans require a new schema version.</li>
             </ul>
           </div>
         </div>
 
         <h3>Evolution rules</h3>
         <ul>
-          <li><code>assembly-plan/v1</code> permanently means exact final logical bytes. A future carrier-plus-projection contract uses a new schema version and required capability; v1 clients reject it instead of returning different bytes.</li>
-          <li>Unknown schema versions, required capabilities, segment kinds, and fields fail closed before binding or byte I/O.</li>
+          <li><code>assembly-plan/v1</code> permanently means exact final logical bytes. A future carrier-plus-projection contract uses a new schema version; v1 clients reject it instead of returning different bytes.</li>
+          <li>Unknown schema versions, segment kinds, and fields fail closed before binding or byte I/O.</li>
           <li>Published provider and fetcher SPIs do not gain new required abstract methods. Optional behavior is added through methods with defaults or a new versioned SPI.</li>
           <li>Public façade growth is additive: new parameters are keyword-only and have backward-compatible defaults.</li>
         </ul>
@@ -1106,7 +1109,7 @@ replacement = assembly.resolve(descriptor.reference)</code></pre>
           <table>
             <thead><tr><th>Layer</th><th>Initial responsibility</th></tr></thead>
             <tbody>
-              <tr><td>Language-neutral</td><td><code>assembly-list/v1</code>, canonical JSON behavior, and cross-runtime golden vectors.</td></tr>
+              <tr><td>Language-neutral</td><td><code>assembly-list/v1</code> JSON batches and cross-runtime golden vectors.</td></tr>
               <tr><td>Python</td><td>Public SPIs, orchestration, validation, view/reader behavior, static-list adapter, and custom extensibility.</td></tr>
               <tr><td>Rust</td><td>No changes. This design proposes no Rust implementation or FFI path for Assembly or <code>ServiceSegmentFetcher</code>.</td></tr>
               <tr><td>Go / FUSE</td><td>No initial change; future support can consume the portable artifact or completed materialization.</td></tr>
@@ -1116,34 +1119,8 @@ replacement = assembly.resolve(descriptor.reference)</code></pre>
         </div>
       </section>
 
-      <section id="open-decisions">
-        <h2>10. Open decisions and approval gates</h2>
-        <p>
-          The architecture is implementable, but these product choices affect public scope or the performance envelope and
-          should be agreed before implementation is committed.
-        </p>
-        <div class="table-wrap">
-          <table>
-            <thead><tr><th>Decision</th><th>Proposed v1 position</th><th>Why it matters</th></tr></thead>
-            <tbody>
-              <tr><td>Product scale envelope</td><td><strong>Blocking input:</strong> define object count, segments/bytes, lookup-versus-traversal mix, latency, and memory/disk ceilings.</td><td>Determines batch and index representations and conformance fixtures.</td></tr>
-              <tr><td>Fetcher concurrency model</td><td>Require concurrent/asynchronous execution capability; approve the exact Python SPI separately.</td><td>The core must overlap independent I/O without prematurely committing to Rust or doubling every public façade method.</td></tr>
-              <tr><td>Phase-one browsing</td><td>Optional capability; not required for resolve/read/open.</td><td>Some applications already know exact names and have no directory model.</td></tr>
-              <tr><td>Mutable sources</td><td>Allowed under <code>EXPIRATION_ONLY</code>; enforceable identity required for <code>SNAPSHOT_PINNED</code>.</td><td>Supports baseline requirements without making false stability claims.</td></tr>
-              <tr><td>Expiration and re-resolution</td><td>No public <code>refresh</code>. Until an automatic policy is approved, an expired view fails before I/O and callers obtain a replacement with <code>resolve</code>.</td><td>A proposed <code>revalidate_after</code> plus hard <code>expires_at</code> model must preserve the requirement that an expired plan is never used to start work.</td></tr>
-              <tr><td>Service routing reference</td><td>The representation remains open. Any future locator must be transport-neutral and bounded, and the selected local fetcher must validate every target against application policy.</td><td>Supports stateless regional routing without allowing a remote plan to choose credentials or unrestricted origins.</td></tr>
-              <tr><td>Semantic projection</td><td>Out of scope for v1. <code>assembly-plan/v1</code> always means exact final bytes.</td><td>A future carrier-plus-projection result needs a new plan version, required capability, and separate format-specific façade so old clients fail closed.</td></tr>
-              <tr><td>Service request batching</td><td>No manual multi-range fetch in v1; rely on bounded concurrency and transport multiplexing.</td><td>A batch contract adds complexity and should follow benchmark evidence.</td></tr>
-              <tr><td>Defensive binding extensions</td><td>Keep the common binding client-only; any cache identity is optional or derived, and a public <code>resource_policy</code> requires separate approval.</td><td>Preserves cache and authority safety without presenting non-requirement fields as mandatory API.</td></tr>
-              <tr><td>Convenience transport adapter</td><td>Separate follow-up only after approval of a generic transport contract and user-provided protocol translation.</td><td>Keeps the core SPI independent of any server API, authentication scheme, or transport implementation.</td></tr>
-              <tr><td>Portable-list hard ceilings</td><td>Conservative inline and decode limits; applications may lower them.</td><td>Prevents the control artifact from becoming an unbounded bulk-data path.</td></tr>
-            </tbody>
-          </table>
-        </div>
-      </section>
-
       <section id="appendix">
-        <h2>11. Appendix: requirements traceability and references</h2>
+        <h2>10. Appendix: requirements traceability and references</h2>
         <h3>Requirement-to-design traceability</h3>
         <div class="table-wrap">
           <table>
@@ -1153,9 +1130,9 @@ replacement = assembly.resolve(descriptor.reference)</code></pre>
               <tr><td>Synthesized structure or fully generated results</td><td><code>ServiceSegment</code> supports service-produced bytes without teaching MSC the file format.</td></tr>
               <tr><td>Small literal structure</td><td><code>InlineSegment</code> supports strictly bounded bytes with no external I/O.</td></tr>
               <tr><td>Unambiguous complete ordering and length</td><td>The provider returns a complete ordered plan; MSC checks the global segment-length sum before I/O.</td></tr>
-              <tr><td>Versioned language-neutral assembly list</td><td><code>assembly-list/v1</code> provides canonical batches and cross-language golden vectors.</td></tr>
-              <tr><td>Expiration and replacement</td><td>Expiration is mandatory; started work may finish; another resolve returns a distinct generation and view. Automatic re-resolution remains an approval gate.</td></tr>
-              <tr><td>Optional revisions and checksums</td><td>Baseline expiration-only semantics remain valid; callers may require computed snapshot-pinned consistency.</td></tr>
+              <tr><td>Versioned language-neutral assembly list</td><td><code>assembly-list/v1</code> provides strict JSON batches and cross-language golden vectors.</td></tr>
+              <tr><td>Expiration and replacement</td><td>Expiration is mandatory; started work may finish; another resolve returns a distinct generation and view. V1 performs no automatic re-resolution.</td></tr>
+              <tr><td>Optional revisions and checksums</td><td>Deferred from the MVP. V1 enforces expiration and exact lengths; applications retain responsibility for stronger snapshot identity.</td></tr>
               <tr><td>No universal service transport</td><td>Planning and fulfillment use separate in-process SPIs; service fulfillment is supplied by user code and MSC defines no server contract.</td></tr>
               <tr><td>Existing MSC behavior unchanged</td><td>The feature is a parallel package using existing StorageClient instances as dependencies.</td></tr>
             </tbody>
@@ -1172,7 +1149,6 @@ replacement = assembly.resolve(descriptor.reference)</code></pre>
         <h3>Public standards</h3>
         <ul>
           <li><a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110 — HTTP Semantics</a></li>
-          <li><a href="https://www.rfc-editor.org/rfc/rfc8785.html">RFC 8785 — JSON Canonicalization Scheme</a></li>
         </ul>
 
         <p class="small">

--- a/specs/2026-07-21-assembly-view/high-level-design.html
+++ b/specs/2026-07-21-assembly-view/high-level-design.html
@@ -409,7 +409,7 @@
       </p>
       <div class="meta">
         <span>Spec date: 2026-07-21</span>
-        <span>Last revised: 2026-07-22</span>
+        <span>Last revised: 2026-08-25</span>
         <span>Status: Proposed</span>
         <span>Compatibility: Additive</span>
         <span>Reading time: approximately 10 minutes</span>
@@ -444,7 +444,8 @@
         <div class="decision">
           <strong>Build a separate <code>multistorageclient.assembly</code> module.</strong> Applications construct an
           <code>AssemblyClient</code> with a user-supplied <code>AssemblyPlanProvider</code>, local object-source bindings, and
-          service executors. Resolving a logical name returns a fixed, expiring <code>AssemblyView</code>. The module neither
+          service fetchers. Resolving a logical name returns an exact, read-only <code>AssemblyView</code> backed by one
+          validated plan. The module neither
           subclasses <code>StorageClient</code> nor registers an assembled backend as a <code>StorageProvider</code>.
         </div>
 
@@ -471,7 +472,7 @@
           that composes bytes already available through that access. The assembly service is an application capability, not
           a new storage backend and not necessarily an HTTP service.
         </p>
-        <div class="formula">descriptor metadata → complete plan → validation + frozen bindings → executable AssemblyView</div>
+        <div class="formula">resolve request → metadata-bearing complete plan → validation + frozen bindings → executable AssemblyView</div>
       </section>
 
       <section id="scope">
@@ -486,7 +487,7 @@
             <thead><tr><th>Segment</th><th>Meaning</th><th>Executed by</th></tr></thead>
             <tbody>
               <tr><td><code>ObjectSegment</code></td><td>An exact byte range from an existing physical object.</td><td>A locally configured <code>StorageClient</code> binding.</td></tr>
-              <tr><td><code>ServiceSegment</code></td><td>Opaque bytes generated or transformed by an application service.</td><td>A user-defined, locally configured <code>ServiceSegmentExecutor</code>.</td></tr>
+              <tr><td><code>ServiceSegment</code></td><td>Opaque bytes fetched from an application service.</td><td>A user-defined, locally configured <code>ServiceSegmentFetcher</code>.</td></tr>
               <tr><td><code>InlineSegment</code></td><td>A small, strictly bounded literal carried in the plan.</td><td>The assembly module without external I/O.</td></tr>
             </tbody>
           </table>
@@ -497,7 +498,7 @@
             <h3>Goals</h3>
             <ul>
               <li>Expose one read-only logical byte stream over ordered multi-source segments.</li>
-              <li>Resolve a complete plan with mandatory expiration and caller-controlled refresh.</li>
+              <li>Resolve one complete plan with mandatory expiration through a single provider call.</li>
               <li>Support exact ranges, streaming, metadata, and bounded local materialization.</li>
               <li>Allow any planning backend through an in-process provider interface.</li>
               <li>Keep credentials, endpoints, and executable bindings under local application control.</li>
@@ -509,6 +510,7 @@
             <ul>
               <li>Define a universal HTTP or gRPC API for the planning service.</li>
               <li>Teach MSC about specific file formats, media containers, schemas, rows, or samples.</li>
+              <li>Return a semantic superset that requires a format-specific projection step; v1 views expose exact final bytes.</li>
               <li>Add write, delete, copy, sync, or presign semantics to assembled views.</li>
               <li>Make the feature automatically appear in every existing MSC, FUSE, CLI, or fsspec path.</li>
               <li>Let a remote plan choose credentials, profiles, arbitrary endpoints, or Python objects.</li>
@@ -520,8 +522,8 @@
           <strong>Requirements versus defensive design.</strong> The requirements explicitly call for configured sources and
           services, direct storage reads for object segments, transport-neutral service segments, optional source
           versions/validators, bounded execution, and no breaking changes to existing providers. They do not require public
-          binding-revision or resource-policy hooks, a built-in network executor, an MSC-defined external service API, or
-          format-specific executors. If implementation work proposes those additional safeguards or conveniences, they remain
+          binding-revision or resource-policy hooks, a built-in network fetcher, an MSC-defined external service API, or
+          format-specific projection handlers. If implementation work proposes those additional safeguards or conveniences, they remain
           separately reviewable defensive design—not requirements.
         </div>
       </section>
@@ -576,7 +578,7 @@
 
       <section id="architecture">
         <h2>4. Architecture and ownership boundaries</h2>
-        <div class="architecture" role="img" aria-label="AssemblyClient resolves descriptor metadata, obtains and validates a complete plan, freezes local bindings, and only then returns an executable AssemblyView.">
+        <div class="architecture" role="img" aria-label="AssemblyClient obtains descriptor metadata and a complete plan in one provider call, validates the result, freezes local bindings, and only then returns an executable AssemblyView.">
           <div class="arch-row">
             <div></div>
             <div class="arch-node"><strong>Application</strong><br><span class="small">constructs dependencies and asks for a logical object</span></div>
@@ -584,11 +586,11 @@
           </div>
           <div class="arch-arrow">↓</div>
           <div class="arch-row">
-            <div class="arch-node user"><strong>AssemblyPlanProvider</strong><br><span class="small"><code>resolve_descriptor()</code> → metadata<br><code>get_plan()</code> → complete plan</span></div>
+            <div class="arch-node user"><strong>AssemblyPlanProvider</strong><br><span class="small"><code>get_plan(request)</code> → descriptor metadata + complete plan</span></div>
             <div class="arch-node new"><strong>AssemblyClient.resolve()</strong><br><span class="small">coordinate · validate · freeze · compute capabilities</span></div>
-            <div class="arch-node"><strong>Local binding registry</strong><br><span class="small">StorageClient sources · user-owned service executors</span></div>
+            <div class="arch-node"><strong>Local binding registry</strong><br><span class="small">StorageClient sources · user-owned service fetchers</span></div>
           </div>
-          <div class="arch-arrow">↓ descriptor metadata → complete plan → validation + frozen alias snapshot</div>
+          <div class="arch-arrow">↓ metadata-bearing complete plan → validation + frozen alias snapshot</div>
           <div class="arch-row">
             <div></div>
             <div class="arch-node new"><strong>AssemblyView</strong><br><span class="small"><code>metadata</code> = descriptor · validated plan · frozen bindings · lifecycle</span></div>
@@ -597,7 +599,7 @@
           <div class="arch-arrow">↓ dispatch by explicit segment kind</div>
           <div class="arch-row">
             <div class="arch-node existing"><strong>ObjectSegment</strong><br><span class="small">existing StorageClient → StorageProvider</span></div>
-            <div class="arch-node user"><strong>ServiceSegment</strong><br><span class="small">user-owned ServiceSegmentExecutor</span></div>
+            <div class="arch-node user"><strong>ServiceSegment</strong><br><span class="small">user-owned ServiceSegmentFetcher</span></div>
             <div class="arch-node new"><strong>InlineSegment</strong><br><span class="small">bounded plan bytes</span></div>
           </div>
           <div class="arch-legend">
@@ -623,7 +625,7 @@
             <ul>
               <li>Logical namespace and file-format meaning.</li>
               <li>Plan-provider implementation and backend protocol.</li>
-              <li>Source bindings and service-executor implementations wired at construction.</li>
+              <li>Source bindings and service-fetcher implementations wired at construction.</li>
               <li>Credential, endpoint, and dependency lifecycle choices.</li>
             </ul>
           </div>
@@ -648,8 +650,8 @@
         </p>
 
         <p>
-          An object source wraps an already configured <code>StorageClient</code>. A service executor is a concrete
-          user-owned implementation of <code>ServiceSegmentExecutor</code>. MSC defines the in-process behavior of that SPI,
+          An object source wraps an already configured <code>StorageClient</code>. A service fetcher is a concrete
+          user-owned implementation of <code>ServiceSegmentFetcher</code>. MSC defines the in-process behavior of that SPI,
           not the application's external protocol.
         </p>
 
@@ -663,8 +665,8 @@ raw_source = ObjectSourceBinding(
     client=raw_storage,
 )
 
-# User code implements MSC's ServiceSegmentExecutor SPI.
-rewrite_service = MyServiceExecutor(
+# User code implements MSC's ServiceSegmentFetcher SPI.
+rewrite_service = MyServiceFetcher(
     client=my_service_client,
 )
 
@@ -676,8 +678,8 @@ assembly = AssemblyClient(
     object_sources={
         "raw": raw_source,          # selected by ObjectSegment.source_id
     },
-    service_executors={
-        "rewrite": rewrite_service, # selected by ServiceSegment.executor_id
+    service_fetchers={
+        "rewrite": rewrite_service, # selected by ServiceSegment.fetcher_id
     },
 )
 
@@ -694,12 +696,13 @@ descriptor = view.metadata
 footer = view.read(ByteRange(offset=footer_offset, size=8192))
 view.materialize("/tmp/run-42.bin")
 
-# Refresh creates a replacement view; the original never changes.
-new_view = assembly.refresh(view)</code></pre>
+# Resolve the same reference again when the application needs a replacement
+# view; there is no separate public refresh operation.
+replacement = assembly.resolve(descriptor.reference)</code></pre>
 
         <div class="callout info">
-          <strong><code>MyServiceExecutor</code> is application code, not an MSC built-in type.</strong> It translates one
-          <code>ServiceExecutionRequest</code> into the application's HTTP, gRPC, SDK, or local-service call. It never receives
+          <strong><code>MyServiceFetcher</code> is application code, not an MSC built-in type.</strong> It translates one
+          <code>ServiceFetchRequest</code> into the application's HTTP, gRPC, SDK, or local-service call. It never receives
           the complete <code>AssemblyPlan</code>, never chooses segment order, and returns only the byte stream for one
           <code>ServiceSegment</code> under the declared length, range mode, deadline, and cancellation contract.
         </div>
@@ -708,12 +711,12 @@ new_view = assembly.refresh(view)</code></pre>
           <table>
             <thead><tr><th>Operation</th><th>What the caller gets</th><th>Important behavior</th></tr></thead>
             <tbody>
-              <tr><td><code>resolve</code></td><td>A fixed, expiring <code>AssemblyView</code>.</td><td>Resolve metadata, acquire and validate the complete plan, freeze bindings, compute capabilities, then return; no executable view is exposed earlier.</td></tr>
+              <tr><td><code>resolve</code></td><td>An exact, expiring <code>AssemblyView</code>.</td><td>Acquire descriptor metadata and the complete plan in one provider call, validate it, freeze bindings, compute capabilities, then return; no executable view is exposed earlier.</td></tr>
               <tr><td><code>read</code></td><td>Exactly one logical byte window.</td><td>Map the requested offsets through the view's validated plan and dispatch only intersecting segments.</td></tr>
               <tr><td><code>open</code></td><td>A read-only stream.</td><td>The reader stays on the same generation and plan; seek is advertised only when that plan supports it safely.</td></tr>
               <tr><td><code>metadata</code></td><td>The view's <code>AssemblyDescriptor</code>.</td><td>Control-plane metadata includes its reference, generation, size, and expiration; the descriptor itself cannot read, open, or materialize bytes.</td></tr>
               <tr><td><code>materialize</code></td><td>A complete local file.</td><td>Walk the same plan in bounded windows and atomically publish; no-replace by default.</td></tr>
-              <tr><td><code>refresh</code></td><td>A new view.</td><td>Optional provider capability; the old view remains unchanged.</td></tr>
+              <tr><td>replacement resolution</td><td>A new view from another <code>resolve</code> call.</td><td>The public API has no separate refresh operation; expiration and any automatic re-resolution policy are described below.</td></tr>
               <tr><td><code>list</code> / <code>glob</code></td><td>Logical descriptors.</td><td>Optional browsing capability, separate from executable plan batches.</td></tr>
               <tr><td>write / delete / copy / sync</td><td>Not supported.</td><td>Assembled views are deliberately read-only.</td></tr>
             </tbody>
@@ -745,9 +748,9 @@ new_view = assembly.refresh(view)</code></pre>
         <p class="small">
           An <code>AssemblyDescriptor</code> is metadata only and has no byte operations. The executable view never owns a
           StorageProvider, replans the object, or refreshes itself. <code>open()</code> creates a reader pinned to the same
-          descriptor and plan; <code>refresh()</code> creates another view. Client-wide scheduling, reader state, staging,
+          descriptor and plan; resolving the reference again creates another view. Client-wide scheduling, reader state, staging,
           and atomic publication are detailed in
-          <a href="implementation-and-test-plan.html#executor">Executor, AssemblyView, reader, and materialization</a>.
+          <a href="implementation-and-test-plan.html#executor">Execution, AssemblyView, reader, and materialization</a>.
         </p>
 
         <div class="callout">
@@ -755,7 +758,7 @@ new_view = assembly.refresh(view)</code></pre>
           and lifecycle stay in the local bindings. Dependencies are borrowed by default. The exact façade is documented in
           <a href="implementation-and-test-plan.html#public-facade-reference">the API reference subsection</a>, and error
           construction in <a href="implementation-and-test-plan.html#exceptions">the implementation error contract</a>.
-          Custom executor details are in <a href="implementation-and-test-plan.html#sources">the executor SPI</a>.
+          Custom fetcher details are in <a href="implementation-and-test-plan.html#sources">the fetcher SPI</a>.
         </div>
       </section>
 
@@ -769,37 +772,32 @@ new_view = assembly.refresh(view)</code></pre>
 
         <figure class="sample-flow" aria-labelledby="parquet-example-caption">
           <figcaption id="parquet-example-caption" class="sample-caption">
-            Descriptor metadata → complete plan → validated executable view → one logical byte stream
+            Complete plan with descriptor metadata → validated executable view → one exact logical byte stream
           </figcaption>
 
           <div class="sample-stage sample-plan">
             <div class="sample-stage-heading">
               <div>
-                <span class="label">1 · Resolve control-plane metadata</span>
-                <strong><code>AssemblyPlanProvider.resolve_descriptor(request)</code></strong>
+                <span class="label">1 · Resolve the complete plan</span>
+                <strong><code>AssemblyPlanProvider.get_plan(request)</code></strong>
               </div>
-              <span class="tag">returns metadata only</span>
+              <span class="tag">one provider call</span>
             </div>
 
             <div class="sample-object-heading">
               <div>
-                <span class="label">AssemblyDescriptor g-193</span>
-                <code>AssemblyDescriptor("exports/run-42.parquet")</code>
+                <span class="label">AssemblyPlan g-193</span>
+                <code>exports/run-42.parquet · g-193</code>
               </div>
-              <span class="small">generation <code>g-193</code> · logical size · mandatory expiration</span>
+              <span class="small">descriptor metadata · mandatory expiration · exact result semantics</span>
             </div>
-            <p class="small">The descriptor cannot read, open, or materialize bytes.</p>
-          </div>
-
-          <div class="sample-arrow">
-            ↓ <code>AssemblyPlanProvider.get_plan(descriptor)</code> returns the complete <code>AssemblyPlan</code> for exactly
-            <code>g-193</code>—never a range-specific fragment
+            <p class="small">The response contains both the metadata-only descriptor and every ordered segment for this generation.</p>
           </div>
 
           <div class="sample-stage sample-plan">
             <div class="sample-stage-heading">
               <div>
-                <span class="label">2 · Complete AssemblyPlan</span>
+                <span class="label">Complete AssemblyPlan</span>
                 <strong>Six ordered logical byte segments</strong>
               </div>
               <span class="tag">logical size = checked segment-length sum</span>
@@ -836,13 +834,13 @@ new_view = assembly.refresh(view)</code></pre>
                 <span class="segment-number">4</span>
                 <strong>Page indexes</strong>
                 <code>build-indexes</code>
-                <span class="small">ServiceSegment · <code>executor_id="rewrite"</code></span>
+                <span class="small">ServiceSegment · <code>fetcher_id="rewrite"</code></span>
               </div>
               <div class="byte-segment service">
                 <span class="segment-number">5</span>
                 <strong>Metadata + length</strong>
                 <code>FileMetaData</code>
-                <span class="small">ServiceSegment · <code>executor_id="rewrite"</code></span>
+                <span class="small">ServiceSegment · <code>fetcher_id="rewrite"</code></span>
               </div>
               <div class="byte-segment inline">
                 <span class="segment-number">6</span>
@@ -866,10 +864,10 @@ new_view = assembly.refresh(view)</code></pre>
           <div class="sample-stage sample-view">
             <div class="sample-stage-heading">
               <div>
-                <span class="label">3 · Returned execution façade</span>
+                <span class="label">2 · Returned execution façade</span>
                 <strong><code>AssemblyClient.resolve()</code> returns <code>AssemblyView[g-193]</code></strong>
               </div>
-              <span class="tag">fixed until caller-controlled refresh</span>
+              <span class="tag">exact and fixed until expiration</span>
             </div>
             <div class="view-state-grid">
               <div class="view-state">
@@ -882,13 +880,13 @@ new_view = assembly.refresh(view)</code></pre>
               </div>
               <div class="view-state">
                 <strong>Frozen bindings</strong>
-                <span class="small"><code>raw</code> → ObjectSourceBinding · <code>rewrite</code> → user-owned MyServiceExecutor</span>
+                <span class="small"><code>raw</code> → ObjectSourceBinding · <code>rewrite</code> → user-owned MyServiceFetcher</span>
               </div>
             </div>
           </div>
 
           <div class="sample-arrow">
-            ↓ <code>AssemblyView</code> maps the requested logical offsets through its plan; the client's shared executor
+            ↓ <code>AssemblyView</code> maps the requested logical offsets through its plan; the client's shared execution engine
             dispatches only the intersecting slices
           </div>
 
@@ -905,7 +903,7 @@ new_view = assembly.refresh(view)</code></pre>
             </div>
             <div class="sample-owner service">
               <span class="label">Generated bytes</span>
-              <strong>User-owned <code>MyServiceExecutor</code></strong>
+              <strong>User-owned <code>MyServiceFetcher</code></strong>
               <p>Fulfills one service segment through the application's own protocol; it does not receive or order the complete plan.</p>
             </div>
           </div>
@@ -919,7 +917,7 @@ new_view = assembly.refresh(view)</code></pre>
               </div>
               <div class="card">
                 <strong><code>view.open()</code></strong>
-                <p class="small">Maps every cursor read against the same generation and six-segment plan without resolving again.</p>
+                <p class="small">Maps every cursor read against the same generation and six-segment plan without silently changing plans.</p>
               </div>
               <div class="card">
                 <strong><code>view.materialize(...)</code></strong>
@@ -949,7 +947,7 @@ new_view = assembly.refresh(view)</code></pre>
 
         <div class="callout">
           <strong>The format boundary is intentional.</strong> If a different application assembles JSONL, a media file, or
-          an unknown future format, the AssemblyClient algorithm is unchanged. Only the plan provider and service executors
+          an unknown future format, the AssemblyClient algorithm is unchanged. Only the plan provider and service fetchers
           know why each byte range belongs in that position.
         </div>
       </section>
@@ -962,19 +960,10 @@ new_view = assembly.refresh(view)</code></pre>
         </p>
 
         <pre><code>class AssemblyPlanProvider(ABC):
-    def resolve_descriptor(
-        self, request: ResolveAssemblyRequest
-    ) -> AssemblyDescriptor: ...
-
     def get_plan(
         self,
-        descriptor: AssemblyDescriptor,
-        *,
-        deadline_monotonic: float | None = None,
+        request: ResolveAssemblyRequest,
     ) -> AssemblyPlan: ...
-
-    # Optional: advertise support and return a replacement generation.
-    def refresh(self, request: RefreshAssemblyRequest) -> AssemblyDescriptor: ...
 
     def close(self) -> None: ...</code></pre>
 
@@ -982,8 +971,8 @@ new_view = assembly.refresh(view)</code></pre>
           <div class="card">
             <h3>The provider promises</h3>
             <ul>
-              <li><code>resolve_descriptor()</code> returns metadata only: one exact reference, generation, size, and future expiration.</li>
-              <li><code>get_plan()</code> returns that descriptor's complete ordered object plan, never a range-specific fragment.</li>
+              <li><code>get_plan()</code> returns one metadata-bearing, complete ordered object plan, never a range-specific fragment.</li>
+              <li>The embedded descriptor identifies the exact reference, generation, size, and future expiration represented by the plan.</li>
               <li>Canonical bounded models and stable public failure classifications.</li>
             </ul>
           </div>
@@ -1010,7 +999,7 @@ new_view = assembly.refresh(view)</code></pre>
         <h3>Planning and byte fulfillment are separate roles</h3>
         <p>
           <code>AssemblyPlanProvider</code> says <em>which bytes form the object</em>.
-          A user-owned <code>ServiceSegmentExecutor</code> produces bytes for exactly one service segment under its declared
+          A user-owned <code>ServiceSegmentFetcher</code> fetches bytes for exactly one service segment under its declared
           length, range, deadline, and cancellation contract. It receives neither the complete plan nor authority to order
           segments. One backend may support both concerns, but the application injects separate adapters so the paths can
           have different authorization, scaling, retry, and lifecycle policies.
@@ -1018,7 +1007,7 @@ new_view = assembly.refresh(view)</code></pre>
 
         <h3>Core adoption has no network-adapter dependency</h3>
         <p>
-          Custom providers and service executors are sufficient for the core feature. A reusable network convenience adapter
+          Custom providers and service fetchers are sufficient for the core feature. A reusable network convenience adapter
           would be a separately approved follow-up with its own generic transport contract; it is not a prerequisite for the
           Assembly engine or its end-to-end tests.
         </p>
@@ -1033,8 +1022,8 @@ new_view = assembly.refresh(view)</code></pre>
 
         <div class="grid-2">
           <div class="card">
-            <h3>Fixed and expiring views</h3>
-            <p>A view holds its descriptor, one complete plan, frozen bindings, computed capabilities, and lifecycle state. Expiration is checked before each new operation. Refresh creates another view and never mutates the old one.</p>
+            <h3>Exact and expiring views</h3>
+            <p>A v1 view holds descriptor metadata, one complete exact-result plan, frozen bindings, computed capabilities, and lifecycle state. Expiration is checked before each new operation. The public API has no separate refresh method; another <code>resolve</code> call creates another view.</p>
           </div>
           <div class="card">
             <h3>Truthful consistency</h3>
@@ -1054,13 +1043,12 @@ new_view = assembly.refresh(view)</code></pre>
           </div>
           <div class="card">
             <h3>Local trust boundary</h3>
-            <p>Plans carry aliases, never credentials or arbitrary endpoints. Public errors are typed and redacted so backend messages, resources, and secrets do not cross the boundary.</p>
+            <p>Plans select locally registered aliases and carry only bounded declarative service operations and parameters. If a future locator is approved, the selected fetcher validates its target under local policy; credentials remain local. Public errors are typed and redacted.</p>
           </div>
         </div>
 
         <div class="sequence" aria-label="Runtime sequence">
-          <div class="sequence-item"><strong>Resolve descriptor</strong><code>resolve_descriptor()</code> selects metadata for one fixed generation; it exposes no byte operations.</div>
-          <div class="sequence-item"><strong>Acquire complete plan</strong><code>get_plan(descriptor)</code> returns all ordered segments for that generation.</div>
+          <div class="sequence-item"><strong>Acquire complete plan</strong><code>get_plan(request)</code> returns descriptor metadata and all ordered segments for one generation.</div>
           <div class="sequence-item"><strong>Validate and freeze</strong>MSC checks freshness, limits, aliases, segment kinds, and total length, then freezes bindings and computes capabilities.</div>
           <div class="sequence-item"><strong>Return the view</strong>Only now does <code>AssemblyClient.resolve()</code> expose an executable <code>AssemblyView</code>.</div>
           <div class="sequence-item"><strong>Map and dispatch</strong>Only logical slices intersecting the request become work, under one deadline and cancellation scope.</div>
@@ -1091,12 +1079,21 @@ new_view = assembly.refresh(view)</code></pre>
             <h3>Additive</h3>
             <ul>
               <li><code>multistorageclient.assembly</code> package and explicit construction.</li>
-              <li>Provider and service-executor SPIs plus an adopter conformance suite.</li>
+              <li>Provider and service-fetcher SPIs plus an adopter conformance suite.</li>
               <li>Versioned <code>assembly-list/v1</code> artifact and golden vectors.</li>
               <li>Python client, view, reader, models, and stable error contract.</li>
+              <li>Explicit <code>exact</code> v1 result semantics; future semantic-projection plans require a new version and capability.</li>
             </ul>
           </div>
         </div>
+
+        <h3>Evolution rules</h3>
+        <ul>
+          <li><code>assembly-plan/v1</code> permanently means exact final logical bytes. A future carrier-plus-projection contract uses a new schema version and required capability; v1 clients reject it instead of returning different bytes.</li>
+          <li>Unknown schema versions, required capabilities, segment kinds, and fields fail closed before binding or byte I/O.</li>
+          <li>Published provider and fetcher SPIs do not gain new required abstract methods. Optional behavior is added through methods with defaults or a new versioned SPI.</li>
+          <li>Public façade growth is additive: new parameters are keyword-only and have backward-compatible defaults.</li>
+        </ul>
 
         <div class="callout">
           <strong>Explicit trade-off:</strong> a clean parallel module is not automatically transparent to every existing
@@ -1111,7 +1108,7 @@ new_view = assembly.refresh(view)</code></pre>
             <tbody>
               <tr><td>Language-neutral</td><td><code>assembly-list/v1</code>, canonical JSON behavior, and cross-runtime golden vectors.</td></tr>
               <tr><td>Python</td><td>Public SPIs, orchestration, validation, view/reader behavior, static-list adapter, and custom extensibility.</td></tr>
-              <tr><td>Rust</td><td>No changes. This design proposes no Rust implementation or FFI path for Assembly or <code>ServiceSegmentExecutor</code>.</td></tr>
+              <tr><td>Rust</td><td>No changes. This design proposes no Rust implementation or FFI path for Assembly or <code>ServiceSegmentFetcher</code>.</td></tr>
               <tr><td>Go / FUSE</td><td>No initial change; future support can consume the portable artifact or completed materialization.</td></tr>
               <tr><td>Configuration</td><td>No new storage profile type; explicit constructor injection in v1.</td></tr>
             </tbody>
@@ -1130,9 +1127,13 @@ new_view = assembly.refresh(view)</code></pre>
             <thead><tr><th>Decision</th><th>Proposed v1 position</th><th>Why it matters</th></tr></thead>
             <tbody>
               <tr><td>Product scale envelope</td><td><strong>Blocking input:</strong> define object count, segments/bytes, lookup-versus-traversal mix, latency, and memory/disk ceilings.</td><td>Determines batch and index representations and conformance fixtures.</td></tr>
-              <tr><td>Provider concurrency model</td><td>Synchronous and thread-safe, matching current MSC public style.</td><td>A simultaneous async surface would double the initial API and test matrix.</td></tr>
+              <tr><td>Fetcher concurrency model</td><td>Require concurrent/asynchronous execution capability; approve the exact Python SPI separately.</td><td>The core must overlap independent I/O without prematurely committing to Rust or doubling every public façade method.</td></tr>
               <tr><td>Phase-one browsing</td><td>Optional capability; not required for resolve/read/open.</td><td>Some applications already know exact names and have no directory model.</td></tr>
               <tr><td>Mutable sources</td><td>Allowed under <code>EXPIRATION_ONLY</code>; enforceable identity required for <code>SNAPSHOT_PINNED</code>.</td><td>Supports baseline requirements without making false stability claims.</td></tr>
+              <tr><td>Expiration and re-resolution</td><td>No public <code>refresh</code>. Until an automatic policy is approved, an expired view fails before I/O and callers obtain a replacement with <code>resolve</code>.</td><td>A proposed <code>revalidate_after</code> plus hard <code>expires_at</code> model must preserve the requirement that an expired plan is never used to start work.</td></tr>
+              <tr><td>Service routing reference</td><td>The representation remains open. Any future locator must be transport-neutral and bounded, and the selected local fetcher must validate every target against application policy.</td><td>Supports stateless regional routing without allowing a remote plan to choose credentials or unrestricted origins.</td></tr>
+              <tr><td>Semantic projection</td><td>Out of scope for v1. <code>assembly-plan/v1</code> always means exact final bytes.</td><td>A future carrier-plus-projection result needs a new plan version, required capability, and separate format-specific façade so old clients fail closed.</td></tr>
+              <tr><td>Service request batching</td><td>No manual multi-range fetch in v1; rely on bounded concurrency and transport multiplexing.</td><td>A batch contract adds complexity and should follow benchmark evidence.</td></tr>
               <tr><td>Defensive binding extensions</td><td>Keep the common binding client-only; any cache identity is optional or derived, and a public <code>resource_policy</code> requires separate approval.</td><td>Preserves cache and authority safety without presenting non-requirement fields as mandatory API.</td></tr>
               <tr><td>Convenience transport adapter</td><td>Separate follow-up only after approval of a generic transport contract and user-provided protocol translation.</td><td>Keeps the core SPI independent of any server API, authentication scheme, or transport implementation.</td></tr>
               <tr><td>Portable-list hard ceilings</td><td>Conservative inline and decode limits; applications may lower them.</td><td>Prevents the control artifact from becoming an unbounded bulk-data path.</td></tr>
@@ -1153,7 +1154,7 @@ new_view = assembly.refresh(view)</code></pre>
               <tr><td>Small literal structure</td><td><code>InlineSegment</code> supports strictly bounded bytes with no external I/O.</td></tr>
               <tr><td>Unambiguous complete ordering and length</td><td>The provider returns a complete ordered plan; MSC checks the global segment-length sum before I/O.</td></tr>
               <tr><td>Versioned language-neutral assembly list</td><td><code>assembly-list/v1</code> provides canonical batches and cross-language golden vectors.</td></tr>
-              <tr><td>Expiration and refresh</td><td>Expiration is mandatory; started work may finish; refresh returns a distinct generation and view.</td></tr>
+              <tr><td>Expiration and replacement</td><td>Expiration is mandatory; started work may finish; another resolve returns a distinct generation and view. Automatic re-resolution remains an approval gate.</td></tr>
               <tr><td>Optional revisions and checksums</td><td>Baseline expiration-only semantics remain valid; callers may require computed snapshot-pinned consistency.</td></tr>
               <tr><td>No universal service transport</td><td>Planning and fulfillment use separate in-process SPIs; service fulfillment is supplied by user code and MSC defines no server contract.</td></tr>
               <tr><td>Existing MSC behavior unchanged</td><td>The feature is a parallel package using existing StorageClient instances as dependencies.</td></tr>

--- a/specs/2026-07-21-assembly-view/implementation-and-test-plan.html
+++ b/specs/2026-07-21-assembly-view/implementation-and-test-plan.html
@@ -1,0 +1,2472 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Assembly Module — Implementation Design and Test Plan</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f6f8fb;
+      --surface: #ffffff;
+      --surface-soft: #eef3f7;
+      --text: #172033;
+      --muted: #5f6b7c;
+      --border: #d8e0e8;
+      --accent: #116b5a;
+      --accent-soft: #e1f3ee;
+      --accent-text: #0b5043;
+      --warning: #8a5b00;
+      --warning-soft: #fff4d6;
+      --danger: #9d3038;
+      --danger-soft: #fdebed;
+      --info: #426891;
+      --info-soft: #e8f0f8;
+      --code-bg: #101827;
+      --code-text: #eef4ff;
+      --shadow: 0 8px 28px rgba(25, 38, 57, 0.08);
+      --max: 1480px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0d131d;
+        --surface: #141c29;
+        --surface-soft: #1c2635;
+        --text: #e9eef6;
+        --muted: #aab4c4;
+        --border: #2b384a;
+        --accent: #6bd9bd;
+        --accent-soft: #173a34;
+        --accent-text: #acf0df;
+        --warning: #ffd174;
+        --warning-soft: #3d321c;
+        --danger: #ff9fa8;
+        --danger-soft: #442328;
+        --info: #9bc6f1;
+        --info-soft: #1b3047;
+        --code-bg: #080d14;
+        --code-text: #eef4ff;
+        --shadow: 0 8px 28px rgba(0, 0, 0, 0.28);
+      }
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.62;
+    }
+    a { color: var(--accent); text-underline-offset: 0.18em; }
+    code, pre { font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace; }
+    code {
+      padding: 0.1em 0.28em;
+      border-radius: 0.3rem;
+      background: var(--surface-soft);
+      font-size: 0.92em;
+      overflow-wrap: anywhere;
+    }
+    pre {
+      margin: 1rem 0;
+      padding: 1rem 1.1rem;
+      overflow-x: auto;
+      border-radius: 0.7rem;
+      background: var(--code-bg);
+      color: var(--code-text);
+      line-height: 1.5;
+      font-size: 0.86rem;
+    }
+    pre code { padding: 0; background: transparent; color: inherit; overflow-wrap: normal; }
+    h1, h2, h3, h4 { line-height: 1.24; letter-spacing: -0.015em; }
+    h1 { margin: 0.35rem 0 0.8rem; font-size: clamp(2rem, 4.8vw, 3.5rem); }
+    h2 { margin: 0 0 1rem; font-size: clamp(1.4rem, 2.5vw, 2rem); }
+    h3 { margin: 1.55rem 0 0.65rem; font-size: 1.16rem; }
+    h4 { margin: 1.15rem 0 0.45rem; font-size: 1rem; }
+    p { margin: 0.6rem 0 1rem; }
+    ul, ol { padding-left: 1.35rem; }
+    li + li { margin-top: 0.38rem; }
+
+    .hero {
+      border-bottom: 1px solid var(--border);
+      background:
+        radial-gradient(circle at 82% 10%, color-mix(in srgb, var(--accent) 16%, transparent), transparent 30rem),
+        var(--surface);
+    }
+    .hero-inner { max-width: var(--max); margin: 0 auto; padding: 4rem 2.2rem 3.3rem; }
+    .eyebrow {
+      color: var(--accent);
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      font-size: 0.8rem;
+    }
+    .subtitle { max-width: 1040px; margin: 0; color: var(--muted); font-size: 1.08rem; }
+    .meta, .doc-links { display: flex; flex-wrap: wrap; gap: 0.6rem 1.1rem; align-items: center; }
+    .meta { margin-top: 1.4rem; color: var(--muted); font-size: 0.9rem; }
+    .doc-links { margin-top: 1.25rem; }
+    .button {
+      display: inline-block;
+      padding: 0.55rem 0.8rem;
+      border: 1px solid var(--border);
+      border-radius: 0.55rem;
+      background: var(--surface);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 650;
+    }
+    .button.primary { border-color: var(--accent); background: var(--accent); color: var(--bg); }
+
+    .layout {
+      display: grid;
+      grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+      gap: 2rem;
+      max-width: var(--max);
+      margin: 0 auto;
+      padding: 2rem 2.2rem 6rem;
+    }
+    .toc {
+      align-self: start;
+      position: sticky;
+      top: 1.2rem;
+      max-height: calc(100vh - 2.4rem);
+      overflow-y: auto;
+      padding: 0.8rem 0;
+      font-size: 0.88rem;
+    }
+    .toc strong { display: block; margin-bottom: 0.55rem; }
+    .toc a {
+      display: block;
+      padding: 0.32rem 0.6rem;
+      border-left: 2px solid transparent;
+      color: var(--muted);
+      text-decoration: none;
+    }
+    .toc a:hover { border-left-color: var(--accent); color: var(--text); background: var(--accent-soft); }
+    main { min-width: 0; }
+    section {
+      margin-bottom: 1.6rem;
+      padding: 1.8rem;
+      border: 1px solid var(--border);
+      border-radius: 0.9rem;
+      background: var(--surface);
+      box-shadow: var(--shadow);
+      scroll-margin-top: 1.2rem;
+    }
+    .decision {
+      padding: 1.1rem 1.2rem;
+      border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
+      border-radius: 0.7rem;
+      background: var(--accent-soft);
+    }
+    .decision strong { color: var(--accent-text); }
+    .callout {
+      margin: 1rem 0;
+      padding: 0.9rem 1rem;
+      border-left: 4px solid var(--warning);
+      background: var(--warning-soft);
+    }
+    .callout.danger { border-left-color: var(--danger); background: var(--danger-soft); }
+    .callout.info { border-left-color: var(--info); background: var(--info-soft); }
+    .grid-2, .grid-3, .summary-grid {
+      display: grid;
+      gap: 0.9rem;
+      margin: 1rem 0;
+    }
+    .grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .grid-3, .summary-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .card {
+      padding: 1rem;
+      border: 1px solid var(--border);
+      border-radius: 0.7rem;
+      background: var(--surface-soft);
+    }
+    .card h3, .card h4 { margin-top: 0; }
+    .label {
+      display: block;
+      margin-bottom: 0.25rem;
+      color: var(--muted);
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+    .value { display: block; font-size: 1.12rem; font-weight: 750; }
+    .small { color: var(--muted); font-size: 0.88rem; }
+    .tag {
+      display: inline-block;
+      margin: 0.15rem 0.25rem 0.15rem 0;
+      padding: 0.2rem 0.5rem;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      background: var(--surface-soft);
+      font-size: 0.8rem;
+    }
+    .yes { color: var(--accent-text); font-weight: 700; }
+    .no { color: var(--danger); font-weight: 700; }
+    .maybe { color: var(--warning); font-weight: 700; }
+    .table-wrap { max-width: 100%; overflow-x: auto; margin: 1rem 0; }
+    table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+    th, td { padding: 0.72rem; border-bottom: 1px solid var(--border); text-align: left; vertical-align: top; }
+    th { background: var(--surface-soft); font-size: 0.82rem; letter-spacing: 0.02em; }
+    tr:last-child td { border-bottom: 0; }
+
+    .architecture {
+      display: grid;
+      gap: 0.7rem;
+      margin: 1.1rem 0;
+      padding: 1rem;
+      border: 1px dashed var(--border);
+      border-radius: 0.8rem;
+      background: color-mix(in srgb, var(--surface-soft) 72%, transparent);
+    }
+    .arch-row { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.75rem; align-items: stretch; }
+    .arch-node {
+      padding: 0.8rem;
+      border: 1px solid var(--border);
+      border-radius: 0.6rem;
+      background: var(--surface);
+      text-align: center;
+    }
+    .arch-node.new { border-color: color-mix(in srgb, var(--accent) 65%, var(--border)); background: var(--accent-soft); }
+    .arch-node.user { border-color: color-mix(in srgb, var(--warning) 60%, var(--border)); background: var(--warning-soft); }
+    .arch-arrow { text-align: center; color: var(--muted); font-weight: 700; }
+
+    .sequence { margin: 1rem 0; counter-reset: seq; }
+    .sequence-item {
+      position: relative;
+      margin-left: 1.1rem;
+      padding: 0 0 1rem 1.5rem;
+      border-left: 2px solid var(--border);
+    }
+    .sequence-item::before {
+      counter-increment: seq;
+      content: counter(seq);
+      position: absolute;
+      left: -0.85rem;
+      top: -0.05rem;
+      width: 1.55rem;
+      height: 1.55rem;
+      display: grid;
+      place-items: center;
+      border-radius: 50%;
+      background: var(--accent);
+      color: var(--bg);
+      font-weight: 700;
+      font-size: 0.78rem;
+    }
+    .sequence-item:last-child { padding-bottom: 0; border-left-color: transparent; }
+    .sequence-item strong { display: block; }
+
+    .formula {
+      padding: 0.85rem 1rem;
+      border-radius: 0.65rem;
+      background: var(--code-bg);
+      color: var(--code-text);
+      font-family: "SFMono-Regular", Consolas, monospace;
+      overflow-x: auto;
+      white-space: nowrap;
+    }
+    .phase {
+      display: grid;
+      grid-template-columns: 7rem minmax(0, 1fr);
+      gap: 0.9rem;
+      margin: 0.85rem 0;
+      padding: 0.9rem;
+      border: 1px solid var(--border);
+      border-radius: 0.65rem;
+      background: var(--surface-soft);
+    }
+    .phase-name { color: var(--accent-text); font-weight: 800; }
+    .checklist { list-style: none; padding-left: 0; }
+    .checklist li { position: relative; padding-left: 1.5rem; }
+    .checklist li::before { content: "□"; position: absolute; left: 0; color: var(--accent); font-weight: 800; }
+
+    @media (max-width: 1000px) {
+      .layout { grid-template-columns: 1fr; padding-top: 1rem; }
+      .toc { position: static; max-height: none; display: flex; flex-wrap: wrap; gap: 0.25rem; border-bottom: 1px solid var(--border); }
+      .toc strong { width: 100%; }
+      .toc a { border-left: 0; border-bottom: 2px solid transparent; }
+      .toc a:hover { border-bottom-color: var(--accent); }
+    }
+    @media (max-width: 760px) {
+      .hero-inner, .layout { padding-left: 1rem; padding-right: 1rem; }
+      section { padding: 1.15rem; }
+      .grid-2, .grid-3, .summary-grid, .arch-row { grid-template-columns: 1fr; }
+      .phase { grid-template-columns: 1fr; }
+      .button { width: 100%; text-align: center; }
+    }
+    @media print {
+      body { background: #fff; color: #111; }
+      .hero { background: #fff; }
+      .toc, .doc-links { display: none; }
+      .layout { display: block; padding: 1rem; }
+      section { box-shadow: none; break-inside: avoid; }
+      a { color: inherit; }
+    }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <div class="hero-inner">
+      <div class="eyebrow">Implementation Design · Detailed Test Plan</div>
+      <h1>Assembly Module</h1>
+      <p class="subtitle">
+        Concrete implementation boundaries, file changes, execution algorithms, test cases, rollout gates, and definition
+        of done for the additive <code>multistorageclient.assembly</code> module, with optional transport work kept separate.
+      </p>
+      <div class="meta">
+        <span>Spec date: 2026-07-21</span>
+        <span>Last revised: 2026-07-22</span>
+        <span>Status: Proposed</span>
+        <span>Depends on: High-Level Design approval</span>
+        <span>Initial release: Read-only and opt-in</span>
+      </div>
+      <div class="doc-links">
+        <a class="button" href="high-level-design.html">High-Level Design</a>
+        <a class="button" href="assembly-workflow-user-guide.html">Workflow User Guide</a>
+        <a class="button primary" href="implementation-and-test-plan.html">Implementation &amp; Test Plan</a>
+      </div>
+    </div>
+  </header>
+
+  <div class="layout">
+    <nav class="toc" aria-label="Table of contents">
+      <strong>Contents</strong>
+      <a href="#stance">1. Implementation stance</a>
+      <a href="#topology">2. Component topology</a>
+      <a href="#runtime">3. Runtime flow</a>
+      <a href="#contracts">4. Contracts and models</a>
+      <a href="#provider">5. Provider adapter</a>
+      <a href="#validation">6. Validation and planning</a>
+      <a href="#sources">7. Object and service bindings</a>
+      <a href="#executor">8. Executor, view, reader</a>
+      <a href="#http-adapter">9. Optional HTTP adapter</a>
+      <a href="#python-scope">10. Python-only scope</a>
+      <a href="#operations">11. Operational semantics</a>
+      <a href="#files">12. File-level plan</a>
+      <a href="#test-architecture">13. Test architecture</a>
+      <a href="#test-cases">14. Detailed test cases</a>
+      <a href="#performance">15. Performance plan</a>
+      <a href="#rollout">16. Delivery gates</a>
+      <a href="#risks">17. Risks and completion</a>
+      <a href="#commands">18. Commands and references</a>
+    </nav>
+
+    <main>
+      <section id="stance">
+        <h2>1. Implementation stance</h2>
+        <div class="decision">
+          <strong>Implement an independent Python assembly layer and a language-neutral list codec.</strong>
+          The Python layer owns public contracts, expiration, complete-object validation, scheduling, and dispatch. Object
+          segments use an injected existing <code>StorageClient</code>; service segments use a separate
+          <code>ServiceSegmentExecutor</code> SPI implemented by the user. The initial core release requires no built-in HTTP
+          adapter. Existing StorageClient and StorageProvider behavior is not modified.
+        </div>
+
+        <div class="summary-grid">
+          <div class="card">
+            <span class="label">Extension boundary</span>
+            <span class="value">AssemblyPlanProvider</span>
+            <p class="small">Injected Python SPI returns one complete object plan for a fixed descriptor generation; it need not use the portable list artifact.</p>
+          </div>
+          <div class="card">
+            <span class="label">Execution boundary</span>
+            <span class="value">StorageClient + Service Executor</span>
+            <p class="small">Object bytes use public MSC APIs; synthesized bytes use an independent service SPI.</p>
+          </div>
+          <div class="card">
+            <span class="label">Transport boundary</span>
+            <span class="value">User-owned adapter</span>
+            <p class="small">HTTP, gRPC, an SDK, or a local call remains behind the user implementation of the service SPI.</p>
+          </div>
+        </div>
+
+        <h3>Constraints inherited from the high-level design</h3>
+        <ul>
+          <li>No <code>AssembledStorageProvider</code>, Provider-to-Provider ownership, or access to a client's private provider.</li>
+          <li>No <code>StorageClient</code> subclass and no implicit registration in storage profiles, provider factories, or URI routing.</li>
+          <li>No MSC-defined HTTP/gRPC contract for the plan service; only the in-process provider SPI is standardized.</li>
+          <li>No plan-supplied credentials, absolute origins, storage profiles, or arbitrary executable callbacks.</li>
+          <li>Every descriptor and portable-list snapshot has a mandatory expiration. The default <code>EXPIRATION_ONLY</code> policy does not pretend optional selectors, validators, or operation revisions are enforced; <code>SNAPSHOT_PINNED</code> is an explicit stricter opt-in.</li>
+          <li>A read, materialization, or open-reader lifetime may cross expiration only if admitted while the descriptor was valid. New operations on that view fail until the caller explicitly resolves a new view.</li>
+          <li>Object, service, and inline segments remain an explicit public discriminated union; service transport adapters remain application-owned behind the public executor SPI.</li>
+          <li>The initial public API is synchronous, read-only, explicit, and importable from <code>multistorageclient.assembly</code>.</li>
+        </ul>
+
+        <h3>Requirement alignment and proposal boundaries</h3>
+        <div class="summary-grid">
+          <div class="card">
+            <span class="label">Explicitly required</span>
+            <p class="small">Configured sources and services; direct StorageClient reads for object segments; transport-neutral service segments; optional source versions/validators; bounded execution; and no breaking changes to existing providers.</p>
+          </div>
+          <div class="card">
+            <span class="label">Defensive design, not a requirement</span>
+            <p class="small">Requirements do not explicitly require <code>binding_revision</code> or <code>resource_validator</code>. V1 keeps <code>ObjectSourceBinding</code> client-only, scopes instruction caches to one client and frozen registry snapshot, disables logical-byte caching, and adds no public provider-specific resource-policy hook.</p>
+          </div>
+          <div class="card">
+            <span class="label">Separate optional follow-up</span>
+            <p class="small">Requirements do not explicitly require a built-in HTTP executor, an MSC-defined external service API, or a format-specific executor. Any generic HTTP convenience adapter requires separate approval.</p>
+          </div>
+        </div>
+
+        <div class="callout">
+          This is an implementation proposal, not implementation authorization. Public types, capability semantics, strict
+          expiration behavior, consistency policies, inline limits, service capabilities, and product scale inputs are
+          approval gates before core source code changes begin. The optional generic HTTP adapter contract is not a core approval gate.
+        </div>
+      </section>
+
+      <section id="topology">
+        <h2>2. Component topology and dependency direction</h2>
+        <div class="architecture" role="img" aria-label="The application injects an AssemblyPlanProvider, StorageClient bindings, and ServiceSegmentExecutors into AssemblyClient. Python validates a complete object plan and dispatches its explicit segment union. Existing StorageClients remain owners of their StorageProviders.">
+          <div class="arch-row">
+            <div class="arch-node user"><strong>Plan provider</strong><br><code>AssemblyPlanProvider</code><br><span class="small">logical reference → valid descriptor generation + complete object plan</span></div>
+            <div class="arch-node new"><strong>AssemblyClient / View</strong><br><span class="small">expiration policy and user API</span></div>
+            <div class="arch-node new"><strong>Assembly caches</strong><br><span class="small">all instruction-derived entries expire with their descriptor</span></div>
+          </div>
+          <div class="arch-arrow">provider output → validate complete object → intersect caller range → dispatch segment kinds</div>
+          <div class="arch-row">
+            <div class="arch-node new"><strong>PlanValidator</strong><br><span class="small">expiration, union, global length, limits</span></div>
+            <div class="arch-node new"><strong>ReadPlanner / Executor</strong><br><span class="small">range intersection, bounded fan-out, atomic scatter</span></div>
+            <div class="arch-node new"><strong>Binding registries</strong><br><span class="small">StorageClients and service executors</span></div>
+          </div>
+          <div class="arch-arrow">object reads · service executions · inline copies ↓</div>
+          <div class="arch-row">
+            <div class="arch-node"><strong>ObjectSegmentExecutor</strong><br><span class="small">existing public StorageClient.read</span></div>
+            <div class="arch-node user"><strong>ServiceSegmentExecutor</strong><br><span class="small">STABLE_SUBRANGES or WHOLE_RESULT</span></div>
+            <div class="arch-node new"><strong>Inline executor</strong><br><span class="small">bounded literal bytes, no I/O</span></div>
+          </div>
+          <div class="arch-arrow">↓ existing ownership is preserved</div>
+          <div class="arch-row">
+            <div class="arch-node"><strong>StorageClient → StorageProvider</strong></div>
+            <div class="arch-node user"><strong>User HTTP / gRPC / SDK / local adapter</strong></div>
+            <div class="arch-node"><strong>Memory / temp-file staging</strong></div>
+          </div>
+        </div>
+
+        <h3>One-way dependencies</h3>
+        <div class="formula">application → assembly module → public StorageClient API + service executor SPI → physical systems</div>
+        <ul>
+          <li>The assembly package defines a frozen <code>ByteRange</code>. It may accept MSC's existing mutable <code>Range</code> only at a convenience edge and immediately copy it.</li>
+          <li>Existing client and provider packages do not import the assembly package.</li>
+          <li>The plan provider does not receive StorageClient objects, service executors, credentials, or an executor.</li>
+          <li>A ServiceSegmentExecutor receives one service operation, never a full AssemblyPlan, and never interprets logical ordering.</li>
+          <li>A user service adapter translates one <code>ServiceExecutionRequest</code> to its own transport and never receives the complete plan.</li>
+          <li>The language-neutral <code>assembly-list/v1</code> codec is independent of provider and service transport implementations.</li>
+        </ul>
+      </section>
+
+      <section id="runtime">
+        <h2>3. Runtime flow from public entry point to bytes</h2>
+        <p>The complete call path for <code>assembly.read(reference, ByteRange(28672, 20480))</code> is:</p>
+
+        <div class="sequence">
+          <div class="sequence-item">
+            <strong>Normalize the request</strong>
+            <span><code>AssemblyClient.read</code> canonicalizes the reference and range, checks client state, and rejects limits before any provider, StorageClient, or service-executor call.</span>
+          </div>
+          <div class="sequence-item">
+            <strong>Resolve one valid descriptor generation</strong>
+            <span>The client calls <code>AssemblyPlanProvider.resolve_descriptor</code> once. Its <code>AssemblyDescriptor</code> is metadata only—reference, generation, size, expiration, and optional descriptive fields—and cannot read, open, or materialize bytes. The client rejects a substituted reference or generation and a missing, malformed, or expired <code>expires_at</code>. No view is observable yet.</span>
+          </div>
+          <div class="sequence-item">
+            <strong>Acquire the complete object plan</strong>
+            <span>The client calls <code>get_plan</code> for that exact descriptor. A provider may page its backend internally, but returns all ordered segments for the object and cannot substitute a different generation or a range-specific fragment.</span>
+          </div>
+          <div class="sequence-item">
+            <strong>Validate and publish the view</strong>
+            <span>The validator checks the segment discriminator, checked global length, hard inline limits, aliases, optional selectors/validators/operation revisions/checksums, and the selected consistency policy. It then freezes the resolved local source/service objects and computes capabilities. Only now does <code>AssemblyClient.resolve</code> return an executable <code>AssemblyView</code> containing the descriptor, validated complete plan, frozen bindings, consistency/capabilities, and lifecycle state. Refresh repeats this pipeline and returns another view.</span>
+          </div>
+          <div class="sequence-item">
+            <strong>Intersect the caller range</strong>
+            <span>Only after global validation, the planner intersects the requested range with object and inline segments and chooses subrange or whole-result execution for each service segment.</span>
+          </div>
+          <div class="sequence-item">
+            <strong>Dispatch bounded operations</strong>
+            <span>Object segments call existing StorageClient APIs directly. Range-capable services receive stable subranges. Each touched WHOLE_RESULT stage key—descriptor generation, plan digest, and segment ordinal—gets one logical request submission per top-level operation and is staged under fixed memory/temp-file bounds before slicing; a SAFE executor may make multiple private transport attempts.</span>
+          </div>
+          <div class="sequence-item">
+            <strong>Verify every chunk</strong>
+            <span>Each binding enforces only capabilities present in its concrete contract: the initial object binding rejects selectors/enforcing validators, while service executors validate advertised revision and retry semantics. A checksum may be absent, but when supplied MSC always stages and verifies the complete segment before exposing any slice.</span>
+          </div>
+          <div class="sequence-item">
+            <strong>Commit atomically</strong>
+            <span>Verified chunks scatter incrementally into a private destination buffer; only after every chunk passes may the executor return immutable bytes. V1 publishes no logical-byte cache entry.</span>
+          </div>
+        </div>
+
+        <h3>Failure boundary</h3>
+        <p>
+          A terminal error cancels queued work, signals the shared cancellation token, closes open service result streams, discards
+          every unpublished chunk and staged output, and returns one stable domain exception. The token is internal in v1: MSC
+          signals it after a sibling failure or parent-client close; the synchronous public façade has no caller-supplied
+          cancellation input. The absolute operation deadline strictly bounds admission and MSC-owned waits. A provider or
+          service executor receives that deadline and must honor it cooperatively. The current synchronous
+          <code>StorageClient.read</code> accepts neither a deadline nor a cancellation token, so MSC can check the deadline
+          before and after the call but cannot preempt an in-progress read. Applications must configure the StorageClient's
+          underlying transport timeouts and retry envelope accordingly; a late result is discarded after the deadline is
+          observed. A future additive object-binding contract may offer stronger cancellation without changing StorageClient.
+        </p>
+        <div class="callout info">
+          Expiration is an admission check, not an in-flight cancellation deadline. An operation admitted while the descriptor is
+          valid may finish after <code>expires_at</code>. Its result may be published to the caller or atomically materialized,
+          but no instruction-derived cache entry is usable after expiration. A completed materialized file has an independent,
+          application-owned retention lifetime and does not become invalid merely because its source descriptor later expires.
+        </div>
+      </section>
+
+      <section id="contracts">
+        <h2>4. Concrete contracts and immutable models</h2>
+        <p>
+          Public models live in Python, use frozen slotted dataclasses, and are validated at construction and again at trust
+          boundaries. <code>assembly-list/v1</code> is a normative, versioned, language-neutral JSON representation; providers
+          may construct the equivalent models directly, but they do not get a private Python-only semantic contract.
+        </p>
+        <div class="callout info">
+          <strong>Descriptor is not view.</strong> <code>AssemblyDescriptor</code> is immutable control-plane metadata and has
+          no byte-I/O methods. <code>AssemblyView</code> is the executable handle created only after MSC retrieves and validates
+          the complete <code>AssemblyPlan</code>, freezes local bindings, computes consistency/capabilities, and initializes
+          lifecycle state. <code>AssemblyView.metadata</code> returns the exact descriptor captured by that view.
+        </div>
+
+        <div class="callout info">
+          <strong>Gate 0 status.</strong> Numeric operational defaults shown in this section are proposed inputs, not stable API
+          defaults, until the product scale and memory envelope is approved. The 16 KiB per-inline-segment and 64 KiB
+          inline-per-object values are different: they are normative hard upper ceilings, and configuration may only lower them.
+        </div>
+
+        <pre><code>JsonScalarInput = str | int | float | bool | None
+JsonInput = JsonScalarInput | Sequence["JsonInput"] | Mapping[str, "JsonInput"]
+
+@dataclass(frozen=True, slots=True)
+class FrozenJsonScalar:
+    kind: Literal["null", "boolean", "number", "string"]
+    value: None | bool | str  # number stores its canonical RFC 8785 spelling
+
+    @classmethod
+    def from_value(cls, value: JsonScalarInput) -> "FrozenJsonScalar": ...
+
+@dataclass(frozen=True, slots=True)
+class FrozenJsonArray:
+    items: tuple["JsonValue", ...]
+
+@dataclass(frozen=True, slots=True)
+class FrozenJsonObject:
+    items: tuple[tuple[str, "JsonValue"], ...]
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, JsonInput]) -> "FrozenJsonObject": ...
+
+JsonValue = FrozenJsonScalar | FrozenJsonArray | FrozenJsonObject
+ASSEMBLY_LIST_SCHEMA_V1: Final = "assembly-list/v1"
+ASSEMBLY_PLAN_SCHEMA_V1: Final = "assembly-plan/v1"
+
+class AssemblyConsistency(Enum):
+    EXPIRATION_ONLY = "expiration_only"       # default
+    SNAPSHOT_PINNED = "snapshot_pinned"       # explicit stricter opt-in
+
+class ServiceRangeMode(Enum):
+    STABLE_SUBRANGES = "stable_subranges"
+    WHOLE_RESULT = "whole_result"
+
+class RetrySafety(Enum):
+    NEVER = "never"
+    SAFE = "safe"
+
+class RevisionUse(Enum):
+    ENFORCE_DURING_READ = "enforce_during_read"
+    IDENTITY_ONLY = "identity_only"
+
+StrPath = str | os.PathLike[str]
+
+# Gate 0 must approve the proposed operational defaults below before they
+# become stable API defaults. The 16 KiB per-segment and 64 KiB per-object
+# inline values are normative hard upper ceilings; configuration may lower
+# but never raise them.
+@dataclass(frozen=True, slots=True)
+class AssemblyClientConfig:
+    max_concurrency: int = 16
+    max_active_operations: int = 64
+    max_segments_per_object: int = 100_000
+    max_plan_bytes: int = 16 * 1024 * 1024
+    max_read_bytes: int = 512 * 1024 * 1024
+    max_output_memory_bytes_total: int = 2 * 1024**3
+    materialization_window_bytes: int = 64 * 1024 * 1024
+    max_object_read_chunk_bytes: int = 64 * 1024 * 1024
+    max_inflight_object_bytes: int = 256 * 1024 * 1024
+    max_service_chunk_bytes: int = 1024 * 1024
+    max_object_bytes: int = 16 * 1024**4
+    max_namespace_utf8_bytes: int = 1024
+    max_key_utf8_bytes: int = 16 * 1024
+    max_reference_parameters: int = 128
+    max_resource_utf8_bytes: int = 16 * 1024
+    max_operation_utf8_bytes: int = 1024
+    max_identity_metadata_utf8_bytes: int = 64 * 1024
+    max_parameter_depth: int = 32
+    max_parameter_items: int = 10_000
+    max_parameter_canonical_bytes: int = 1024 * 1024
+    max_inline_segment_bytes: int = 16 * 1024
+    max_inline_bytes_per_object: int = 64 * 1024
+    max_complete_segment_memory_bytes: int = 64 * 1024 * 1024
+    max_complete_segment_staged_bytes: int = 16 * 1024**3
+    max_staging_memory_bytes_per_operation: int = 256 * 1024 * 1024
+    max_staging_bytes_per_operation: int = 32 * 1024**3
+    max_staging_memory_bytes_total: int = 1024**3
+    max_staging_bytes_total: int = 128 * 1024**3
+    staging_directory: StrPath | None = None
+    operation_timeout_seconds: float = 300.0
+    max_list_page_size: int = 10_000
+    max_cursor_utf8_bytes: int = 16 * 1024
+    max_glob_results: int = 100_000
+    max_glob_scanned_items: int = 1_000_000
+    plan_cache_entries: int = 256
+    required_consistency: AssemblyConsistency = AssemblyConsistency.EXPIRATION_ONLY
+
+@dataclass(frozen=True, slots=True)
+class ByteRange:
+    offset: int
+    size: int
+
+@dataclass(frozen=True, slots=True)
+class AssemblyReference:
+    namespace: str
+    key: str
+    parameters: tuple[tuple[str, FrozenJsonScalar], ...] = ()
+
+    @classmethod
+    def from_mapping(
+        cls,
+        *,
+        namespace: str,
+        key: str,
+        parameters: Mapping[str, JsonScalarInput] | None = None,
+    ) -> "AssemblyReference": ...
+
+@dataclass(frozen=True, slots=True)
+class ResolveAssemblyRequest:
+    reference: AssemblyReference
+    generation: str | None = None
+    deadline_monotonic: float | None = field(default=None, compare=False, hash=False, repr=False)
+
+@dataclass(frozen=True, slots=True)
+class SourceSelector:
+    kind: str
+    value: str
+
+@dataclass(frozen=True, slots=True)
+class SourceValidator:
+    kind: str
+    value: str
+    use: RevisionUse
+
+@dataclass(frozen=True, slots=True)
+class OperationRevision:
+    kind: str
+    value: str
+    use: RevisionUse
+
+@dataclass(frozen=True, slots=True)
+class AssemblyDescriptor:
+    """Control-plane metadata only; never an executable byte handle."""
+    reference: AssemblyReference
+    generation: str
+    size: int
+    expires_at: datetime
+    etag: str | None = None
+    content_type: str | None = None
+    published_at: datetime | None = None
+
+@dataclass(frozen=True, slots=True)
+class RefreshAssemblyRequest:
+    previous: AssemblyDescriptor
+    deadline_monotonic: float | None = field(default=None, compare=False, hash=False, repr=False)
+
+@dataclass(frozen=True, slots=True)
+class ListAssembliesRequest:
+    namespace: str
+    prefix: str = ""
+    cursor: str | None = None
+    page_size: int = 1000
+    deadline_monotonic: float | None = field(default=None, compare=False, hash=False, repr=False)
+
+@dataclass(frozen=True, slots=True)
+class AssemblyPage:
+    listing_generation: str
+    items: tuple[AssemblyDescriptor, ...]
+    next_cursor: str | None = None
+
+@dataclass(frozen=True, slots=True)
+class Checksum:
+    algorithm: Literal["sha256"]
+    value: str  # 64 lowercase hexadecimal characters
+
+@dataclass(frozen=True, slots=True)
+class ObjectSegment:
+    kind: Literal["object"]
+    source_id: str
+    resource: str
+    byte_range: ByteRange
+    length: int
+    selector: SourceSelector | None = None
+    validator: SourceValidator | None = None
+    checksum: Checksum | None = None
+
+@dataclass(frozen=True, slots=True)
+class ServiceSegment:
+    kind: Literal["service"]
+    executor_id: str
+    operation: str
+    parameters: FrozenJsonObject
+    length: int
+    range_mode: ServiceRangeMode = ServiceRangeMode.WHOLE_RESULT
+    retry_safety: RetrySafety = RetrySafety.NEVER
+    operation_revision: OperationRevision | None = None
+    checksum: Checksum | None = None
+
+@dataclass(frozen=True, slots=True)
+class InlineSegment:
+    kind: Literal["inline"]
+    data: bytes
+    length: int
+
+AssemblySegment: TypeAlias = ObjectSegment | ServiceSegment | InlineSegment
+
+@dataclass(frozen=True, slots=True)
+class AssemblyObjectDefinition:
+    reference: AssemblyReference
+    size: int
+    segments: tuple[AssemblySegment, ...]
+    etag: str | None = None
+    content_type: str | None = None
+    published_at: datetime | None = None
+
+@dataclass(frozen=True, slots=True)
+class AssemblyPlan:
+    schema_version: Literal["assembly-plan/v1"]
+    descriptor: AssemblyDescriptor
+    segments: tuple[AssemblySegment, ...]
+    plan_digest: str
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        schema_version: Literal["assembly-plan/v1"],
+        descriptor: AssemblyDescriptor,
+        segments: Sequence[AssemblySegment],
+    ) -> "AssemblyPlan": ...
+
+@dataclass(frozen=True, slots=True)
+class AssemblyListBatch:
+    schema_version: Literal["assembly-list/v1"]
+    list_id: str
+    issued_at: datetime
+    expires_at: datetime
+    batch_index: int
+    batch_count: int
+    objects: tuple[AssemblyObjectDefinition, ...]  # never split across batches
+    batch_digest: str</code></pre>
+
+        <pre><code>@dataclass(frozen=True, slots=True)
+class AssemblyListSnapshot:
+    list_id: str
+    issued_at: datetime
+    expires_at: datetime
+    batch_count: int
+
+@dataclass(frozen=True, slots=True)
+class AssemblyListDecodeLimits:
+    max_encoded_batch_bytes: int = 64 * 1024 * 1024
+    max_objects_per_batch: int = 100_000
+    max_segments_per_object: int = 100_000
+    max_json_depth: int = 64
+    max_json_string_utf8_bytes: int = 1024 * 1024
+    max_json_nodes_per_batch: int = 2_000_000
+
+@dataclass(frozen=True, slots=True)
+class InMemoryAssemblyListLimits:
+    max_objects: int = 100_000
+    max_segments: int = 1_000_000
+    max_canonical_bytes: int = 256 * 1024 * 1024
+
+def decode_assembly_list_batch(
+    data: bytes | bytearray | memoryview | str,
+    *,
+    limits: AssemblyListDecodeLimits | None = None,
+) -> AssemblyListBatch: ...
+
+def encode_assembly_list_batch(batch: AssemblyListBatch) -> bytes: ...
+
+def iter_decode_assembly_list_batches(
+    stream: BinaryIO,
+    *,
+    limits: AssemblyListDecodeLimits | None = None,
+) -> Iterator[AssemblyListBatch]: ...
+
+def write_assembly_list_batches(
+    batches: Iterable[AssemblyListBatch],
+    stream: BinaryIO,
+) -> None: ...</code></pre>
+
+        <h3 id="public-facade-reference">Exact public façade reference</h3>
+        <p>
+          The high-level design intentionally shows only the common workflow. This subsection is the normative signature
+          reference for the façade, view, reader, optional browsing iterator, and their advertised capabilities. Provider
+          code returns descriptors; only the client returns views.
+        </p>
+        <pre><code>RangeLike = ByteRange | multistorageclient.types.Range  # copied immediately to ByteRange
+
+@dataclass(frozen=True, slots=True)
+class AssemblyCapabilities:
+    browse: bool
+    refresh: bool
+
+@dataclass(frozen=True, slots=True)
+class AssemblyViewCapabilities:
+    byte_range_read: bool
+    streaming_open: bool
+    seek: bool
+    consistency: AssemblyConsistency
+
+class AssemblyClient:
+    def __init__(
+        self,
+        *,
+        plan_provider: AssemblyPlanProvider,
+        object_sources: Mapping[str, ObjectSourceBinding],
+        service_executors: Mapping[str, ServiceSegmentExecutor],
+        config: AssemblyClientConfig | None = None,
+        close_dependencies: bool = False,
+    ) -> None: ...
+
+    @property
+    def capabilities(self) -> AssemblyCapabilities: ...
+
+    def resolve(
+        self,
+        reference: AssemblyReference | str,
+        *,
+        generation: str | None = None,
+        required_consistency: AssemblyConsistency | None = None,
+    ) -> AssemblyView:
+        """Return only after descriptor, complete plan, bindings, and capabilities are valid."""
+        ...
+
+    def refresh(self, view: AssemblyView, *, required_consistency: AssemblyConsistency | None = None) -> AssemblyView: ...
+    def info(
+        self,
+        reference: AssemblyReference | str,
+        *,
+        generation: str | None = None,
+    ) -> AssemblyDescriptor:
+        """Resolve descriptor metadata only.
+
+        Do not call get_plan, resolve bindings, compute executable
+        consistency, or perform object/service byte I/O.
+        """
+        ...
+    def read(self, reference: AssemblyReference | str, byte_range: RangeLike | None = None, *, generation: str | None = None, required_consistency: AssemblyConsistency | None = None) -> bytes: ...
+    def open(self, reference: AssemblyReference | str, *, generation: str | None = None, required_consistency: AssemblyConsistency | None = None) -> AssemblyReader: ...
+    def materialize(self, reference: AssemblyReference | str, destination: StrPath, *, generation: str | None = None, required_consistency: AssemblyConsistency | None = None, overwrite: bool = False, fsync: bool = False) -> None: ...
+    def list(self, *, namespace: str, prefix: str = "", cursor: str | None = None, page_size: int = 1000) -> AssemblyPage: ...
+    def glob(self, *, namespace: str, pattern: str) -> "AssemblyGlobIterator": ...
+    def close(self) -> None: ...
+    def __enter__(self) -> "AssemblyClient": ...
+    def __exit__(self, *exc: object) -> None: ...
+
+class AssemblyView:
+    @property
+    def metadata(self) -> AssemblyDescriptor:
+        """Return this executable view's immutable control-plane descriptor."""
+        ...
+
+    @property
+    def consistency(self) -> AssemblyConsistency: ...
+
+    @property
+    def required_consistency(self) -> AssemblyConsistency: ...
+
+    @property
+    def capabilities(self) -> AssemblyViewCapabilities: ...
+
+    def read(self, byte_range: RangeLike | None = None) -> bytes: ...
+    def open(self) -> AssemblyReader: ...
+    def materialize(self, destination: StrPath, *, overwrite: bool = False, fsync: bool = False) -> None: ...
+    def close(self) -> None: ...
+    def __enter__(self) -> "AssemblyView": ...
+    def __exit__(self, *exc: object) -> None: ...
+
+class AssemblyReader(io.RawIOBase):
+    @property
+    def metadata(self) -> AssemblyDescriptor: ...
+
+    def readable(self) -> bool: return True
+    def seekable(self) -> bool: return self._capabilities.seek
+    def writable(self) -> bool: return False
+    def read(self, size: int = -1) -> bytes: ...
+    def readall(self) -> bytes: ...
+    def readinto(self, buffer: bytearray | memoryview) -> int: ...
+    def seek(self, offset: int, whence: int = os.SEEK_SET) -> int: ...
+    def tell(self) -> int: ...
+
+class AssemblyGlobIterator(Iterator[AssemblyDescriptor]):
+    def __iter__(self) -> "AssemblyGlobIterator": ...
+    def __next__(self) -> AssemblyDescriptor: ...
+    def close(self) -> None: ...
+    def __enter__(self) -> "AssemblyGlobIterator": ...
+    def __exit__(self, *exc: object) -> None: ...</code></pre>
+
+        <p class="small">
+          <code>AssemblyClient.info()</code> is intentionally descriptor-only: it validates the reference, requested generation,
+          descriptor model, and expiration, but never calls <code>get_plan</code>, inspects object or service bindings, computes
+          executable consistency, or performs byte I/O. Call <code>resolve()</code> when a validated executable view or a
+          consistency guarantee is required.
+        </p>
+        <p class="small">
+          Browsing is optional and is advertised by <code>AssemblyCapabilities.browse</code>. The exact configuration fields,
+          defaults, validation rules, admission semantics, and cursor/glob limits are specified in the surrounding
+          implementation sections rather than in the high-level document.
+        </p>
+
+        <h3>Language-neutral list and canonical plan digest</h3>
+        <p>
+          An assembly list is one or more ordered <code>AssemblyListBatch</code> values with one <code>list_id</code>, issuance,
+          mandatory <code>expires_at</code>, batch count, contiguous zero-based batch indexes, and
+          exactly the declared number of batches. An object
+          definition cannot be split between batches. This gives streaming traversal a bounded batch envelope while allowing
+          an <code>AssemblyListStore</code> to choose a memory, disk, or remote exact-name index. That executable list is distinct from
+          the optional browsing index: browse pages contain names/metadata/cursors and cannot be passed to the executor.
+          The v1 artifact intentionally carries no refresh locator: refresh auth/transport is provider-owned through
+          <code>AssemblyPlanProvider.refresh</code>. StaticAssemblyListProvider is non-refreshable; a custom provider may keep
+          an artifact-carried or out-of-band locator internally and must still return a new identity/expiration.
+        </p>
+        <p>
+          <code>plan_digest</code> is a provider-supplied canonical instruction digest that MSC recomputes and verifies; the
+          <code>AssemblyPlan.create</code> convenience computes it for direct-model providers. It is not a required expected
+          digest of output bytes.
+          It is <code>sha256:&lt;64 lowercase hex characters&gt;</code> over the UTF-8 RFC 8785 JSON Canonicalization Scheme
+          projection containing exactly <code>schema_version</code>, <code>descriptor</code>, and the ordered discriminated
+          <code>segments</code>. It excludes itself and execution-only deadlines. The list codec uses UTC RFC 3339 timestamps
+          with exactly six fractional-second digits and <code>Z</code>, rejects timezone-naive values and unknown fields/kinds,
+          and represents inline bytes as canonical unpadded base64url. <code>FrozenJsonArray</code> and
+          <code>FrozenJsonObject</code> preserve JSON kind identity even for pair-shaped values; service parameters require an
+          object root, while reference parameters allow scalar values only. Both parameter forms reject non-finite numbers
+          and normalize negative zero. All object-key tuples use RFC 8785 UTF-16 code-unit order in memory and on the wire;
+          lone surrogates are rejected and no Unicode normalization is performed. Frozen scalar equality/hash includes JSON
+          kind plus canonical value: booleans differ from numbers, while <code>1</code>/<code>1.0</code> and
+          <code>0</code>/<code>-0.0</code> normalize equal. Every non-JSON schema integer requires
+          <code>type(value) is int</code>, rejecting bool and integral float. Every integer
+          is in <code>[-(2**53)+1, (2**53)-1]</code>; offsets, lengths, sizes, and
+          batch indexes are additionally non-negative.
+        </p>
+        <pre><code>assembly_reference := {
+  "namespace": string,
+  "key": string,
+  "parameters": { string: json_scalar }  # scalar values only; RFC 8785 UTF-16 key order
+}
+source_selector := {"kind": string, "value": string}
+source_validator := {"kind": string, "value": string,
+                     "use": "enforce_during_read" | "identity_only"}
+operation_revision := {"kind": string, "value": string,
+                       "use": "enforce_during_read" | "identity_only"}
+checksum := {"algorithm": "sha256", "value": lower_hex_64_without_prefix}</code></pre>
+        <pre><code>{
+  "schema_version": "assembly-list/v1",
+  "list_id": string,
+  "issued_at": utc_rfc3339_microseconds,
+  "expires_at": utc_rfc3339_microseconds,
+  "batch_index": integer,
+  "batch_count": integer,
+  "objects": [{
+    "reference": assembly_reference,
+    "size": integer,
+    "etag": string | null,
+    "content_type": string | null,
+    "published_at": utc_rfc3339_microseconds | null,
+    "segments": [
+      {"kind": "object", "source_id": string, "resource": string,
+       "byte_range": {"offset": integer, "size": integer}, "length": integer,
+       "selector": source_selector | null, "validator": source_validator | null,
+       "checksum": checksum | null},
+      {"kind": "service", "executor_id": string, "operation": string,
+       "parameters": json_object, "length": integer,
+       "range_mode": "stable_subranges" | "whole_result",
+       "retry_safety": "never" | "safe",
+       "operation_revision": operation_revision | null,
+       "checksum": checksum | null},
+      {"kind": "inline", "data_base64": string, "length": integer}
+    ]
+  }],
+  "batch_digest": sha256_prefixed_lower_hex
+}</code></pre>
+        <p class="small">
+          Optional values are explicit JSON <code>null</code>; arrays retain semantic order. Every batch carries expiration so
+          it can be rejected independently. Across one snapshot, <code>list_id</code>, <code>issued_at</code>,
+          <code>expires_at</code>, and <code>batch_count</code> must match. Golden vectors cover each union arm, multi-batch lists,
+          empty objects, Unicode, timestamps, base64, and invalid unknown fields.
+        </p>
+
+        <h3>Canonical invariants not expressed by the type declarations</h3>
+        <ul>
+          <li>Every <code>AssemblyReference</code> is unique within one complete list snapshot, including across batch boundaries.</li>
+          <li>A zero-size object has an empty plan. Otherwise, every segment length is positive and the checked sum of ordered segment lengths equals the descriptor size.</li>
+          <li><code>ObjectSegment.byte_range.size == ObjectSegment.length</code>; <code>InlineSegment.length == len(InlineSegment.data)</code>.</li>
+          <li><code>AssemblyDescriptor.etag</code> is an optional identity of the complete assembled byte sequence. It is distinct from a source validator and MSC never synthesizes it from segment identities.</li>
+          <li><code>batch_digest</code> is SHA-256 over the RFC 8785 canonical batch projection excluding <code>batch_digest</code> itself. <code>plan_digest</code> similarly excludes itself and execution-only deadlines.</li>
+          <li>Operation deadlines do not participate in model equality, hashing, digest projections, or cache identity.</li>
+          <li><code>plan_digest</code> and <code>batch_digest</code> protect instructions/artifacts. Neither is an output-byte checksum nor sufficient evidence for <code>SNAPSHOT_PINNED</code>.</li>
+        </ul>
+
+        <h3>Local binding authority and hard inline limits</h3>
+        <p>
+          Object source and service aliases are local. A list cannot choose a profile, client, endpoint, credentials, or
+          executor implementation. Validation resolves each alias and freezes the concrete local object in the view. An object
+          resource is interpreted only through the bound StorageClient's existing public logical-path semantics; it cannot
+          reconfigure that client or select authority outside it. Applications must therefore bind a least-privilege logical
+          namespace appropriate for every plan they accept. V1 adds no provider-specific narrower-path policy on top of that
+          public StorageClient namespace. Rebinding an alias never mutates an existing view. Inline data is decoded
+          under two immutable v1 upper ceilings: at most <strong>16 KiB per InlineSegment</strong> and
+          <strong>64 KiB total decoded inline bytes per object/plan</strong>. Client configuration may lower, but never raise,
+          either ceiling. Encoded-size and overall-plan limits apply in
+          addition; inline bytes never become a bulk-data escape hatch.
+        </p>
+
+        <h3>Expiration and consistency policies</h3>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Rule</th><th><code>EXPIRATION_ONLY</code> (default)</th><th><code>SNAPSHOT_PINNED</code> (opt-in)</th></tr></thead>
+            <tbody>
+              <tr><td>Mandatory freshness</td><td colspan="2">Missing, malformed, or expired <code>expires_at</code> raises <code>AssemblyExpiredError</code> before an operation begins.</td></tr>
+              <tr><td>Optional identity/checksum fields</td><td>All may be absent. The initial object binding rejects selectors/enforcing validators but accepts identity-only metadata; service revisions are enforced only when advertised. Identity-only values cannot imply snapshot safety.</td><td>Each object segment needs a verified complete checksum in v1; each service segment needs an advertised enforced revision or verified complete checksum.</td></tr>
+              <tr><td>Same-length mutation</td><td>May be undetectable and is documented as such.</td><td>Must fail closed before publishing bytes.</td></tr>
+              <tr><td>Cross-operation byte cache</td><td colspan="2">Disabled in v1. Consistency computation still determines what the view may claim, but it does not enable a logical-byte cache.</td></tr>
+              <tr><td>Refresh</td><td colspan="2"><code>AssemblyClient.refresh(view)</code> resolves a replacement and returns a new view with a new <code>generation</code>/<code>expires_at</code>; it never extends or mutates the old view, and a None consistency argument preserves the old view's originally requested minimum.</td></tr>
+              <tr><td>In-flight expiration</td><td colspan="2">An operation admitted while valid may finish. A subsequent operation on the old view is rejected.</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="callout danger">
+          <code>EXPIRATION_ONLY</code> is a truthful weaker guarantee, not a hidden snapshot mode. A
+          <code>HEAD → ordinary GET → HEAD</code> sequence is not an atomic pinned read and cannot satisfy
+          <code>SNAPSHOT_PINNED</code>, even when both metadata calls return the same value.
+        </div>
+        <p class="small">
+          A <code>Checksum</code> covers the complete bytes of its segment, not an arbitrary caller-selected subrange.
+          When present it is normative: MSC executes/stages and verifies that complete segment under the configured
+          verification-byte limits before every requested slice, in either consistency mode and regardless of another
+          enforced identity. Successful verification may then contribute snapshot safety.
+        </p>
+      </section>
+
+      <section id="provider">
+        <h2>5. AssemblyPlanProvider adapter and conformance boundary</h2>
+        <p>
+          The provider is a narrow in-process SPI. It may internally call any service or local catalog, but MSC never sees
+          its transport. Implementations translate backend responses to canonical models and backend failures to stable
+          assembly exceptions.
+        </p>
+
+<pre><code>class AssemblyPlanProvider(ABC):
+    @property
+    def supports_refresh(self) -> bool:
+        """Immutable explicit capability; override together with refresh."""
+        return False
+
+    @abstractmethod
+    def resolve_descriptor(self, request: ResolveAssemblyRequest) -> AssemblyDescriptor:
+        """Resolve a named object as one fixed, unexpired generation."""
+
+    @abstractmethod
+    def get_plan(
+        self,
+        descriptor: AssemblyDescriptor,
+        *,
+        deadline_monotonic: float | None = None,
+    ) -> AssemblyPlan:
+        """Return every ordered segment for the descriptor's complete object."""
+
+    def refresh(self, request: RefreshAssemblyRequest) -> AssemblyDescriptor:
+        raise AssemblyCapabilityError()
+
+    def close(self) -> None:
+        pass
+
+class BrowsableAssemblyPlanProvider(AssemblyPlanProvider):
+    @abstractmethod
+    def list(self, request: ListAssembliesRequest) -> AssemblyPage:
+        """Return stable metadata only; pages are not executable plans."""
+
+class AssemblyListStore(ABC):
+    @property
+    @abstractmethod
+    def snapshot(self) -> AssemblyListSnapshot: ...
+
+    @abstractmethod
+    def get(self, reference: AssemblyReference) -> AssemblyObjectDefinition | None: ...
+
+    @abstractmethod
+    def iter_objects(
+        self,
+        *,
+        namespace: str,
+        prefix: str = "",
+    ) -> Iterator[AssemblyObjectDefinition]: ...
+
+    def close(self) -> None:
+        pass
+
+class StaticAssemblyListProvider(BrowsableAssemblyPlanProvider):
+    def __init__(
+        self,
+        store: AssemblyListStore,
+        *,
+        close_store: bool = False,
+    ) -> None: ...
+
+    @classmethod
+    def from_batches(
+        cls,
+        batches: Iterable[AssemblyListBatch],
+        *,
+        limits: InMemoryAssemblyListLimits | None = None,
+        batch_limits: AssemblyListDecodeLimits | None = None,
+    ) -> "StaticAssemblyListProvider": ...</code></pre>
+
+        <h3>Contract choices</h3>
+        <ul>
+          <li><code>resolve_descriptor</code> and <code>get_plan</code> are separate provider calls so metadata pins one descriptor generation before plan retrieval. <code>resolve_descriptor</code> returns only an <code>AssemblyDescriptor</code>; it never returns an executable object or exposes <code>read</code>, <code>open</code>, or <code>materialize</code>. <code>AssemblyClient.resolve</code> invokes both provider calls, validates the complete plan, freezes local bindings, computes capabilities, and returns no <code>AssemblyView</code> until every step succeeds. <code>get_plan(descriptor, *, deadline_monotonic=...)</code> receives the pinned descriptor directly and no byte range.</li>
+          <li><code>AssemblyCapabilities.refresh</code> captures the provider's immutable exact-bool <code>supports_refresh</code> value at construction. <code>refresh</code> rejects false before a provider call; StaticAssemblyListProvider advertises false, and a refreshable provider overrides both property and method.</li>
+          <li>No provider binding revision is required or echoed by the descriptor. Core instruction caches are scoped to one <code>AssemblyClient</code> and its concrete provider instance; they are never reused across provider instances.</li>
+          <li><code>get_plan</code> returns one complete object plan. Backend/list batching is an implementation detail; a partial segment page never enters the validator or executor.</li>
+          <li><code>StaticAssemblyListProvider</code> is the reference concrete-list surface. For each object definition it sets <code>descriptor.generation = snapshot.list_id</code> and <code>descriptor.expires_at = snapshot.expires_at</code>; reference, size, ETag, content type, and publication time come from that object definition. It constructs the plan with <code>assembly-plan/v1</code> and computes the canonical plan digest locally. The batch-iterator convenience applies default or supplied <code>AssemblyListDecodeLimits</code> structurally even to direct-model batches, then enforces <code>InMemoryAssemblyListLimits</code> over aggregate objects, segments, and canonical bytes before commit. Exact canonical bytes exclude newline framing, but measurement streams into a capped counter/digest sink using the smaller remaining per-batch/aggregate allowance; it aborts at one over and never materializes a full encoding only to measure. Large deployments inject a replayable <code>AssemblyListStore</code>.</li>
+          <li>An <code>AssemblyListStore</code> declares one immutable snapshot, exact lookup, and traversal. Its conformance suite verifies stable results, fully validated batch provenance, close behavior, and the approved cost/memory envelope.</li>
+          <li>Browsing is a separate optional <code>BrowsableAssemblyPlanProvider</code> capability. Its pages and cursors are stable metadata views, not fragments of executable assembly lists.</li>
+          <li><code>resolve_descriptor</code>, <code>get_plan</code>, and optional <code>list</code> are unconditionally thread-safe in v1; close begins only after the application stops new operations.</li>
+          <li>The synchronous v1 contract matches the current StorageClient surface. A later async API must use separate classes/methods, not silently change blocking behavior.</li>
+          <li>Provider retries are internal and bounded. AssemblyClient does not layer general retries around provider calls.</li>
+          <li>There is no automatic refresh. <code>AssemblyClient.refresh(view)</code> asks the provider for a replacement and returns a distinct view; a None consistency argument preserves the old view's originally requested minimum, while only an explicit override changes it. Failure leaves the old view unchanged: a still-valid, open view remains usable, while an expired or closed view remains unusable.</li>
+        </ul>
+
+        <h3 id="provider-error-contract">Provider error contract</h3>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Exception</th><th>Meaning</th><th>AssemblyClient behavior</th></tr></thead>
+            <tbody>
+              <tr><td><code>AssemblyNotFoundError</code></td><td>Logical key is unknown.</td><td>Do not call sources; surface a fresh canonical copy.</td></tr>
+              <tr><td><code>AssemblyGenerationUnavailableError</code></td><td>The requested generation cannot be served.</td><td>Never fall forward to latest.</td></tr>
+              <tr><td><code>AssemblyProviderAuthenticationError</code></td><td>The provider backend rejected credentials after its own safe refresh attempt.</td><td>Do not add an authentication retry.</td></tr>
+              <tr><td><code>AssemblyProviderRetryableError</code></td><td>The provider exhausted its bounded retries on a transient failure.</td><td>Do not add an outer retry loop.</td></tr>
+              <tr><td><code>InvalidAssemblyPlanError</code></td><td>The provider returned a structurally or semantically invalid plan.</td><td>Fail before source I/O and record a contract violation.</td></tr>
+              <tr><td><code>AssemblyCapabilityError</code></td><td>Refresh, browsing, or requested consistency is unsupported.</td><td>Fail without fallback or implicit downgrade.</td></tr>
+              <tr><td><code>AssemblyProviderError</code></td><td>An unexpected provider <code>Exception</code>.</td><td>Retain only a safe type token and discard the original object and message.</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="small">
+          Exact allowlisted outcomes are copied into fresh canonical instances using validated safe fields. Subclasses,
+          arbitrary arguments, malformed fields, and incoming cause/context chains never pass through the provider boundary.
+        </p>
+
+        <h3>MSC-supplied provider conformance suite</h3>
+        <p>
+          <code>multistorageclient.assembly.testing</code> exposes reusable pytest cases/factories. It proves behavior rather
+          than transport shape: mandatory expiration, stable descriptor generation, complete-object coverage, deterministic exceptions,
+          limits, concurrency claims, and lifecycle. A separate suite covers <code>ServiceSegmentExecutor</code>; neither suite
+          is coupled to HTTP payloads or endpoint names.
+        </p>
+
+        <div class="callout info">
+          Provider implementations own authentication refresh and transport retries. They must not include tokens, full
+          sensitive URLs, or backend response bodies in <code>repr</code>, cache keys, metrics, or public exceptions.
+        </div>
+      </section>
+
+      <section id="validation">
+        <h2>6. Validation and range planning</h2>
+        <h3>Configuration validation</h3>
+        <p>
+          Every public config/limits dataclass validates in <code>__post_init__</code> and raises <code>AssemblyConfigurationError</code>
+          before dependency/network I/O. Integer fields reject bool/integral float; all byte/count/concurrency/glob/timeout
+          ceilings are positive except <code>plan_cache_entries &gt;= 0</code>, and every integer configuration value is at most
+          <code>2**53 - 1</code>. Every seconds field is finite, within <code>[0, 604800]</code> where zero is allowed or
+          <code>(0, 604800]</code> otherwise. Inline limits may only lower 16/64 KiB and object aggregate is at least segment.
+          The exact byte-limit relationships are <code>materialization_window_bytes &lt;= max_read_bytes</code>;
+          <code>max_object_read_chunk_bytes &lt;= min(max_read_bytes, materialization_window_bytes,
+          max_inflight_object_bytes, max_complete_segment_memory_bytes, max_staging_memory_bytes_per_operation,
+          max_staging_memory_bytes_total)</code>;
+          <code>max_service_chunk_bytes &lt;= min(max_read_bytes, materialization_window_bytes,
+          max_complete_segment_memory_bytes, max_staging_memory_bytes_per_operation,
+          max_staging_memory_bytes_total)</code>; <code>max_complete_segment_memory_bytes &lt;=
+          max_complete_segment_staged_bytes &lt;= max_staging_bytes_per_operation</code>; and
+          <code>max_complete_segment_memory_bytes &lt;= max_staging_memory_bytes_per_operation &lt;=
+          max_staging_bytes_per_operation</code>. The complete-segment thresholds apply equally to WHOLE_RESULT service
+          segments and to checksum-bearing object or service segments that require complete-result staging. Twice each of
+          <code>max_read_bytes</code> and <code>materialization_window_bytes</code> fits
+          <code>max_output_memory_bytes_total</code>. Per-operation staging memory and bytes do not exceed their matching
+          client-wide totals.
+          A staging path must be an existing absolute directory after <code>os.fspath</code>; construction neither
+          creates nor write-probes it. Any future generic HTTP adapter defines and validates its own transport limits in a
+          separately approved contract; those limits are not part of the Assembly core configuration.
+          Every canonical string rejects lone surrogates before cache/digest work. Named namespace/key/resource/operation,
+          cursor, and parameter limits apply first; <code>max_identity_metadata_utf8_bytes</code> is the catch-all for
+          generation/list ID, aliases, ETag/content type, selector/validator/revision kind/value,
+          listing generation, and any other canonical identity/metadata string without a stricter named cap. This semantic
+          validation applies equally to decoded and live/direct provider models.
+          List input requires <code>1 &lt;= page_size &lt;= max_list_page_size</code> and a cursor no larger than
+          <code>max_cursor_utf8_bytes</code>. Provider output must contain at most the requested item count, use a next cursor
+          under the same byte ceiling, and pass normal descriptor validation before caching or glob accumulation.
+          Glob uses the longest literal prefix, requests no page larger than the remaining
+          <code>max_glob_scanned_items</code> budget, and raises <code>AssemblyLimitExceededError</code> without another provider
+          call if a non-null cursor remains after the exact budget. It separately raises before yielding result
+          <code>max_glob_results + 1</code>; earlier iterator yields are not rolled back.
+        </p>
+        <h3>Validation order</h3>
+        <ol>
+          <li>Validate reference, schema/list versions, mandatory <code>expires_at</code>, and configured limits. Require <code>descriptor.reference == request.reference</code> and, when <code>request.generation</code> is non-None, <code>descriptor.generation == request.generation</code>; reject a silent fall-forward before plan/source I/O. Text limits count strict UTF-8 bytes; semantic parameter depth includes the parameter root object, while codec depth includes the complete document root (default 64 versus semantic 32). Recursive item count includes object members/array elements, and parameter bytes use exact RFC 8785 encoding.</li>
+          <li>At operation admission, compare one captured UTC clock value with <code>expires_at</code>; equality is expired. Reject before provider plan lookup when a cached descriptor is already expired.</li>
+          <li>Validate that the complete plan echoes the descriptor, then perform cheap structural checks before canonical encoding: exact model types, segment tuple count, discriminator, strict integers, text byte limits, parameter depth/item/canonical-byte limits, inline decoded limits, and checksum/revision grammar. Reject immediately on the first bound violation.</li>
+          <li>Tuple order is logical order. Validate every positive length/object range with checked arithmetic; compute the checked sum of every segment length and require it to equal <code>descriptor.size</code>, including for a partial caller read.</li>
+          <li>Stream the exact RFC 8785 digest projection (schema version, descriptor, ordered segments; no digest/deadline) into both SHA-256 and a capped byte counter. Do not construct a second complete encoding. Equality with <code>max_plan_bytes</code> is accepted; abort as soon as byte <code>max_plan_bytes + 1</code> would be emitted, then verify <code>plan_digest</code>. The same bounded path handles decoded and direct-model providers.</li>
+          <li>Resolve object aliases to existing StorageClients and service aliases to ServiceSegmentExecutors, then freeze those concrete local objects. Instruction caches remain scoped to this client and frozen registry snapshot; v1 exposes no binding identity for cross-registry reuse.</li>
+          <li>Validate service modes/retry declarations, binding support for optional selectors/validators/operation revisions/checksums, staging feasibility, computed capabilities, and the selected <code>AssemblyConsistency</code> requirements.</li>
+          <li>Normalize and bounds-check the caller's half-open logical range, intersect it with the already validated full plan, then allocate or stage output and begin I/O.</li>
+        </ol>
+
+        <h3>Range arithmetic</h3>
+        <div class="formula">logical interval = [offset, offset + size) &nbsp;·&nbsp; segment-local interval = [intersection start, intersection end)</div>
+        <p>
+          Python checks every canonical integer and addition against the interoperable <code>2**53 - 1</code> ceiling before
+          allocation or dispatch. A zero-length logical read returns <code>b""</code> without segment I/O, but plan validation
+          still occurs when required to prove the descriptor's complete-object definition and global length. A user executor
+          owns any conversion to its transport's range convention.
+        </p>
+
+        <h3>ReadOperation</h3>
+        <pre><code>@dataclass(frozen=True, slots=True)
+class ObjectReadOperation:
+    source_id: str
+    resource: str
+    fetch_range: ByteRange
+    selected_range_in_fetch: ByteRange
+    selector: SourceSelector | None
+    validator: SourceValidator | None
+    destination_offset: int
+    checksum: Checksum | None
+
+@dataclass(frozen=True, slots=True)
+class ServiceReadOperation:
+    executor_id: str
+    operation: str
+    parameters: FrozenJsonObject
+    full_result_length: int
+    requested_subrange: ByteRange
+    range_mode: ServiceRangeMode
+    retry_safety: RetrySafety
+    operation_revision: OperationRevision | None
+    checksum: Checksum | None
+    destination_offset: int</code></pre>
+
+        <p class="small">
+          <code>ObjectReadOperation.fetch_range</code> is the absolute object range passed to StorageClient, while
+          <code>selected_range_in_fetch</code> is relative to the returned fetch bytes. For an ordinary object read, MSC fetches
+          only the caller intersection and selects <code>ByteRange(0, fetch_range.size)</code>. For a checksum-bearing object
+          segment, MSC fetches and stages the segment's complete declared object range, verifies it, and only then copies the
+          caller's selected subrange to <code>destination_offset</code>.
+        </p>
+
+        <h3>No cross-segment coalescing in v1</h3>
+        <p>
+          Every intersected object segment remains one independent logical object operation. Within it, MSC issues
+          consecutive public <code>StorageClient.read</code> calls of at most <code>max_object_read_chunk_bytes</code>; a
+          checksum-bearing segment uses its complete source range as <code>fetch_range</code> and records the caller intersection
+          in <code>selected_range_in_fetch</code>, while an ordinary segment fetches only the caller intersection and selects that
+          complete fetch. V1 never combines adjacent object segments, even when alias/resource/ranges appear compatible,
+          because ObjectSourceBinding exposes no atomic selection, checksum-boundary, or maximum-range coalescing capability. Inline slices copy directly;
+          STABLE_SUBRANGES receives exact intersections; each WHOLE_RESULT segment is keyed by descriptor generation,
+          validated plan digest, and segment ordinal, and is staged once per admitted top-level operation. Repeated intersections with one ordinal
+          reuse that stage, while equal-valued segments at different ordinals never deduplicate. A future additive binding
+          capability may enable coalescing with its own conformance contract.
+        </p>
+      </section>
+
+      <section id="sources">
+        <h2>7. Object bindings and ServiceSegmentExecutor SPI</h2>
+
+        <p>
+          The complete v1 public object-binding surface is <code>ObjectSourceBinding(client=storage_client)</code>. The binding
+          selects an already configured public StorageClient logical namespace; it adds no profile, endpoint, credential,
+          provider, cache-identity, ownership, or provider-specific path-policy controls.
+        </p>
+        <p>
+          For service fulfillment, only <code>range_modes</code> and <code>execute</code> are abstract. The optional
+          <code>snapshot_revision_kinds</code> and <code>thread_safe</code> capabilities have conservative defaults, and
+          <code>close</code> is an optional lifecycle hook. Every capability property must remain immutable for the lifetime of
+          the injected executor; AssemblyClient captures and validates those values before exposing a view.
+        </p>
+
+        <pre><code>class CancellationToken(Protocol):
+    @property
+    def cancelled(self) -> bool: ...
+
+    def raise_if_cancelled(self) -> None: ...
+
+@dataclass(frozen=True, slots=True)
+class SourceReadContext:
+    deadline_monotonic: float | None = field(compare=False, hash=False, repr=False)
+    cancellation: CancellationToken = field(compare=False, hash=False, repr=False)
+    max_chunk_bytes: int = field(compare=False, hash=False, repr=False)
+
+@dataclass(frozen=True, slots=True)
+class ObjectSourceBinding:
+    client: StorageClient = field(repr=False, compare=False, hash=False)
+
+@dataclass(frozen=True, slots=True)
+class ServiceExecutionRequest:
+    segment: ServiceSegment
+    requested_range: ByteRange | None  # non-None only for STABLE_SUBRANGES
+
+class ServiceResultStream(Iterator[bytes], Protocol):
+    def close(self) -> None: ...
+
+class ServiceSegmentExecutor(ABC):
+    @property
+    @abstractmethod
+    def range_modes(self) -> frozenset[ServiceRangeMode]: ...
+
+    @property
+    def snapshot_revision_kinds(self) -> frozenset[str]:
+        """Revision kinds both enforced here and sufficient to pin complete result bytes."""
+        return frozenset()
+
+    @property
+    def thread_safe(self) -> bool:
+        return False
+
+    @abstractmethod
+    def execute(
+        self,
+        request: ServiceExecutionRequest,
+        *,
+        context: SourceReadContext,
+    ) -> ServiceResultStream:
+        """Return a stream for the exact requested subrange or complete result."""
+
+    def close(self) -> None:
+        pass</code></pre>
+
+        <div class="callout info">
+          The core release expects a user-owned implementation such as <code>MyServiceExecutor</code>. It translates one
+          <code>ServiceExecutionRequest</code> into the user's HTTP, gRPC, SDK, or local-service call. It never receives an
+          <code>AssemblyPlan</code>, never decides segment ordering, and returns only the byte stream for one service segment
+          while honoring declared length/range mode, the shared deadline, and cooperative cancellation. MSC standardizes
+          this in-process SPI, not the user's external wire contract.
+        </div>
+
+        <h3>Frozen binding registries</h3>
+        <ul>
+          <li>AssemblyClient defensively copies separate <code>object_sources: Mapping[str, ObjectSourceBinding]</code> and <code>service_executors: Mapping[str, ServiceSegmentExecutor]</code>; malformed or duplicate aliases fail construction. Either mapping may be empty when the resolved plan uses none of that segment kind.</li>
+          <li>Plans select only aliases. They cannot construct a client/executor or mutate endpoint, profile, prefix, credentials, or retry policy.</li>
+          <li>The complete public object binding is <code>ObjectSourceBinding(client=storage_client)</code>. MSC freezes that concrete association in each view. The plan's <code>resource</code> is a logical path inside that client's already configured public namespace; it cannot reconfigure or expand the client authority. Applications bind a least-privilege namespace suitable for every accepted plan. V1 adds no provider-specific narrower path policy.</li>
+          <li>StorageClients are always borrowed and never closed by AssemblyClient. Calls to each distinct StorageClient object are conservatively serialized across aliases and views.</li>
+          <li><code>snapshot_revision_kinds</code> defaults empty. A kind may be advertised only when the executor enforces that revision and it is sufficient, with operation and parameters, to pin the complete result bytes.</li>
+          <li><code>range_modes</code>, <code>snapshot_revision_kinds</code>, and <code>thread_safe</code> are immutable for the injected executor's lifetime. AssemblyClient captures exact validated values before view exposure. <code>thread_safe=False</code> serializes calls to the same executor across aliases and views; an exact <code>True</code> opts that executor into client-wide concurrency.</li>
+          <li>The same client or executor may appear under multiple aliases. A transferred service executor is closed at most once; a StorageClient remains borrowed under every alias.</li>
+          <li>The same Python object identity cannot occupy different dependency roles (plan provider, service executor, StorageClient). A backend serving multiple roles uses distinct adapters; construction rejects cross-role identity reuse so ownership and <code>CloseFailure</code> remain unambiguous.</li>
+          <li>The plan provider and service executors are borrowed by default. <code>close_dependencies=True</code> transfers only those dependencies to AssemblyClient; it never transfers a StorageClient.</li>
+          <li>On failure AssemblyClient signals the shared cancellation token, attempts every service-stream close and shared-stage cleanup, and cancels queued work. A user executor observes that token through <code>SourceReadContext</code>; custom blocking I/O remains cooperative and must obey the context deadline. Failed stage artifacts follow the retained-reservation/orphan rules below.</li>
+          <li>Every yielded item is non-empty <code>bytes</code> with length ≤ <code>SourceReadContext.max_chunk_bytes</code> (from <code>AssemblyClientConfig.max_service_chunk_bytes</code>). Wrong type, empty, or oversized chunks attempt stream close and raise the primary <code>ServiceProtocolError</code> before copy/staging.</li>
+          <li>Exact allowlisted <code>ServiceSegmentError</code>, <code>AssemblyCancelledError</code>, and <code>AssemblyTimeoutError</code> outcomes are copied into fresh canonical instances using only validated safe fields. Subclasses, malformed typed errors, and any other custom-executor <code>Exception</code> become <code>ServiceExecutorError(cause_type=safe_type_token(...))</code>. Capture only the safe classification in the catch, discard the caught object, and raise after leaving the handler so neither <code>__cause__</code> nor <code>__context__</code> retains it. Checks outside the catch give cancellation/deadline precedence, and <code>BaseException</code> is never wrapped.</li>
+          <li>Cleanup attempts executor-owned result streams first in reverse registration-token order, then MSC-owned stage sink/fd/path resources in reverse registration-token order. A primary execution error takes precedence. With otherwise successful bytes, the first result-stream close failure becomes redacted <code>ServiceExecutorError</code> and the current private output is discarded. If private-stage cleanup also fails, <code>ServiceExecutorError</code> retains precedence while the artifact/reservation transfers to the orphan registry. A sole MSC-stage cleanup failure is <code>AssemblyStagingError</code>.</li>
+        </ul>
+
+        <h3>Core segment dispatch</h3>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Segment</th><th>Implementation</th><th>Required behavior</th><th>Primary purpose</th></tr></thead>
+            <tbody>
+              <tr><td><code>ObjectSegment</code></td><td>Python dispatcher → existing <code>StorageClient.read</code></td><td>Exact public range read; short reads fail. Initial v1 rejects selectors/enforcing validators; identity-only validators remain weak.</td><td>Bulk bytes travel directly from configured storage to MSC.</td></tr>
+              <tr><td><code>ServiceSegment</code></td><td>User <code>ServiceSegmentExecutor</code></td><td>Advertise supported range modes, enforce exact length, operation-revision/checksum and retry declarations honestly.</td><td>Transport-neutral synthesized bytes.</td></tr>
+              <tr><td><code>InlineSegment</code></td><td>Python memory copy</td><td>Decode/validate before I/O; enforce 16 KiB segment and 64 KiB object aggregate ceilings.</td><td>Small constants only.</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Object selector and validator semantics</h3>
+        <p>
+          In default <code>EXPIRATION_ONLY</code> mode, an ObjectSegment without a selector or validator is legal and is read
+          directly through one or more bounded <code>StorageClient.read(resource, Range(offset, size))</code> calls. A <code>SourceSelector</code> always asks
+          the binding to select that exact version. A <code>SourceValidator</code> uses <code>RevisionUse</code> to declare
+          enforcement during the read or identity-only use; identity-only metadata cannot establish stable bytes or satisfy
+          <code>SNAPSHOT_PINNED</code>.
+          Today's public StorageClient cannot generally pass an expected version to provider GET, so the initial v1 binding
+          rejects every selector and every <code>ENFORCE_DURING_READ</code> validator before I/O; an ordinary
+          <code>info → read → info</code> sequence is never promoted to enforced snapshot semantics. In
+          <code>SNAPSHOT_PINNED</code> mode, an object segment therefore needs complete checksum verification in v1; a later
+          additive conditional-read binding may support selectors without changing the list schema. No code touches
+          <code>_storage_provider</code>.
+        </p>
+        <p>
+          A plan chooses only a local source alias and a logical <code>resource</code> interpreted by that alias's already-bound
+          StorageClient. It cannot choose a different client, profile, endpoint, credential, or provider, and Assembly never
+          broadens the StorageClient's public logical namespace. The application must configure that client with the
+          least-privilege namespace appropriate for accepted plans. V1 deliberately adds no provider-specific narrower path
+          policy; applications needing a narrower boundary create a correspondingly restricted StorageClient binding.
+        </p>
+
+        <h3>Exact object-read error normalization</h3>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Public StorageClient outcome</th><th>Required assembly exception</th></tr></thead>
+            <tbody>
+              <tr><td><code>FileNotFoundError</code></td><td><code>SourceNotFoundError</code></td></tr>
+              <tr><td><code>PermissionError</code></td><td><code>SourceAuthorizationError</code></td></tr>
+              <tr><td><code>RetryableError</code> after StorageClient exhaustion</td><td><code>SourceRetryableError</code>; no AssemblyClient retry</td></tr>
+              <tr><td><code>TimeoutError</code> / <code>ConnectionError</code> while the global deadline remains</td><td><code>SourceTransportError</code></td></tr>
+              <tr><td>Any other <code>Exception</code></td><td><code>SourceReadError(cause_type=safe_type_token(type(exc)))</code></td></tr>
+              <tr><td>Non-<code>bytes</code> / oversized result</td><td><code>SourceProtocolError</code></td></tr>
+              <tr><td>Short result</td><td><code>ShortSourceReadError</code></td></tr>
+              <tr><td>Checksum mismatch</td><td><code>SourceIntegrityError</code></td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p>
+          Inside <code>except Exception</code>, record only the safe classification/token; then leave the handler, discard the
+          caught object, construct a fresh canonical assembly error, and raise it from a fresh
+          <code>_SanitizedDependencyCause(safe_type_token)</code>. The original backend exception is absent from both
+          <code>__cause__</code> and <code>__context__</code> and is not otherwise retained. Public exception text is the sealed
+          class name only; <code>SourceReadError</code> exposes only its bounded <code>cause_type</code> field. Bounded alias/range
+          information may appear in redacted telemetry, never in exception text. Catch <code>Exception</code>, not
+          <code>BaseException</code>. Check cancellation and the absolute deadline outside the catch so their stable outcomes
+          are <code>AssemblyCancelledError</code> and <code>AssemblyTimeoutError</code>. Never inspect private providers, SDK
+          causes, status codes, or messages. Unsupported selectors/enforcing validators remain pre-I/O
+          <code>AssemblyCapabilityError</code> because current StorageClient has no typed conditional-read surface.
+          <code>safe_type_token(T)</code> accepts <code>T.__name__</code> only when it matches
+          <code>[A-Za-z_][A-Za-z0-9_]{0,127}</code>; otherwise it returns <code>Exception</code>.
+        </p>
+
+        <h3>Service range, staging, stability, and retry</h3>
+        <ul>
+          <li><code>STABLE_SUBRANGES</code> is allowed only when both the segment and executor explicitly support it. Every requested subrange must belong to one stable logical byte string for the duration of the operation.</li>
+          <li><code>WHOLE_RESULT</code> is the default. Within one resolved view and top-level operation, MSC submits one logical <code>ServiceExecutionRequest</code> through one <code>execute</code> call for each stage key <code>(generation, plan_digest, segment_ordinal)</code>, where the ordinal is the zero-based position in the validated <code>AssemblyPlan.segments</code> tuple, even when several requested slices touch it. This key is operation-local and does not authorize cross-provider or cross-binding cache reuse. Different ordinals remain distinct even when every segment value is equal. Executor-owned SAFE retry may turn that submission into multiple private transport attempts.</li>
+          <li>A checksum may be omitted, but when supplied it is normative in every consistency mode. For a partial STABLE_SUBRANGES access, request/stage the complete segment, verify the digest, and only then slice; never compare the complete checksum with a partial response. Another enforcing revision does not waive this instruction.</li>
+          <li><code>max_complete_segment_memory_bytes</code> is a per-complete-segment memory threshold and <code>max_complete_segment_staged_bytes</code> is the per-complete-segment hard cap. Before launch, reserve declared length against both per-operation and client-wide stage-byte totals. Use memory only when both memory totals also have capacity; otherwise use a unique private file. Multi-budget acquisition is all-or-none; temporary contention waits/serializes until the operation deadline and maps to <code>AssemblyTimeoutError</code>, while a complete segment larger than an applicable per-segment, per-operation, or client-wide hard cap fails before I/O.</li>
+          <li><code>AssemblyClientConfig.staging_directory</code> selects the optional private-file parent for any complete-segment staging, including WHOLE_RESULT service output and checksum verification. A user executor may impose a stricter result limit, but it cannot weaken the AssemblyClient staging ceilings.</li>
+          <li>The result is length-checked while staging, optionally digest-checked, then sliced. Before external launch, each stage receives a deterministic registration token in logical scheduling order. Exact-length mismatch raises <code>ServiceLengthMismatchError</code>; complete checksum mismatch raises <code>ServiceIntegrityError</code>. Either failure attempts every MSC-owned stage sink/fd close and private-path unlink in reverse token order before bytes from that stage/current call are published; executor-owned result streams follow their separate rule above. Earlier successful reader calls may already be observed. Staged data is never reused across top-level operations in v1.</li>
+          <li>Private-stage allocation/create/write/flush/close/unlink failures use redacted <code>AssemblyStagingError(cause_type=...)</code>; no private path or OS message is public. A cleanup failure never masks or chains onto an already-selected execution error: the primary typed error wins, while the failed artifact stays in a private orphan registry. If the operation would otherwise succeed, cleanup completes before returning bytes or publishing a destination; failure discards private output and raises <code>AssemblyStagingError</code> with the first safe failure type in deterministic cleanup order after every action was attempted. Reader close follows the same selection.</li>
+          <li>A file-backed stage reservation is released only after <em>all</em> owned sinks/file descriptors are closed <em>and</em> every private pathname is unlinked; an in-memory reservation waits for all owned sinks/buffers to release. Allocation/create failure before an artifact exists releases immediately. A partially cleaned artifact remains charged against the matching client-wide memory/disk total and is retried on reader/client close, preventing repeated failures from creating unbounded unaccounted storage. When an operation/reader ends, its per-operation charge ends only after ownership of the continuously held client-wide charge atomically transfers to the orphan ledger. Reader close marks the reader closed and releases its active-operation slot even when cleanup raises. Parent close attempts every retained artifact and adds at most one aggregate <code>CloseFailure(dependency_kind="staging_artifact", aliases=(), ...)</code> for the first safe failure type if any remain.</li>
+          <li>Destination failures use the exact redacted <code>AssemblyMaterializationError(phase=..., cause_type=..., committed=...)</code> contract. Before the atomic commit point <code>committed=False</code> and the prior/concurrently-created destination is preserved; cleanup or directory-fsync failure after publication reports <code>committed=True</code> and never falsely claims rollback.</li>
+          <li><code>RetrySafety.NEVER</code> permits exactly one private attempt once the logical submission starts, regardless of whether that attempt produces any response bytes. <code>RetrySafety.SAFE</code> permits only the executor's documented bounded retry under the shared deadline; the assembly executor adds no outer retry.</li>
+          <li>Service operation revisions are optional. Identity-only revisions may classify metrics but cannot satisfy <code>SNAPSHOT_PINNED</code>. An enforcing revision qualifies only when its kind appears in <code>snapshot_revision_kinds</code>; a fully verified complete-result checksum qualifies independently.</li>
+        </ul>
+      </section>
+
+      <section id="executor">
+        <h2>8. Executor, AssemblyView, seekable reader, and materialization</h2>
+        <h3>Client-wide admission and byte reservations</h3>
+        <ul>
+          <li>Acquire exactly one <code>max_active_operations</code> slot before provider/source I/O or large allocation for each top-level resolve, info, refresh, list page, one-shot read, materialization, or open. A glob iterator holds one from first advancement through exhaustion/close. A successfully opened reader holds its slot until reader/parent close; a passive view holds none.</li>
+          <li>Convenience methods propagate the admitted operation context into a private resolve/plan helper; that helper never reacquires. Glob's private page fetches reuse its iterator slot instead of calling the public admitted list path, and materialization windows/reader calls reuse their operation's existing slot. This rule is required for every convenience at <code>max_active_operations=1</code>.</li>
+          <li>Slot waiters allocate no large buffer, observe the shared deadline/cancellation, and are awakened by parent close. Capture the expiration admission clock only after slot acquisition; timeout maps to <code>AssemblyTimeoutError</code>, cancellation to <code>AssemblyCancelledError</code>, and parent close to <code>AssemblyClosedError</code>.</li>
+          <li><code>AssemblyGlobIterator</code> is a public idempotently closeable context manager. It acquires on first advancement, and exhaustion, explicit close, iterator error, cancellation/deadline, or parent close releases exactly once; close before first advancement acquires nothing. Early-breaking callers use <code>with</code> or <code>close()</code>. Its own close/exhaustion makes later advancement return <code>StopIteration</code>; parent close maps later use to <code>AssemblyClosedError</code>.</li>
+          <li>Before allocating a read result or materialization window, reserve twice its clamped length from client-wide <code>max_output_memory_bytes_total</code>. Reject a single reservation above the total; otherwise wait to the deadline. Release after the immutable bytes cross to caller ownership or the window is written/discarded.</li>
+          <li>Immediately before launching each complete-segment stage, atomically reserve that stage's declared length against both per-operation and client-wide total staging bytes. Do not pre-reserve every stage in the plan. Select memory only if both memory budgets also have space; otherwise select a private file. Acquire all counters under one scheduler or none, never hold one budget while waiting for another. This permits forward readers and materialization to serialize individually feasible stages whose sum exceeds the per-operation cap; retained seekable-reader stages keep their reservations until close.</li>
+          <li>The independent client-wide <code>max_inflight_object_bytes</code> bounds live StorageClient result chunks. Thus client-owned output, stage memory/disk, object chunks, operation count, and active source calls all have non-multiplying global ceilings across callers.</li>
+        </ul>
+        <h3>Executor algorithm</h3>
+        <ol>
+          <li>Receive one fully validated complete object plan plus the caller's requested range; expiration has already passed the operation-admission check.</li>
+          <li>Create one SourceReadContext with the operation's absolute monotonic deadline and thread-safe internal cancellation token. MSC signals that token after a sibling failure or parent close; v1 has no caller-supplied cancellation input.</li>
+          <li>Allocate one private pre-sized output buffer after all size/coverage limits pass.</li>
+          <li>Intersect the range with the three segment kinds; group object operations by StorageClient binding, service operations by executor, and copy inline slices locally.</li>
+          <li>Acquire a client-wide concurrency budget shared across concurrent views and reads.</li>
+          <li>For each object operation, split <code>fetch_range</code> into consecutive chunks no larger than <code>max_object_read_chunk_bytes</code>. Before each public <code>StorageClient.read</code>, check the absolute deadline and reserve the declared chunk length from the client-wide <code>max_inflight_object_bytes</code> budget. The call has no deadline parameter and cannot be preempted; after it returns, check the deadline again, discard late bytes, require exact length, and release the reservation. Hold one concurrency permit and any per-client serialization lock across the ordered sequence. An ordinary operation fetches only its intersection. A checksum-bearing operation stages the complete <code>fetch_range</code>, hashes it, then copies <code>selected_range_in_fetch</code>, so temp-file staging never requires a complete StorageClient result in memory. Call range-capable services with exact subranges and key each WHOLE_RESULT stage by descriptor generation, validated plan digest, and segment ordinal.</li>
+          <li>As each chunk or staged slice completes, verify exact length. When a checksum is supplied, first stage and verify the complete segment (never a partial body against a complete digest), then copy the requested slice into the non-overlapping private destination and release it when lifecycle rules permit.</li>
+          <li>On first terminal error, stop scheduling, signal cancellation, attempt every service-stream/stage close and private-file unlink in reverse deterministic registration-token order, and drain cooperative provider/service work only to its required deadline. An already-running synchronous StorageClient call remains non-preemptible until it returns or its configured underlying timeout fires; keep its permit and byte reservation until then and discard any late result. Retain failed artifacts and their reservations for later retry, discard the private output, and preserve the original typed terminal error as the public outcome.</li>
+          <li>After every destination slice succeeds, freeze to <code>bytes</code> and return; v1 commits no logical-byte cache entry.</li>
+        </ol>
+
+        <p>
+          The AssemblyClient semaphore is client-wide and bounds active StorageClient and service executions; a streaming
+          service result retains its permit and any per-executor lock until staging completes or closes. Creating a per-read pool would allow
+          <code>concurrent callers × max_concurrency</code> active executions. A user-owned executor may impose a stricter
+          transport-specific limit, but that implementation detail neither replaces nor multiplies the AssemblyClient budget.
+        </p>
+
+        <h3>AssemblyView and reader state</h3>
+        <ul>
+          <li>An AssemblyView is the executable handle. It retains one metadata-only <code>AssemblyDescriptor</code>, the complete validated <code>AssemblyPlan</code>, frozen concrete source/service bindings, mandatory expiration, originally selected <code>required_consistency</code> minimum, computed consistency/capabilities, and lifecycle state. <code>AssemblyView.metadata</code> returns that exact descriptor. None of this executable state is exposed by <code>AssemblyPlanProvider.resolve_descriptor</code>.</li>
+          <li>It never mutates or refreshes itself. <code>AssemblyClient.refresh(view)</code> returns a new view and requires a replacement generation and expiration. With <code>required_consistency=None</code>, refresh preserves the old view's originally required minimum; it never derives the minimum from the computed consistency or a later client default. Only an explicit argument changes it.</li>
+          <li>Each public <code>read</code>, <code>materialize</code>, and <code>open</code> admission captures the clock once and rejects an expired view before range planning or source/service work. Once admitted, that operation may finish after expiration.</li>
+          <li>Concurrent <code>view.read</code> calls are supported; an individual seekable reader is not thread-safe.</li>
+          <li>An AssemblyReader is one admitted operation from successful <code>open</code> until <code>close</code>. It owns the pinned descriptor/validated plan, SourceReadContext, operation-local complete-segment stage registry, cursor, and closed state.</li>
+          <li>Closing the originating AssemblyView rejects new work through that view but does not cancel an already opened reader. The reader survives independently until its own close or parent-client close.</li>
+          <li>Reader <code>read</code>/<code>seek</code> calls do not recheck descriptor expiration or resolve another generation. A reader opened while valid may continue after expiration; a new <code>open</code> on that view fails.</li>
+          <li>Each reader read intersects its minimal logical range with the same validated complete-object plan. Any complete-segment stage required by a WHOLE_RESULT service or checksum-bearing object/service segment is created at most once per descriptor generation, validated plan digest, and segment ordinal for that reader and retained across seeks until close.</li>
+          <li>Capability computation is total. Validation rejects a WHOLE_RESULT or checksum-bearing full stage when its declared complete length exceeds its applicable per-result hard cap or <code>max_staging_bytes_per_operation</code>. Executor-advertised range modes are included in the computation but cannot weaken client limits. Every successfully resolved v1 view therefore has <code>byte_range_read=True</code> and <code>streaming_open=True</code>; a future false flag raises <code>AssemblyCapabilityError</code> before execution I/O.</li>
+          <li>Seek is true only when the checked sum of all distinct potentially retained stages is at most <code>max_staging_bytes_per_operation</code>. Equality is accepted. Seekable readers retain encountered stages; forward-only readers and materialization release a stage immediately after the cursor/last window passes its final logical byte, allowing several individually feasible stages to serialize even when their sum exceeds the cap. V1 never evicts and replays a stage behind a seekable cursor.</li>
+          <li>Using a view or reader after parent close raises <code>AssemblyClosedError</code>.</li>
+          <li>After non-negative/checked validation, explicit ByteRange reads clamp at EOF: zero size or offset at/past EOF returns empty, and a crossing range ends at object size. Negative/overflowing input raises <code>InvalidAssemblyRangeError</code>. Reader seeks beyond EOF are allowed; a target below zero raises that error, and subsequent reads beyond EOF are empty. The clamped output length must not exceed <code>max_read_bytes</code>.</li>
+          <li>Atomicity is per reader call, not the reader lifetime. <code>read/readinto</code> stages the current call privately; terminal execution failure publishes nothing for that call, leaves cursor and destination buffer unchanged, closes/poisons the reader, and raises the typed error. Prior successful calls remain an observable prefix; later read/seek raises <code>AssemblyClosedError</code>. Pre-execution argument errors do not poison it.</li>
+          <li>Override <code>RawIOBase.read(size=-1)</code> and <code>readall()</code>; do not inherit an implementation that loops through committing <code>readinto</code> calls. Compute the full clamped public-call length first (<code>-1</code> means the remainder), reject it above <code>max_read_bytes</code>, stage it privately, and advance the cursor exactly once after complete success.</li>
+        </ul>
+
+        <h3>Materialization</h3>
+        <pre><code>view.materialize(
+    destination: str | os.PathLike[str],
+    *,
+    overwrite: bool = False,
+    fsync: bool = False,
+) -> None</code></pre>
+        <p>
+          For a filesystem path, write and close a unique temporary file in the destination directory and validate the entire
+          assembled output. Create every private materialization or complete-segment stage file exclusively, use no-follow
+          creation where the platform supports it, and use POSIX mode <code>0600</code>. Never reuse or follow an existing path.
+          Publication retains the temporary inode's effective mode. With <code>fsync=True</code>, flush and fsync that file before publication. The commit point is one
+          atomic filesystem operation: <code>os.replace</code> when <code>overwrite=True</code>; when false, create the destination
+          with an atomic same-filesystem no-replace primitive (initially hard-link the closed staging inode, then unlink its
+          temporary name). A precheck is only an optimization and never supplies race safety. If no atomic no-replace primitive
+          is supported, fail with
+          <code>AssemblyMaterializationError(phase="commit", cause_type="OSError", committed=False)</code> without changing
+          the destination. A destination created concurrently wins and is preserved.
+          An arbitrary binary stream cannot provide atomic replace;
+          v1 should therefore keep path materialization as the guaranteed API and direct stream users to <code>open()</code>.
+          If materialization began before descriptor expiration it may complete afterward. Before the atomic commit point, any error
+          has <code>committed=False</code>, removes the staging name best-effort, and preserves the previous destination. After
+          commit, the new destination is already visible; unlinking the extra staging link and optional parent-directory fsync
+          occur afterward. Their failures use <code>phase="cleanup"</code> or <code>"directory_fsync"</code> with
+          <code>committed=True</code>; MSC must not claim rollback, and durability is indeterminate after directory-fsync
+          failure. Once commit succeeds, the file's retention and deletion are application policy: later descriptor expiration neither deletes nor invalidates completed bytes.
+          All windows of one materialization share one operation context and complete-segment stage registry, so a WHOLE_RESULT
+          service or checksum-bearing object/service segment ordinal is not re-executed or refetched. Every operation-local private stage is cleaned successfully before the destination commit;
+          a cleanup failure therefore prevents publication rather than leaving a committed destination with an unreported
+          private orphan. Each logical window is exactly <code>min(materialization_window_bytes, remaining_bytes)</code>;
+          the last may be shorter, and the private assembled-output buffer never exceeds the configured window (separate
+          complete-segment staging reservations still apply).
+        </p>
+
+        <h3>Memory policy</h3>
+        <ul>
+          <li><code>read</code> is bounded by <code>max_read_bytes</code>. The initial Python implementation may hold its mutable private output and immutable returned <code>bytes</code> simultaneously, so the specified peak is at most twice the clamped result length plus bounded in-flight chunks and service stages; a later proven no-copy path may lower but not raise this gate.</li>
+          <li><code>materialize</code> uses windowed reads and a staging file so object size is not duplicated in memory.</li>
+          <li>Complete plans are bounded by segment count and encoded size before range intersection or read scheduling.</li>
+          <li>Complete-segment stages have separate per-result memory, per-result bytes, operation-wide, and client-wide temp-file byte ceilings. These limits cover WHOLE_RESULT services and complete object/service verification required by checksums; each descriptor-generation, plan-digest, and segment-ordinal stage key is materialized once per top-level operation.</li>
+          <li>Inline data has hard decoded upper ceilings of 16 KiB per segment and 64 KiB per complete object; configuration may only lower them.</li>
+          <li>Every user-owned service stream is measured against declared length and client staging ceilings; transport metadata is never trusted as a substitute.</li>
+        </ul>
+      </section>
+
+      <section id="http-adapter">
+        <h2>9. Optional phase-two generic HTTP adapter</h2>
+        <div class="decision">
+          <strong>The Assembly core does not require or ship an HTTP service adapter.</strong>
+          The initial feature is complete when a user-defined <code>ServiceSegmentExecutor</code> can execute service segments
+          through HTTP, gRPC, an SDK, or a local call without any MSC-defined wire protocol. A possible generic
+          <code>HttpServiceSegmentExecutor</code> is a separate phase-two convenience adapter, subject to approval of its own
+          format-neutral contract.
+        </div>
+
+        <h3>Core/non-core boundary</h3>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Concern</th><th>Initial Assembly core</th><th>Optional HTTP adapter</th></tr></thead>
+            <tbody>
+              <tr><td>Service extension contract</td><td><code>ServiceSegmentExecutor</code> and <code>ServiceExecutionRequest</code>.</td><td>Implements that same SPI; introduces no second assembly model.</td></tr>
+              <tr><td>External API</td><td>User-owned and transport neutral.</td><td>MSC still defines no server endpoints, payload schema, or authentication API.</td></tr>
+              <tr><td>Protocol translation</td><td>User implementation owns it.</td><td>A user-provided translation hook would map one service request to a bounded HTTP request.</td></tr>
+              <tr><td>Assembly semantics</td><td>Validation, planning, bounds, staging, lifecycle, and errors.</td><td>Must not receive a complete plan or decide segment ordering.</td></tr>
+              <tr><td>Release dependency</td><td>Required.</td><td>Not required for core acceptance, E2E coverage, packaging, or release.</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Approval conditions for a future adapter</h3>
+        <ul>
+          <li>Approve a separately versioned, format-neutral generic HTTP adapter contract. This document intentionally does not freeze its config class, request/response payloads, endpoints, authentication callbacks, status mappings, or retry defaults.</li>
+          <li>Keep origin, credentials, allowed paths, and translation code in trusted local configuration. An assembly plan may select only a locally registered executor alias and opaque operation/parameters.</li>
+          <li>Require the adapter to obey the existing service SPI: one segment request, exact declared bytes, explicit range mode, shared deadline/cancellation, bounded chunks, redacted errors, and no access to the complete plan or segment ordering.</li>
+          <li>Demonstrate that the contract is generic rather than tied to a particular data format or one application's service API.</li>
+        </ul>
+
+        <h3>Open decisions owned by the follow-up</h3>
+        <ul>
+          <li>Whether a built-in adapter is valuable enough to justify a stable public surface.</li>
+          <li>The smallest generic request/response translation hook and how authentication remains application-owned.</li>
+          <li>Origin confinement, TLS, redirects, proxies, retries, response-size limits, streaming, cancellation, and process-lifecycle behavior.</li>
+        </ul>
+
+        <div class="callout info">
+          None of these open decisions blocks the core module. Core E2E tests use an in-process user-defined
+          <code>ServiceSegmentExecutor</code> and pass with no HTTP adapter or network server.
+        </div>
+      </section>
+
+      <section id="python-scope">
+        <h2>10. Python-only implementation scope</h2>
+        <div class="decision">
+          <strong>All initial Assembly implementation work is in Python.</strong>
+          Public models, the list codec, provider and service SPIs, expiration/consistency semantics, plan validation, range
+          mapping, bounded execution, staging, cache policy, views, readers, and materialization remain in the
+          <code>multistorageclient.assembly</code> Python package.
+        </div>
+        <p>
+          The Rust extension layer has no changes and no Assembly implementation is proposed there. StorageClient continues
+          to use its existing implementation exactly as it does outside the Assembly module.
+        </p>
+      </section>
+
+      <section id="operations">
+        <h2>11. Cache, retry, lifecycle, telemetry, and security</h2>
+
+        <h3>Cache layers</h3>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Layer</th><th>Key</th><th>Commit rule</th><th>Initial default</th></tr></thead>
+            <tbody>
+              <tr><td>Descriptor</td><td>reference + generation + internal provider-instance scope</td><td>After model/expiration validation; lookup rechecks expiration. The entry never crosses provider instances without a separately approved trustworthy identity.</td><td>Per-client bounded LRU with hard expiry no later than the descriptor's <code>expires_at</code>.</td></tr>
+              <tr><td>Validated complete plan</td><td>descriptor/generation + plan digest + consistency policy + this client's frozen local registry snapshot</td><td>Only after complete-object/global-length/union validation and binding freeze. Entries never cross an AssemblyClient or registry-snapshot boundary.</td><td>Small bounded LRU; hard expiry at the captured descriptor expiration, never sliding.</td></tr>
+              <tr><td>Logical bytes</td><td>Not applicable in v1.</td><td>No logical-byte cache is populated.</td><td>Disabled; v1 exposes no object-binding or executor cache identity.</td></tr>
+              <tr><td>Complete-segment staging</td><td>top-level operation + generation + plan digest + segment ordinal</td><td>After exact length and optional digest validation.</td><td>Memory/temp-file staging for WHOLE_RESULT service segments and complete checksum verification is local to the current resolved view and operation. Different ordinals never deduplicate; cleanup failure remains explicitly tracked and charged until retry.</td></tr>
+              <tr><td>Completed materialized file</td><td>Application-selected destination</td><td>Only after the atomic commit operation succeeds.</td><td>Not an assembly cache. Lifetime is application-owned and independent of descriptor expiration.</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <h3>Retry ownership</h3>
+        <ul>
+          <li>Provider adapter retries its own transport without changing the exact request.</li>
+          <li>StorageClient retains its documented retry behavior; AssemblyClient adds no outer object-read retry. Because the current read API accepts no deadline, applications configure its underlying transport timeout and retry envelope with the Assembly operation budget in mind.</li>
+          <li>A ServiceSegmentExecutor may create more than one private attempt only when the segment says <code>RetrySafety.SAFE</code>, using its documented bound under the shared deadline. <code>RetrySafety.NEVER</code> permits exactly one private attempt once submission starts, even when that attempt fails before any response byte is observed.</li>
+          <li>The assembly executor never retries an object or service submission. It owns concurrency, internal cancellation, staging cleanup, atomic publication, and hard deadline enforcement for admission and MSC-owned waits; it can only observe the deadline before and after a synchronous StorageClient call.</li>
+          <li>No layer retries invalid/expired plans, binding mismatches, enforced revision mismatches, digest failures, unknown kinds, or protocol violations.</li>
+          <li>Defaults prevent multiplicative retries: every nested operation receives one absolute monotonic deadline and each WHOLE_RESULT stage key has one logical executor submission. Only its explicit SAFE policy may create multiple private attempts inside that submission; NEVER always remains one attempt.</li>
+          <li><code>AssemblyTimeoutError</code> (also <code>TimeoutError</code>) is the sole public outcome once the shared absolute deadline is observed exhausted at provider, scheduling, object, service, or staging boundaries. The deadline hard-bounds admission, MSC-owned waits, and cooperative provider/service work. An in-progress synchronous StorageClient call cannot be preempted and may return after that instant; MSC checks immediately afterward, discards late bytes/errors, and then raises <code>AssemblyTimeoutError</code>. While budget remains, a provider-local transient timeout maps to <code>AssemblyProviderRetryableError</code>, and object/service local timeouts map to their transport classes. The v1 façade has no caller-cancellation argument: its internal token is signaled by sibling failure or parent close, and cooperative code checks it between attempts or chunks.</li>
+        </ul>
+
+        <h3 id="exceptions">Canonical public exception hierarchy and construction</h3>
+        <pre><code>AssemblyError
+├── AssemblyClosedError
+├── AssemblyCloseError
+├── AssemblyCancelledError
+├── AssemblyTimeoutError                    # also a TimeoutError
+├── AssemblyExpiredError
+├── AssemblyStagingError
+├── AssemblyMaterializationError
+├── AssemblyNotFoundError                   # also a FileNotFoundError
+├── AssemblyGenerationUnavailableError
+├── AssemblyCapabilityError
+├── AssemblyConfigurationError              # also a ValueError
+├── AssemblyLimitExceededError              # also a ValueError
+├── InvalidAssemblyRangeError                # also a ValueError
+├── AssemblyProviderError
+│   ├── AssemblyProviderAuthenticationError
+│   └── AssemblyProviderRetryableError
+├── InvalidAssemblyPlanError
+│   └── UnsupportedAssemblySchemaError
+├── UnknownObjectSourceError
+├── UnknownServiceExecutorError
+├── ServiceSegmentError
+│   ├── ServiceExecutorError
+│   ├── ServiceAuthenticationError
+│   ├── ServiceAuthorizationError
+│   ├── ServiceNotFoundError
+│   ├── ServiceRevisionMismatchError
+│   ├── ServiceRangeNotSatisfiableError
+│   ├── ServiceLengthMismatchError
+│   ├── ServiceIntegrityError
+│   ├── ServiceProtocolError
+│   └── ServiceTransportError
+└── ObjectSourceError
+    ├── SourceReadError                     # unclassified public StorageClient failure
+    ├── SourceAuthorizationError
+    ├── SourceNotFoundError
+    ├── SourceRetryableError                # StorageClient exhausted its own retries
+    ├── ShortSourceReadError
+    ├── SourceIntegrityError
+    ├── SourceProtocolError
+    └── SourceTransportError</code></pre>
+        <p class="small">
+          Provider and source adapters preserve only a bounded, sanitized cause-type token. They never retain the original
+          backend exception, parse its message, or inspect private provider state.
+        </p>
+        <pre><code>class AssemblyError(Exception):
+    def __init__(self, /) -> None:
+        super().__init__()
+
+    def __str__(self) -> str:
+        return type(self).__name__
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}()"
+
+@dataclass(frozen=True, slots=True)
+class CloseFailure:
+    dependency_kind: Literal["staging_artifact", "plan_provider", "service_executor"]
+    aliases: tuple[str, ...]  # sorted configured aliases; empty for staging and the plan provider
+    error_type: str          # safe_type_token(type(exc)); never its message
+
+class _SanitizedDependencyCause(Exception):
+    cause_type: str
+
+    def __init__(self, cause_type: str) -> None: ...
+
+class AssemblyCloseError(AssemblyError):
+    failures: tuple[CloseFailure, ...]
+
+    def __init__(self, failures: Sequence[CloseFailure]) -> None: ...
+
+class ServiceTransportError(ServiceSegmentError):
+    retryable: bool          # classification only; not permission for an outer retry
+
+    def __init__(self, *, retryable: bool) -> None: ...
+
+class SourceReadError(ObjectSourceError):
+    cause_type: str
+
+    def __init__(self, *, cause_type: str) -> None: ...
+
+class ServiceExecutorError(ServiceSegmentError):
+    cause_type: str
+
+    def __init__(self, *, cause_type: str) -> None: ...
+
+class AssemblyLimitExceededError(AssemblyError, ValueError):
+    limit_name: str
+    limit_value: int
+    observed: int
+
+    def __init__(self, *, limit_name: str, limit_value: int, observed: int) -> None: ...
+
+class InvalidAssemblyRangeError(AssemblyError, ValueError):
+    pass
+
+class AssemblyStagingError(AssemblyError):
+    cause_type: str
+
+    def __init__(self, *, cause_type: str) -> None: ...
+
+MaterializationPhase: TypeAlias = Literal[
+    "precondition", "create", "write", "file_fsync", "commit", "directory_fsync", "cleanup"
+]
+
+class AssemblyMaterializationError(AssemblyError):
+    phase: MaterializationPhase
+    cause_type: str
+    committed: bool
+
+    def __init__(self, *, phase: MaterializationPhase, cause_type: str, committed: bool) -> None: ...</code></pre>
+        <p>
+          This hierarchy and these structured constructors are normative. Every fieldless public leaf inherits the no-message
+          constructor. Each structured leaf accepts only its documented bounded keyword fields,
+          calls the no-argument base initializer, and never puts arbitrary caller text in <code>args</code>,
+          <code>str</code>, or <code>repr</code>. At provider, validator, object-client, executor, stream-close, and
+          dependency-close boundaries, only exact allowlisted public classes are recognized. MSC copies their validated safe
+          fields into a fresh canonical instance; subclasses or malformed fields normalize to that boundary's generic error.
+          Classification occurs inside <code>except Exception</code>, but the caught object is discarded and the fresh error is
+          raised only after the handler exits. Its only explicit cause may be a newly constructed
+          <code>_SanitizedDependencyCause</code>, whose sole field is <code>safe_type_token</code>. The original object must not
+          be reachable through <code>__cause__</code>, <code>__context__</code>, <code>args</code>, attributes, or formatted
+          traceback. <code>BaseException</code> control-flow signals are not wrapped or logged by this layer.
+        </p>
+        <p class="small">
+          Structured fields are closed: <code>retryable</code> and <code>committed</code> are exact booleans; limit values are strict non-negative JSON-safe
+          integers; phases and dependency kinds are the documented literals; and input sequences are defensively copied and
+          bounded before assignment. <code>safe_type_token(T)</code> returns <code>T.__name__</code> only when it matches
+          <code>[A-Za-z_][A-Za-z0-9_]{0,127}</code>, otherwise <code>Exception</code>. Close failures use deterministic order:
+          at most one aggregate staging-artifact record, then the plan provider and distinct service executors by first alias.
+          Alias tuples are sorted and deduplicated. Public formatting never
+          includes a logical key, resource, URL, parameters, credential, response body, or nested exception message.
+          <code>AssemblyTimeoutError</code> normalizes exhaustion of the shared deadline and remains distinct from MSC's internal
+          sibling-failure/parent-close cancellation; v1 exposes no caller-supplied cancellation input.
+        </p>
+
+        <h3>Lifecycle and ownership</h3>
+        <ul>
+          <li>StorageClients are always borrowed because the existing public StorageClient API has no close lifecycle. AssemblyClient never attempts to close one.</li>
+          <li><code>close_dependencies=False</code> also borrows the plan provider and service executors.</li>
+          <li>With <code>close_dependencies=True</code>, close the provider and each distinct service executor only. A Static provider honors its separate <code>close_store</code> flag.</li>
+          <li>Close sequence: reject new work, cancel queued operations, signal and close active service result streams/internal iterators, drain cooperative work to its deadline, and wait for any already-running synchronous StorageClient call to return under its configured underlying timeout. Then attempt every retained staging artifact, clear caches/views, and optionally close dependencies.</li>
+          <li>Close is state-idempotent: the first call permanently rejects new work. It retries retained artifacts in reverse deterministic registration-token order, then attempts all owned dependencies in deterministic plan-provider then service-executor first-alias order. Every artifact/dependency is attempted; at most one leading <code>staging_artifact</code> record captures the first safe cleanup failure type, then each distinct dependency appears once with sorted/deduplicated aliases. If cleanup fails, the client remains closed and raises one redacted <code>AssemblyCloseError</code>. A later <code>close()</code> retries only outstanding orphan artifacts and never re-closes an already attempted dependency; once no artifact remains, subsequent calls are no-ops.</li>
+          <li>Live clients/views/readers are non-pickleable by default; only explicit configuration/factory wrappers may reconstruct them.</li>
+          <li>Expiration does not close an in-flight operation or a successfully materialized file. It rejects subsequent operations and invalidates instruction-derived caches.</li>
+        </ul>
+
+        <h3>Telemetry</h3>
+        <ul>
+          <li>Spans: <code>assembly.resolve</code>, <code>assembly.plan</code>, <code>assembly.read</code>, <code>assembly.object.read</code>, <code>assembly.service.execute</code>, and <code>assembly.materialize</code>.</li>
+          <li>Metrics: list batches/objects, plan segments by kind, inline bytes, object/service bytes, core service-executor submissions, complete-segment staging bytes/backend, amplification, expiration rejection, cooperative cancellation latency, cache hit/miss, and failure class.</li>
+          <li>Low-cardinality labels only: segment kind, configured alias, range mode, result class, and staging backend.</li>
+          <li>Executor-internal retries and transport-specific telemetry remain owned by the user implementation because the core SPI does not expose them.</li>
+          <li>No logical keys, resources, credentials, ETags, or auth revisions as metric labels. Trace attributes are redacted and bounded.</li>
+        </ul>
+
+        <h3>Security controls</h3>
+        <ul>
+          <li>Treat provider output as untrusted and validate before allocation or I/O.</li>
+          <li>Limit list batch/object count, logical object size, one read, segment count, encoded bytes, decoded inline bytes, resource/parameter length, source/service result range, complete-segment staging memory/temp bytes, concurrency, retries, and time.</li>
+          <li>Use separate local object/service aliases and frozen local binding objects; instruction caches never cross an AssemblyClient or frozen registry snapshot, and logical-byte caching is disabled in v1.</li>
+          <li>Interpret object resources only through each least-privilege bound StorageClient's public logical namespace. Service executors confine operations to their locally configured authority; transport-specific controls belong to that implementation.</li>
+          <li>Create every MSC-owned private stage/materialization file exclusively, use no-follow creation where supported, and use POSIX mode <code>0600</code>; publication retains that inode's effective mode.</li>
+          <li>Make all errors/reprs safe by construction and test redaction with canary secrets.</li>
+        </ul>
+      </section>
+
+      <section id="files">
+        <h2>12. File-by-file implementation plan</h2>
+        <h3>Python package</h3>
+        <pre><code>multi-storage-client/src/multistorageclient/assembly/
+├── __init__.py              # intentional public re-exports only
+├── client.py                # AssemblyClient façade, AssemblyGlobIterator, and lifecycle
+├── view.py                  # immutable generation/expiration-bound AssemblyView
+├── reader.py                # read-only seekable RawIOBase implementation
+├── models.py                # frozen list/plan/segment-union models and policies
+├── provider.py              # AssemblyPlanProvider + StaticAssemblyListProvider
+├── browsing.py              # optional BrowsableAssemblyPlanProvider capability
+├── service.py               # ServiceSegmentExecutor and requests
+├── bindings.py              # immutable StorageClient/service alias bindings
+├── config.py                # limits, consistency, retry, staging, ownership, cache policy
+├── errors.py                # stable public exception hierarchy
+├── testing.py               # provider/service-executor conformance helpers
+├── list_codec.py            # public bounded assembly-list/v1 encode/decode/streaming API
+├── list_store.py            # AssemblyListStore + bounded in-memory small-list implementation
+├── _canonical.py            # RFC 8785 plan projection and instruction digest
+├── _validator.py            # expiration, union, global coverage, consistency, limits
+├── _planner.py              # caller-range intersection and operation-local stage reuse
+├── _executor.py             # bounded scheduling and atomic result assembly
+├── _segment_stage.py        # bounded memory/temp-file complete-segment staging
+└── _cache.py                # expiration-bounded descriptor and validated-plan caches</code></pre>
+
+        <div class="callout info">
+          Only the client/view/reader, stable models/list codec, provider/service contracts, config, and documented errors are public. Leading-
+          underscore planner/executor/cache modules remain implementation details so performance internals can evolve without
+          expanding the compatibility surface.
+        </div>
+
+        <h3>Concrete transport-adapter files (not in the core change)</h3>
+        <p>
+          No concrete transport-adapter module is required or changed by the initial core. Any future adapter's public name,
+          files, protocol, and tests belong to its separately approved specification.
+        </p>
+
+        <h3>Tests and docs</h3>
+        <pre><code>multi-storage-client/tests/test_multistorageclient/unit/assembly/
+├── conftest.py
+├── conformance.py
+├── test_list_codec.py
+├── test_canonical.py
+├── test_models.py
+├── test_provider_conformance.py
+├── test_static_list_provider.py
+├── test_service_executor_conformance.py
+├── test_expiration.py
+├── test_consistency.py
+├── test_validation.py
+├── test_planning.py
+├── test_planning_properties.py
+├── test_bindings.py
+├── test_executor.py
+├── test_client.py
+├── test_view.py
+├── test_reader.py
+├── test_materialize.py
+├── test_storage_client_object.py
+├── test_service_staging.py
+└── test_acceptance.py
+
+multi-storage-client/tests/test_multistorageclient/benchmark/
+└── evaluate_assembly.py
+
+multi-storage-client-docs/src/user_guide/
+└── assembly.rst
+
+multi-storage-client-docs/src/references/
+└── assembly.rst
+
+multi-storage-client-docs/examples/
+└── quickstart.ipynb                    # explicit assembly construction/read example</code></pre>
+
+        <h3>Test-to-file routing</h3>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Concern</th><th>Primary file</th></tr></thead>
+            <tbody>
+              <tr><td>Portable codec, canonical models, and limits</td><td><code>test_list_codec.py</code>, <code>test_canonical.py</code>, <code>test_models.py</code>, <code>test_validation.py</code></td></tr>
+              <tr><td>Reusable adopter contracts</td><td><code>test_provider_conformance.py</code>, <code>test_service_executor_conformance.py</code></td></tr>
+              <tr><td>MSC-supplied static provider and bindings</td><td><code>test_static_list_provider.py</code>, <code>test_bindings.py</code>, <code>test_storage_client_object.py</code></td></tr>
+              <tr><td>Planning and MSC execution internals</td><td><code>test_planning.py</code>, <code>test_planning_properties.py</code>, <code>test_executor.py</code>, <code>test_service_staging.py</code></td></tr>
+              <tr><td>Public client, view, reader, and lifecycle</td><td><code>test_client.py</code>, <code>test_view.py</code>, <code>test_reader.py</code>, <code>test_expiration.py</code>, <code>test_consistency.py</code></td></tr>
+              <tr><td>Materialization and in-process acceptance</td><td><code>test_materialize.py</code>, <code>test_acceptance.py</code></td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Files deliberately unchanged in v1</h3>
+        <ul>
+          <li>StorageProvider ABC, provider enum/mapping, and provider factory.</li>
+          <li>StorageClient constructor, read signature, composite routing, and existing profile schema.</li>
+          <li>Top-level <code>multistorageclient.__init__</code> exports; consumers opt in through the subpackage.</li>
+          <li>FUSE/Go, fsspec, pathlib, CLI, sync, and existing URI routing. Go receives no assembly-list codec or runtime integration in the initial release.</li>
+        </ul>
+      </section>
+
+      <section id="test-architecture">
+        <h2>13. Test architecture, fixtures, and quality gates</h2>
+        <h3>Test pyramid</h3>
+        <div class="grid-3">
+          <div class="card">
+            <h4>Pure unit/property</h4>
+            <p>List codec, segment union, expiration, range intersection, global-length validation, no-cross-segment behavior, error mapping, and instruction-cache scoping. No threads or sockets where unnecessary.</p>
+          </div>
+          <div class="card">
+            <h4>Component/conformance</h4>
+            <p>Plan providers, StaticAssemblyListProvider, StorageClient bindings, user-defined ServiceSegmentExecutors, bounded staging, and lifecycle.</p>
+          </div>
+          <div class="card">
+            <h4>Local integration</h4>
+            <p>In-process user service adapter, mixed object/service/inline objects, expiration/refresh, materialization, and existing suite compatibility.</p>
+          </div>
+        </div>
+
+        <h3>Core fixtures</h3>
+        <ul>
+          <li><code>logical_payload</code>: deterministic bytes with recognizable boundaries.</li>
+          <li><code>fake_utc_clock</code>: advances exactly across expiration boundaries without sleeps.</li>
+          <li><code>valid_list_batch_factory</code>, <code>valid_descriptor</code>, and <code>valid_plan_factory</code>: complete canonical object definitions for all three union arms.</li>
+          <li><code>recording_provider</code>: records calls and can issue a replacement descriptor generation/expiration on refresh.</li>
+          <li><code>recording_storage_client</code>: records public range reads and can mutate same-length bytes.</li>
+          <li><code>recording_service_executor</code>: records the exact request, context, advertised range modes, active count, yielded chunks, stream close, and cancellation.</li>
+          <li><code>whole_result_stream</code>: configurable length/failure/replay behavior with memory/temp staging observation.</li>
+          <li><code>minimal_user_executor</code>: a test-only implementation of only <code>range_modes</code> and <code>execute</code>, proving that no optional hook or concrete MSC executor is required.</li>
+          <li><code>canary_secret</code>: deliberately placed in executor state and rejected resource text to verify redaction.</li>
+        </ul>
+
+        <p>
+          Core tests use only application-supplied in-process providers and executors. Concrete transport adapters and their
+          wire-level behavior are outside this test plan and cannot block or substitute for core acceptance.
+        </p>
+
+        <div class="callout info">
+          Reusable conformance tests exercise only behavior an adopter can observe through the provider or executor SPI.
+          Intentionally malformed doubles, stream cleanup, error normalization, staging, scheduling, and redaction remain MSC
+          unit tests; they are not obligations imposed by the reusable conformance harness.
+        </div>
+
+        <h3>Property-test dependency</h3>
+        <p>
+          Add Hypothesis to the Python development dependency group after approval. CI uses <code>max_examples=200</code> and
+          <code>deadline=None</code>, while preserving minimized failing examples. If the dependency is declined, use seeded
+          deterministic generated partitions, but record the reduced malformed-input coverage as a test-plan exception.
+        </p>
+      </section>
+
+      <section id="test-cases">
+        <h2>14. Detailed test cases and assertions</h2>
+
+        <h3>14.1 Language-neutral list codec, models, and expiration</h3>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Test</th><th>Primary assertion</th></tr></thead>
+            <tbody>
+              <tr><td><code>test_decode_minimal_batch_returns_one_complete_object_definition</code></td><td>Independent JSON input produces frozen typed models and one complete <code>AssemblyObjectDefinition</code>; decoding alone does not create an executable <code>AssemblyPlan</code>.</td></tr>
+              <tr><td><code>test_public_batch_encode_decode_round_trip_and_digest_encoding</code></td><td>One canonical document uses the exact <code>sha256:&lt;64 lowercase hex&gt;</code> digest form.</td></tr>
+              <tr><td><code>test_segment_checksum_uses_unprefixed_lower_hex_64</code></td><td>Segment checksum JSON is distinct from prefixed plan/batch digests and rejects uppercase/prefix variants.</td></tr>
+              <tr><td><code>test_reference_parameters_are_scalar_only</code></td><td>Nested reference values fail while nested service parameters remain injective.</td></tr>
+              <tr><td><code>test_canonical_key_order_uses_rfc8785_utf16_units</code></td><td>BMP/non-BMP golden keys match language-neutral JCS vectors; lone surrogates fail.</td></tr>
+              <tr><td><code>test_frozen_json_scalar_equality_and_hash_are_kind_aware</code></td><td>True/1 and False/0 remain distinct; numerically canonical 1/1.0 and 0/-0.0 normalize equal and digest identically.</td></tr>
+              <tr><td><code>test_schema_integer_fields_reject_bool_and_integral_float</code></td><td>Range, sizes, lengths, indexes, pages, and config counts accept strict int only.</td></tr>
+              <tr><td><code>test_streaming_codec_reads_and_writes_canonical_ndjson_batches</code></td><td>One bounded document per line; iterator never accumulates the snapshot.</td></tr>
+              <tr><td><code>test_streaming_codec_rejects_oversized_line_before_parse_or_large_allocation</code></td><td><code>max_encoded_batch_bytes</code> applies while buffering.</td></tr>
+              <tr><td><code>test_static_from_batches_applies_structural_limits_and_capped_canonical_counter_to_direct_models</code></td><td>An oversized one-shot direct batch aborts at one-over without constructing its complete encoding or committing earlier aggregate counters.</td></tr>
+              <tr><td><code>test_assembly_list_v1_matches_published_language_neutral_golden_vectors</code></td><td>Python encoding and decoding match the shared canonical bytes for all three segment kinds, Unicode, timestamps, and base64; each future consumer language validates the same fixtures in its own suite.</td></tr>
+              <tr><td><code>test_multi_batch_list_requires_shared_metadata_declared_count_and_contiguous_indexes</code></td><td>Mixed list IDs/issuance/expiration/counts, gaps, duplicates, missing batches, indexes outside the declared count, and batch-digest mismatch fail closed.</td></tr>
+              <tr><td><code>test_multi_batch_list_rejects_duplicate_reference_across_batches</code></td><td>One canonical <code>AssemblyReference</code> identifies at most one complete object definition in the validated snapshot.</td></tr>
+              <tr><td><code>test_v1_portable_list_omits_refresh_locator_and_static_provider_is_non_refreshable</code></td><td>Refresh routing remains provider-owned rather than a dead portable field.</td></tr>
+              <tr><td><code>test_batch_never_splits_one_object_definition</code></td><td>A partial/carry-over object is not representable or executable.</td></tr>
+              <tr><td><code>test_rejects_missing_expires_at</code>, <code>test_rejects_malformed_expires_at</code></td><td>Both canonical decoder and direct model construction reject before provider/executor I/O.</td></tr>
+              <tr><td><code>test_expires_at_requires_timezone_and_canonicalizes_to_utc</code></td><td>Equivalent instants have one representation and equality with the clock is expired.</td></tr>
+              <tr><td><code>test_static_provider_rejects_expired_list_at_admission</code></td><td>Raises <code>AssemblyExpiredError</code> before plan exposure with zero object/service calls.</td></tr>
+              <tr><td><code>test_byte_range_is_frozen_hashable_and_bounded</code></td><td>Canonical range cannot mutate and rejects negative/overflow arithmetic.</td></tr>
+              <tr><td><code>test_existing_msc_range_is_copied_at_api_boundary</code></td><td>Later mutation of the caller's Range cannot alter view/request identity.</td></tr>
+              <tr><td><code>test_models_are_slotted_hashable_and_immutable</code></td><td>Mutation and unknown attribute assignment fail; identity types are hashable where documented.</td></tr>
+              <tr><td><code>test_reference_parameters_are_defensively_copied_and_canonical</code></td><td>Mutating the caller's mapping cannot change reference or cache identity.</td></tr>
+              <tr><td><code>test_reference_parameters_reject_nonfinite_numbers</code></td><td>NaN and infinities never enter equality, digest, or cache keys.</td></tr>
+              <tr><td><code>test_reference_integer_parameters_require_json_safe_range</code></td><td>Cross-language plan digests cannot silently round large integers.</td></tr>
+              <tr><td><code>test_frozen_json_array_and_object_are_distinct_for_pair_shaped_values</code></td><td><code>[["a", 1]]</code> and <code>{"a": 1}</code> never collapse to the same Python model or digest.</td></tr>
+              <tr><td><code>test_service_parameters_require_frozen_json_object_root</code></td><td>Nested arrays/objects round-trip injectively while the operation parameter root remains an object.</td></tr>
+              <tr><td><code>test_rejects_unknown_list_or_plan_schema_version</code></td><td>Fails closed with <code>UnsupportedAssemblySchemaError</code>.</td></tr>
+              <tr><td><code>test_rejects_unknown_fields_or_segment_kind</code></td><td>Forward-incompatible input is not silently ignored or reinterpreted.</td></tr>
+              <tr><td><code>test_decodes_object_service_and_inline_discriminated_union</code></td><td>Each kind has its exact fields and cannot borrow fields from another kind.</td></tr>
+              <tr><td><code>test_rejects_inline_segment_over_16_kib</code>, <code>test_rejects_inline_total_over_64_kib</code></td><td>Decoded-byte hard limits apply before allocation/scheduling, independent of base64 size.</td></tr>
+              <tr><td><code>test_zero_length_object_accepts_only_empty_plan</code></td><td>No source call and no non-empty segment.</td></tr>
+              <tr><td><code>test_plan_digest_is_stable_for_canonical_equivalent_input</code></td><td>Map ordering cannot change digest identity.</td></tr>
+              <tr><td><code>test_plan_digest_uses_rfc8785_sha256_and_excludes_self_and_deadlines</code></td><td>It covers descriptor expiration and all segment semantics but remains an instruction digest, not required output digest.</td></tr>
+              <tr><td><code>test_assembly_plan_create_freezes_segments_and_computes_digest</code></td><td>Provider authors can construct a valid plan without implementing canonicalization themselves.</td></tr>
+              <tr><td><code>test_plan_digest_changes_when_semantic_field_changes</code></td><td>Descriptor generation/expiration, union kind, range, alias, parameters, revision, digest, or inline bytes change it.</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>14.2 Provider contract, client refresh, and static-provider behavior</h3>
+        <p>
+          Descriptor, complete-plan, deadline, concurrency, and public-error cases form the reusable provider suite.
+          Expiration/refresh/cache cases are MSC client tests, while static-provider and list-store cases target the
+          MSC-supplied implementation.
+        </p>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Test</th><th>Primary assertion</th></tr></thead>
+            <tbody>
+              <tr><td><code>test_provider_resolve_descriptor_returns_metadata_only_with_mandatory_expiration</code></td><td>The result is an <code>AssemblyDescriptor</code> with no <code>read</code>, <code>open</code>, or <code>materialize</code>; it cannot omit/malformed expiration and is bound to one fixed generation.</td></tr>
+              <tr><td><code>test_provider_resolve_descriptor_must_echo_exact_reference_and_requested_generation</code></td><td>A substituted reference or silent pinned-generation fall-forward is rejected before plan/source calls; latest is allowed only when generation was None.</td></tr>
+              <tr><td><code>test_provider_get_plan_echoes_exact_descriptor_without_byte_range</code></td><td>The provider receives the descriptor directly plus the optional absolute deadline; it cannot return a range-specific fragment or substitute a different generation.</td></tr>
+              <tr><td><code>test_provider_plan_is_complete_object_not_transport_page</code></td><td>Segments globally cover <code>[0, descriptor.size)</code> even when caller later reads a small range.</td></tr>
+              <tr><td><code>test_expired_view_does_not_fall_forward_or_auto_refresh</code></td><td>Raises <code>AssemblyExpiredError</code>; provider is not asked for latest implicitly.</td></tr>
+              <tr><td><code>test_refresh_returns_distinct_view_for_replacement_generation</code></td><td>The returned view has the provider's replacement generation and expiration; the old view retains its descriptor, validated plan, capabilities, and frozen routing. Under <code>EXPIRATION_ONLY</code>, the test makes no claim that mutable source bytes remain unchanged.</td></tr>
+              <tr><td><code>test_refresh_capability_captures_exact_immutable_provider_property_true_and_false</code></td><td>False rejects before a provider call; a provider advertising true implements refresh, and StaticAssemblyListProvider remains false.</td></tr>
+              <tr><td><code>test_refresh_failure_leaves_valid_old_view_unchanged_and_usable</code></td><td>A proactive refresh failure does not change metadata, plan, capabilities, expiration, or source routing; the still-valid old view remains usable through that same frozen execution state. Exact bytes are asserted only in an immutable or <code>SNAPSHOT_PINNED</code> fixture.</td></tr>
+              <tr><td><code>test_refresh_failure_does_not_revive_expired_old_view</code>, <code>test_refresh_failure_does_not_reopen_closed_old_view</code></td><td>Failure never extends expiration or changes lifecycle state; subsequent work raises the original expired/closed outcome without stale fallback.</td></tr>
+              <tr><td><code>test_provider_instruction_cache_is_scoped_to_concrete_provider_instance</code></td><td>No provider revision is required in metadata and instructions are never reused across provider instances.</td></tr>
+              <tr><td><code>test_provider_supports_concurrent_resolve_descriptor_and_get_plan</code></td><td>Required provider methods are thread-safe without an undeclared capability.</td></tr>
+              <tr><td><code>test_provider_honors_expired_monotonic_deadline_without_backend_call</code></td><td>Retries cannot outlive the AssemblyClient operation budget.</td></tr>
+              <tr><td><code>test_provider_exact_public_exception_contract</code></td><td>Not-found, unavailable generation, auth, exhausted retryable backend, malformed output, unsupported capability, unexpected exception, and deadline each map to the frozen hierarchy with no fallback.</td></tr>
+              <tr><td><code>test_provider_unexpected_error_uses_fresh_sanitized_cause_without_original_context</code></td><td>Only the bounded safe type token is reachable; backend text/reference and the original object are absent from cause, context, args, attributes, repr, and traceback.</td></tr>
+              <tr><td><code>test_provider_close_is_idempotent</code></td><td>Second close has no side effect or error.</td></tr>
+              <tr><td><code>test_static_provider_decodes_batches_and_exact_lookup_matches_traversal</code></td><td>Static provider is the concrete-list surface and never executes browse pages.</td></tr>
+              <tr><td><code>test_static_provider_maps_list_id_to_generation_and_preserves_expiration</code></td><td>Every descriptor returned from one static snapshot uses that snapshot's <code>list_id</code> as <code>generation</code> and its exact <code>expires_at</code>; lookup and traversal agree.</td></tr>
+              <tr><td><code>test_static_from_batches_stops_at_aggregate_in_memory_limit</code></td><td>A one-shot iterator cannot accumulate more objects/segments/encoded bytes than configured.</td></tr>
+              <tr><td><code>test_assembly_list_store_get_and_iter_objects_share_one_snapshot</code></td><td>Lookup/traversal are replayable, stable, and return only complete definitions from the declared validated snapshot.</td></tr>
+              <tr><td><code>test_static_provider_revalidates_store_result_before_execution</code></td><td>A faulty store cannot bypass canonical model, expiration, alias, or global-length checks.</td></tr>
+              <tr><td><code>test_static_provider_close_store_flag_controls_store_ownership</code></td><td>Borrowed and owned stores follow the explicit lifecycle contract.</td></tr>
+              <tr><td><code>test_browse_index_cursor_is_stable_and_not_executable</code></td><td>Optional metadata pages do not mix snapshots and cannot be passed as an AssemblyPlan.</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>14.3 Validation and limits</h3>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Tests</th><th>Required assertion</th></tr></thead>
+            <tbody>
+              <tr><td><code>test_accepts_exact_full_object_partition</code></td><td>Valid plan reaches planning unchanged.</td></tr>
+              <tr><td><code>test_partial_read_still_validates_complete_object_global_length</code></td><td>Executor intersects only after validating the checked sum of the full ordered concatenation.</td></tr>
+              <tr><td><code>test_tuple_order_is_the_only_logical_order</code>, <code>test_rejects_unknown_segment_kind</code></td><td>No ambiguous secondary ordering field; zero source calls for unknown kinds.</td></tr>
+              <tr><td><code>test_rejects_global_segment_length_sum_mismatch</code></td><td>Checked sum must equal descriptor size even if requested range lies before the malformed tail.</td></tr>
+              <tr><td><code>test_rejects_object_segment_range_size_length_mismatch</code></td><td><code>ObjectSegment.byte_range.size</code> must equal its declared <code>length</code>; rejection occurs before binding or byte I/O even when the global sum still matches.</td></tr>
+              <tr><td><code>test_rejects_inline_segment_length_data_mismatch</code>, <code>test_nonempty_object_rejects_zero_length_segment</code></td><td>Inline length equals decoded byte length and every segment of a non-empty object is positive; neither invariant can be hidden by a valid global sum.</td></tr>
+              <tr><td><code>test_rejects_negative_numbers</code>, <code>test_rejects_json_safe_integer_overflow</code>, <code>test_rejects_object_byte_range_overflow</code></td><td>No cross-language rounding, OverflowError/MemoryError leakage, or allocation before rejection.</td></tr>
+              <tr><td><code>test_rejects_descriptor_echo_mismatch</code>, <code>test_rejects_generation_or_expiration_echo_mismatch</code></td><td>Provider contract violation before binding lookup.</td></tr>
+              <tr><td><code>test_rejects_plan_digest_mismatch</code></td><td>Provider-supplied digest is recomputed; no cache entry or source call.</td></tr>
+              <tr><td><code>test_rejects_unknown_object_or_service_alias</code>, <code>test_freezes_local_binding_objects_before_io</code></td><td>Plan cannot construct an authority; the view keeps the exact locally supplied objects even if the caller later mutates the input mappings.</td></tr>
+              <tr><td><code>test_expiration_only_accepts_missing_selectors_validators_revisions_and_checksums</code></td><td>Optional identity fields are genuinely optional under the default policy.</td></tr>
+              <tr><td><code>test_identity_only_validator_or_operation_revision_does_not_claim_enforcement</code></td><td>It may identify an operation but cannot enable stable-byte caching or snapshot guarantees.</td></tr>
+              <tr><td><code>test_snapshot_pinned_rejects_unenforceable_object_selector_or_validator</code>, <code>test_snapshot_pinned_rejects_unenforceable_service_revision</code></td><td>Strict opt-in fails before I/O; no HEAD/read/HEAD substitution.</td></tr>
+              <tr><td><code>test_snapshot_pinned_accepts_verified_complete_checksum_for_object</code></td><td>The client-only initial binding accepts snapshot-pinned object bytes only after the complete segment checksum is verified; no unapproved validator or policy hook is required.</td></tr>
+              <tr><td><code>test_any_supplied_checksum_forces_bounded_complete_segment_verification_before_partial_slice</code></td><td>The rule applies in both consistency modes and even alongside an enforcing revision; a complete checksum is never compared to a partial body, and over-limit verification fails before I/O.</td></tr>
+              <tr><td><code>test_rejects_service_range_mode_not_supported_by_executor</code></td><td>Support is determined only by the injected executor's advertised SPI capability; rejection performs zero service calls.</td></tr>
+              <tr><td><code>test_enforces_max_segments</code>, <code>test_enforces_max_plan_bytes</code>, <code>test_enforces_max_logical_size</code>, <code>test_enforces_max_read_bytes</code>, <code>test_enforces_inline_hard_limits</code></td><td>Correct limit name/value and zero downstream calls.</td></tr>
+              <tr><td><code>test_plan_size_streaming_counter_accepts_exact_limit_and_aborts_at_one_over</code>, <code>test_huge_direct_model_fails_cheap_structure_before_full_canonical_encoding</code></td><td>No second complete plan encoding/allocation; direct and decoded paths share exact canonical size semantics.</td></tr>
+              <tr><td><code>test_config_integer_and_timeout_hard_bounds_accept_exact_and_reject_one_over</code></td><td>Strict integers stop at <code>2**53-1</code>, seconds stop at 604800, and invalid values fail before allocation or dependency I/O.</td></tr>
+              <tr><td><code>test_client_wide_budget_relationships_accept_exact_boundaries_and_reject_one_over</code></td><td>Twice the read/window maxima fit output total; per-operation staging memory/disk fit their totals; object chunks fit read/window/in-flight/staging-memory bounds.</td></tr>
+              <tr><td><code>test_plan_rejects_individually_unstageable_full_result_before_execution</code></td><td>A stage above its per-result or aggregate client cap yields a typed limit error with no service/object call; a user executor may enforce an additional private cap.</td></tr>
+              <tr><td><code>test_client_resolve_exposes_no_view_before_complete_plan_validation</code></td><td><code>AssemblyClient.resolve</code> performs <code>resolve_descriptor</code>, exact-generation plan retrieval, global validation, binding freeze, and capability computation before exposing a view; any failure returns no partial view and performs no object or service byte I/O.</td></tr>
+              <tr><td><code>test_plan_validation_failure_performs_no_byte_io</code></td><td>Malformed global length, digest, alias, mode, or consistency fails before any StorageClient or ServiceSegmentExecutor byte call.</td></tr>
+              <tr><td><code>test_valid_v1_view_always_advertises_range_read_and_forward_open</code></td><td>Successfully resolved v1 plans have both flags true; a synthetic future false capability rejects the operation before I/O.</td></tr>
+              <tr><td><code>test_rejects_resource_or_reference_over_length_limit</code></td><td>No unbounded logging/cache key or URL creation.</td></tr>
+              <tr><td><code>test_unassigned_identity_metadata_strings_accept_exact_utf8_cap_and_reject_one_over_or_lone_surrogate</code></td><td>Decoded and direct/live provider models fail before cache, digest, alias lookup, or external I/O for every covered field family.</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>14.4 Planner and property tests</h3>
+        <ul>
+          <li><code>test_plans_range_inside_one_segment</code></li>
+          <li><code>test_plans_range_across_multiple_segments</code></li>
+          <li><code>test_maps_first_and_last_partial_segments</code></li>
+          <li><code>test_handles_exact_segment_boundaries_last_byte_and_eof</code></li>
+          <li><code>test_intersects_object_inline_and_stable_service_segments</code></li>
+          <li><code>test_preserves_destination_offsets_and_optional_selectors_validators_and_revisions</code></li>
+          <li><code>test_checksum_object_operation_uses_complete_fetch_range_and_selected_range_in_fetch</code> — <code>fetch_range</code> is the complete source segment required for digest verification, while <code>selected_range_in_fetch</code> identifies only the caller-requested slice copied from the verified result at the correct destination offset.</li>
+          <li><code>test_unchecked_object_operation_fetches_only_selected_source_intersection</code> — without a checksum, <code>fetch_range</code> is the exact caller intersection and <code>selected_range_in_fetch</code> covers that complete fetched result.</li>
+          <li><code>test_adjacent_object_segments_remain_distinct_public_reads</code></li>
+          <li><code>test_never_coalesces_across_segment_checksum_or_identity_boundaries</code></li>
+          <li><code>test_whole_result_same_ordinal_has_one_logical_submission_per_operation</code></li>
+          <li><code>test_two_equal_valued_whole_result_segments_at_distinct_ordinals_are_not_deduplicated</code></li>
+          <li><code>test_same_whole_result_ordinal_reuses_stage_across_reader_seeks_and_materialization_windows</code></li>
+          <li><code>test_valid_partition_reconstructs_reference_slice</code> — random payload, valid partition, and read range equal direct slicing.</li>
+          <li><code>test_planned_output_is_covered_exactly_once</code> — no destination gap or overlap.</li>
+          <li><code>test_split_read_equals_unsplit_read</code> — <code>read(a,n) == read(a,k) + read(a+k,n-k)</code>.</li>
+          <li><code>test_single_length_or_destination_mapping_mutation_is_rejected</code>.</li>
+          <li><code>test_destination_mapping_is_idempotent</code>.</li>
+          <li><code>test_malformed_numeric_input_always_raises_domain_error</code>.</li>
+        </ul>
+
+        <h3>14.5 Bindings, direct object reads, and the service-executor boundary</h3>
+        <p>
+          Binding tests use only the existing public <code>StorageClient</code> contract. StorageClients are always borrowed;
+          optional Assembly ownership applies only to the plan provider and service executors.
+        </p>
+        <ul>
+          <li><code>test_binding_registries_copy_mappings_and_reject_late_mutation</code></li>
+          <li><code>test_binding_registries_reject_empty_or_malformed_alias_names</code></li>
+          <li><code>test_dependency_object_identity_cannot_be_reused_across_provider_executor_or_client_roles</code></li>
+          <li><code>test_plan_schema_has_no_endpoint_profile_credentials_or_executor_implementation_fields</code></li>
+          <li><code>test_object_source_binding_minimum_constructor_requires_only_client</code></li>
+          <li><code>test_default_client_close_borrows_provider_storage_clients_and_executors</code></li>
+          <li><code>test_close_dependencies_closes_provider_and_distinct_executors_once</code></li>
+          <li><code>test_close_dependencies_never_closes_storage_clients</code></li>
+          <li><code>test_close_attempts_all_owned_provider_and_executor_dependencies_then_raises_redacted_assembly_close_error</code></li>
+          <li><code>test_close_failure_records_are_deduplicated_sorted_and_publicly_typed</code></li>
+          <li><code>test_storage_client_calls_are_serialized_across_aliases_and_views</code></li>
+          <li><code>test_non_thread_safe_service_executor_serializes_calls_and_opt_in_allows_concurrency</code></li>
+          <li><code>test_object_segment_uses_only_public_storage_client_contract</code></li>
+          <li><code>test_client_only_binding_uses_exact_configured_storage_client_authority</code> — a plan selects a local alias and resource only; it cannot replace the bound client, endpoint, profile, credentials, root, or provider.</li>
+          <li><code>test_plan_resource_is_sent_only_to_selected_binding</code> — only the client selected by <code>source_id</code> receives the resource and all other clients record zero calls.</li>
+          <li><code>test_object_chunks_map_exact_source_offsets_and_sizes_without_gap_or_overlap</code></li>
+          <li><code>test_object_interval_below_at_and_above_chunk_limit_uses_exact_consecutive_public_reads</code></li>
+          <li><code>test_checksum_object_partial_access_chunks_and_stages_complete_segment_before_slice</code></li>
+          <li><code>test_object_chunks_never_cross_segment_boundaries_and_request_count_matches_formula</code></li>
+          <li><code>test_client_wide_inflight_object_byte_reservations_bound_concurrent_callers_and_release_on_failure</code></li>
+          <li><code>test_object_read_maps_file_not_found_permission_retryable_and_source_errors_with_sanitized_causes</code></li>
+          <li><code>test_object_read_runtime_error_uses_generic_source_read_error_without_message_or_sdk_cause_parsing</code></li>
+          <li><code>test_object_read_does_not_wrap_base_exception</code></li>
+          <li><code>test_object_read_full_formatted_traceback_redacts_resource_provider_message_and_secret_nested_cause</code></li>
+          <li><code>test_object_read_rejects_non_bytes_short_and_oversized_results_with_exact_classes</code></li>
+          <li><code>test_object_read_checks_deadline_and_internal_cancellation_before_and_after_sync_call</code> — Assembly does not claim to preempt a synchronous <code>StorageClient.read</code>; a late result is discarded and the typed deadline/cancellation outcome takes precedence over result validation.</li>
+          <li><code>test_expiration_only_object_read_does_not_require_info_or_revision</code></li>
+          <li><code>test_object_source_binding_does_not_claim_atomic_selector_or_validator_enforcement</code></li>
+          <li><code>test_private_storage_provider_is_never_accessed</code></li>
+        </ul>
+
+        <p>The reusable <code>ServiceSegmentExecutor</code> conformance suite contains only adopter-observable SPI behavior:</p>
+        <ul>
+          <li><code>test_minimal_executor_implements_only_range_modes_and_execute</code> — a class overriding only those two abstract members is constructible and completes the acceptance read.</li>
+          <li><code>test_assembly_package_exports_no_concrete_service_executor</code></li>
+          <li><code>test_service_executor_receives_one_segment_request_not_complete_plan_or_ordering</code></li>
+          <li><code>test_executor_receives_exact_deadline_cancellation_and_chunk_limit_context</code></li>
+          <li><code>test_executor_range_modes_are_exact_immutable_and_captured_before_view_exposure</code></li>
+          <li><code>test_optional_executor_capabilities_are_immutable_for_injected_lifetime</code> — optional revision-kind and thread-safety declarations cannot change after injection.</li>
+          <li><code>test_service_executor_declared_range_modes_match_observed_behavior</code></li>
+          <li><code>test_stable_subranges_returns_exact_first_middle_and_last_ranges</code></li>
+          <li><code>test_stable_subranges_denotes_one_stable_logical_string_per_operation</code></li>
+          <li><code>test_whole_result_executor_receives_no_requested_range</code></li>
+          <li><code>test_executor_result_must_be_closeable_before_publish</code> — a non-closeable result raises <code>ServiceProtocolError</code> and publishes no bytes.</li>
+          <li><code>test_whole_result_length_mismatch_fails_before_slice_publish</code></li>
+          <li><code>test_service_optional_revision_absent_under_expiration_only</code></li>
+          <li><code>test_snapshot_revision_kinds_defaults_empty_and_is_immutable</code></li>
+          <li><code>test_enforced_service_revision_requires_advertised_snapshot_revision_kind</code></li>
+          <li><code>test_verified_complete_service_checksum_qualifies_without_operation_revision</code></li>
+          <li><code>test_service_enforced_revision_or_digest_mismatch_fails_closed</code></li>
+          <li><code>test_service_checksum_mismatch_raises_service_integrity_error_before_publish</code></li>
+          <li><code>test_retry_safety_never_pre_response_reset_is_not_retried_by_core</code> — the executor is invoked once and the typed fixture failure is surfaced even before any chunk is yielded.</li>
+          <li><code>test_retry_safety_never_partial_stream_failure_is_not_retried_by_core</code> — the executor is invoked once and the current call publishes no bytes.</li>
+          <li><code>test_retry_safety_safe_does_not_add_outer_core_retry</code> — MSC invokes <code>execute</code> once; the test makes no claim about private work inside the user implementation.</li>
+        </ul>
+
+        <p>MSC executor-internal boundary tests, which are not part of the reusable adopter suite, include:</p>
+        <ul>
+          <li><code>test_stream_cleanup_attempts_all_in_reverse_order_and_primary_execution_error_wins</code></li>
+          <li><code>test_sole_stream_close_failure_becomes_sanitized_service_executor_error_and_discards_output</code></li>
+          <li><code>test_result_stream_and_private_stage_cleanup_failures_select_service_executor_error_and_retain_stage_orphan</code></li>
+          <li><code>test_custom_stream_rejects_nonbytes_empty_and_over_context_chunk_limit_before_copy_or_stage</code></li>
+          <li><code>test_service_errors_and_repr_redact_parameters_and_credentials</code></li>
+          <li><code>test_public_error_constructors_reject_arbitrary_messages_and_keep_args_str_repr_canonical</code></li>
+          <li><code>test_custom_typed_error_is_normalized_and_subclass_or_malformed_fields_cannot_bypass_redaction</code></li>
+          <li><code>test_unexpected_custom_executor_exception_maps_to_service_executor_error_without_original_cause_or_context</code></li>
+          <li><code>test_redaction_walks_cause_context_args_attributes_and_full_formatted_traceback</code></li>
+          <li><code>test_service_deadline_internal_cancellation_and_base_exception_are_not_wrapped</code></li>
+        </ul>
+
+        <h3>14.6 Executor, client, view, and reader</h3>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Area</th><th>Tests and key assertions</th></tr></thead>
+            <tbody>
+              <tr><td>Ordering</td><td><code>test_reassembles_out_of_order_completions_in_logical_order</code>; result equals reference bytes.</td></tr>
+              <tr><td>Concurrency</td><td><code>test_never_exceeds_client_wide_concurrency_across_callers</code>; <code>test_streaming_service_result_holds_permit_and_executor_lock_until_closed</code>; <code>test_object_chunk_memory_reservation_never_exceeds_client_wide_byte_budget</code>; <code>test_active_operation_slots_bound_one_shots_and_open_readers_and_release_on_all_exit_paths</code>.</td></tr>
+              <tr><td>Admission reentrancy</td><td><code>test_resolve_info_read_open_materialize_and_glob_do_not_reacquire_at_max_active_operations_one</code>; every convenience completes without self-deadlock and performs only one resolution/list-page sequence.</td></tr>
+              <tr><td>Admission wait</td><td><code>test_slot_wait_allocates_no_output_or_stage_and_observes_deadline_cancel_and_parent_close</code>; <code>test_slot_wait_time_is_followed_by_fresh_expiration_admission_check</code>.</td></tr>
+              <tr><td>Global byte budgets</td><td><code>test_output_total_bounds_concurrent_reads_and_materialization_windows_then_releases</code>; <code>test_staging_memory_and_disk_totals_bound_concurrent_callers_and_retained_readers</code>; <code>test_multi_budget_reservation_is_all_or_none_and_cannot_deadlock</code>.</td></tr>
+              <tr><td>Atomicity</td><td><code>test_short_long_digest_or_enforced_revision_failure_returns_no_bytes_from_current_call</code>; <code>test_reader_prefix_may_be_observed_before_later_call_fails_and_poison_closes_reader</code>; <code>test_reader_read_all_late_segment_failure_returns_nothing_and_commits_cursor_once</code>; cursor/readinto buffer is unchanged for the failed public call and its private output is not published.</td></tr>
+              <tr><td>Cancellation</td><td><code>test_first_terminal_error_signals_shared_token_attempts_every_cleanup_and_cancels_queued_reads</code>; successful cleanup removes the stage, injected cleanup failure follows orphan accounting, and cooperative user calls observe the operation deadline.</td></tr>
+              <tr><td>Retry</td><td><code>test_assembly_executor_never_retries_object_or_service_call</code>; both NEVER and SAFE fixtures observe exactly one core <code>execute</code> invocation. Work internal to the user implementation is out of scope.</td></tr>
+              <tr><td>Composition</td><td><code>test_object_inline_plan_accepts_empty_service_executor_registry</code>; <code>test_inline_only_plan_accepts_empty_object_and_service_registries</code>; <code>test_service_only_plan_accepts_empty_object_source_registry</code>; only aliases actually referenced by the complete plan are required.</td></tr>
+              <tr><td>Resolution</td><td><code>test_one_shot_read_calls_resolve_descriptor_once</code>; <code>test_info_returns_descriptor_without_get_plan_or_byte_io</code>; <code>test_view_operations_reuse_frozen_plan_without_provider_calls</code>; <code>test_open_keeps_one_generation_across_seek_and_read</code>. After resolve, view operations never replan.</td></tr>
+              <tr><td>Segment-free I/O</td><td><code>test_inline_segment_emits_exact_bytes_without_object_or_service_io</code>; <code>test_zero_length_read_validates_complete_plan_then_performs_no_segment_io</code>.</td></tr>
+              <tr><td>Reader expiration</td><td><code>test_reader_opened_while_valid_reads_and_seeks_after_expiration_until_close</code>; <code>test_new_open_after_expiration_fails_before_plan_or_service_io</code>.</td></tr>
+              <tr><td>View/reader close</td><td><code>test_reader_survives_originating_view_close_until_reader_or_parent_close</code>; <code>test_reader_close_result_stream_failure_maps_to_service_executor_error_but_still_releases_slot</code>; reader uses pinned capabilities/state, the view rejects new work, all cleanup is attempted, and parent close cancels both.</td></tr>
+              <tr><td>Reader service stage</td><td><code>test_reader_reuses_one_whole_result_stage_across_reads_and_seeks</code>; <code>test_seek_true_when_retained_stage_sum_equals_cap_and_false_at_cap_plus_one</code>; <code>test_forward_reader_releases_passed_stages_and_does_not_self_deadlock_when_sum_exceeds_cap</code>; <code>test_seekable_reader_retains_stages_without_replay</code>; stage/context close exactly once.</td></tr>
+              <tr><td>Expiration</td><td><code>test_operation_rejects_when_clock_equals_expiration</code>; <code>test_operation_started_valid_may_finish_after_expiration</code>; the next operation fails with <code>AssemblyExpiredError</code>.</td></tr>
+              <tr><td>Refresh</td><td><code>test_client_refresh_returns_new_view_and_never_mutates_old_view</code>; <code>test_refresh_requires_replacement_generation</code>; <code>test_refresh_none_preserves_original_required_minimum_not_computed_or_client_default</code>; <code>test_refresh_explicit_consistency_override_is_intentional</code>.</td></tr>
+              <tr><td>Reference shorthand</td><td><code>test_string_reference_normalizes_to_empty_namespace_key</code>; parameters remain explicit-only.</td></tr>
+              <tr><td>Browsing</td><td><code>test_list_requires_browse_index</code>, <code>test_cursor_is_bound_to_listing_request</code>, <code>test_browse_page_cannot_execute</code>; <code>test_list_page_size_zero_exact_max_and_one_over</code>; <code>test_list_cursor_utf8_exact_cap_one_over_and_lone_surrogate</code>; <code>test_provider_page_rejects_requested_plus_one_items_or_oversized_next_cursor_before_cache</code>; <code>test_glob_no_match_and_late_match_stop_at_exact_scan_budget_without_extra_provider_call</code>; <code>test_glob_result_budget_raises_before_yielding_one_over</code>; <code>test_glob_close_before_start_acquires_none_and_early_close_error_or_exhaustion_releases_slot_once</code>; <code>test_glob_context_manager_releases_slot_when_loop_breaks</code>.</td></tr>
+              <tr><td>Views</td><td><code>test_assembly_view_metadata_returns_exact_resolved_descriptor</code>; <code>test_existing_view_never_switches_generation</code>; <code>test_closing_one_view_rejects_that_view_and_leaves_sibling_view_usable</code>; metadata remains control-plane-only and only a refreshed/new view may observe a replacement generation.</td></tr>
+              <tr><td>Read-only façade</td><td><code>test_assembly_view_exposes_no_write_delete_copy_sync_or_presign_operations</code>; reader writes and truncate raise <code>UnsupportedOperation</code>.</td></tr>
+              <tr><td>Consistency truthfulness</td><td><code>test_expiration_only_same_length_source_mutation_may_change_bytes_without_snapshot_claim</code>; two admitted operations may differ, the view remains <code>EXPIRATION_ONLY</code>, and stale mutable bytes are not reused.</td></tr>
+              <tr><td>Reader</td><td><code>test_reader_supports_seek_tell_readinto_and_eof</code>; <code>test_range_zero_at_eof_past_eof_crossing_eof_negative_and_overflow_boundaries</code>; <code>test_reader_overrides_read_and_readall_instead_of_rawio_looping_default</code>; seek past EOF is allowed, seek before zero fails, and writes/truncate raise <code>UnsupportedOperation</code>.</td></tr>
+              <tr><td>Lifecycle</td><td><code>test_client_close_is_idempotent_and_rejects_new_work</code>; <code>test_view_close_is_idempotent_and_does_not_close_parent_or_siblings</code>; <code>test_close_attempt_order_and_close_failure_order_are_deterministic</code>; <code>test_parent_close_retries_orphans_and_emits_one_leading_staging_failure_record</code>; <code>test_second_close_retries_only_remaining_orphans_without_reclosing_dependencies</code>.</td></tr>
+              <tr><td>Timeout</td><td><code>test_global_deadline_normalizes_provider_queue_object_service_and_staging_exhaustion</code>; while the global budget remains, an already typed provider/source/service domain error is preserved and internal cancellation remains distinct. The object-source case verifies pre/post-call checks and late-result discard, but does not assert a hard latency bound for an already-running synchronous <code>StorageClient.read</code>.</td></tr>
+              <tr><td>Complete-segment staging</td><td><code>test_whole_result_one_logical_submission_serves_multiple_intersections</code>; <code>test_checksum_complete_segment_stage_is_reused_across_reader_seeks_and_materialization_windows</code>; <code>test_small_whole_result_stages_in_memory</code>; <code>test_large_whole_result_stages_to_temp_file</code>; <code>test_complete_segment_memory_and_total_temp_limits_fail_closed</code>; <code>test_staging_create_write_flush_failures_map_to_redacted_staging_error</code>; <code>test_stage_close_and_unlink_attempt_all_in_reverse_order</code>; <code>test_primary_execution_error_wins_without_cleanup_chain</code>; <code>test_sole_private_stage_cleanup_failure_discards_success_and_raises_staging_error</code>; <code>test_file_stage_reservation_requires_both_handle_close_and_path_unlink</code>; <code>test_create_failure_before_artifact_releases_reservation_immediately</code>; <code>test_failed_artifact_reservation_remains_charged_until_cleanup_retry</code>; <code>test_reader_close_failure_still_closes_reader_releases_slot_and_transfers_orphan_charge</code>.</td></tr>
+              <tr><td>Cache</td><td><code>test_descriptor_and_plan_cache_hard_expire_with_descriptor</code>; <code>test_cache_ttl_never_extends_descriptor_expiration</code>; <code>test_expiration_only_does_not_cache_mutable_source_bytes</code>; <code>test_failed_or_expired_plan_is_never_reused</code>.</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>14.7 Materialization</h3>
+        <ul>
+          <li><code>test_materialize_uses_exact_bounded_windows_and_peak_output_buffer_never_exceeds_config</code></li>
+          <li><code>test_materialize_atomically_replaces_destination_when_allowed</code></li>
+          <li><code>test_materialize_refuses_existing_destination_by_default</code></li>
+          <li><code>test_materialize_no_replace_loses_concurrent_destination_race_without_overwriting_winner</code></li>
+          <li><code>test_materialize_unsupported_atomic_no_replace_fails_precommit_and_preserves_destination</code></li>
+          <li><code>test_materialize_failure_preserves_existing_destination</code></li>
+          <li><code>test_materialize_failure_removes_staging_file</code></li>
+          <li><code>test_materialize_fsyncs_file_and_parent_directory_when_enabled</code></li>
+          <li><code>test_postcommit_staging_unlink_failure_reports_cleanup_committed_true_and_destination_visible</code></li>
+          <li><code>test_postcommit_directory_fsync_failure_reports_directory_fsync_committed_true_and_indeterminate_durability</code></li>
+          <li><code>test_precommit_create_write_file_fsync_or_commit_failure_reports_committed_false</code></li>
+          <li><code>test_materialize_private_file_is_exclusive_no_follow_and_mode_0600</code></li>
+          <li><code>test_materialize_published_inode_retains_effective_mode_0600</code></li>
+          <li><code>test_materialization_started_valid_may_commit_after_descriptor_expiration</code></li>
+          <li><code>test_completed_materialization_lifetime_is_independent_of_instruction_expiration</code></li>
+          <li><code>test_new_materialization_after_expiration_is_rejected_before_staging</code></li>
+        </ul>
+
+        <div class="callout info">
+          Concrete transport-adapter behavior is outside the Assembly core test plan. Core acceptance proves the public SPI
+          with the minimal application-supplied in-process executor and contains no tests for hypothetical adapter modules.
+        </div>
+
+        <h3>14.8 In-process acceptance and compatibility</h3>
+        <p>
+          The format-shaped fixtures below are non-blocking examples. The blocking core acceptance gate is the
+          format-neutral mixed-union reconstruction and routing behavior; MSC does not parse or interpret those formats.
+        </p>
+        <ul>
+          <li><code>test_external_jsonl_fixture_uses_only_direct_object_segment_and_matches_golden_bytes</code></li>
+          <li><code>test_external_mp4_fixture_mixes_synthesized_structure_and_gop_aligned_object_ranges</code></li>
+          <li><code>test_external_page_aligned_parquet_fixture_reuses_object_pages_with_synthesized_structure</code></li>
+          <li><code>test_external_through_page_parquet_fixture_is_entirely_service_produced</code></li>
+          <li>Those fixture providers/services live outside format-neutral MSC execution code; tests assert byte composition and call routing, never MSC format parsing.</li>
+          <li><code>test_object_service_and_inline_segments_reconstruct_complete_object</code></li>
+          <li><code>test_partial_range_touching_all_three_segment_kinds_returns_exact_slice</code></li>
+          <li><code>test_range_capable_and_whole_result_services_both_pass_acceptance_flow</code></li>
+          <li><code>test_enforced_service_revision_changes_between_plan_and_read_fail_atomically</code></li>
+          <li><code>test_existing_open_handle_stays_on_original_generation_and_continues_after_expiration_until_close</code></li>
+          <li><code>test_expired_view_refresh_creates_replacement_generation_and_new_bytes</code></li>
+          <li><code>test_plan_cannot_select_executor_implementation_endpoint_or_credentials</code></li>
+          <li><code>test_in_process_acceptance_uses_minimal_application_executor</code></li>
+          <li><code>test_assembly_import_is_opt_in_and_does_not_change_storage_client</code></li>
+          <li><code>test_assembly_is_not_registered_in_storage_provider_enum_or_factory</code></li>
+        </ul>
+
+        <h4>Repository-level verification gates (not new pytest cases)</h4>
+        <ul>
+          <li>The existing StorageClient and StorageProvider unit suites pass without modifying their expected behavior.</li>
+          <li>The reviewed change set contains no Assembly runtime or configuration changes in Rust, Go, or FUSE.</li>
+        </ul>
+      </section>
+
+      <section id="performance">
+        <h2>15. Performance and benchmark plan</h2>
+        <h3>Scenario matrix</h3>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Dimension</th><th>Values</th></tr></thead>
+            <tbody>
+              <tr><td>Objects per list</td><td>1, 1K, 100K, and the approved product maximum</td></tr>
+              <tr><td>List batching</td><td>1 object/batch, 1K objects/batch, encoded-byte-limited batches</td></tr>
+              <tr><td>Segments / encoded plan</td><td>1, 8, 64, 512, 4,096, 16,384, configured 100K boundary, and the approved product segment/encoded-byte maxima</td></tr>
+              <tr><td>Segment kind</td><td>object-only, service-only, inline-heavy at legal limit, mixed union</td></tr>
+              <tr><td>Logical read</td><td>4 KiB, 1 MiB, 64 MiB</td></tr>
+              <tr><td>Binding</td><td>StorageClient local, stable-subrange service, whole-result service, mixed</td></tr>
+              <tr><td>Service staging</td><td>below/at/above memory threshold; temp-file result at approved maximum; hard-limit rejection</td></tr>
+              <tr><td>Concurrency</td><td>1, 4, 16, 64 and multiple concurrent callers</td></tr>
+              <tr><td>Segment adjacency / object chunking</td><td>same binding, different binding, checksum/identity boundary, mixed, and intervals below/at/above object chunk size; v1 never crosses a segment boundary</td></tr>
+              <tr><td>List workload</td><td>full traversal, exact-name hit/miss, sequential/random lookup, browse index page</td></tr>
+              <tr><td>Cache state</td><td>cold descriptor/plan, warm plan, just-before/at/after expiration, replacement descriptor generation</td></tr>
+              <tr><td>Service scheduling</td><td>single request and 8, 64, or 512 independently ready segment requests dispatched through the single-request SPI</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Recorded measurements</h3>
+        <ul>
+          <li>Planner median/p95 and microseconds per segment.</li>
+          <li>List decode/traversal objects per second, exact-name lookup median/p95, time to first object, encoded bytes, and index build time.</li>
+          <li>Peak RSS for streaming codec traversal, scan-backed store, exact-name store, and browse pages as object count grows.</li>
+          <li>End-to-end median/p95, throughput, time to first internal chunk, and completion latency.</li>
+          <li>Core calls to <code>ServiceSegmentExecutor.execute</code>, result bytes, and source-byte amplification; executor-internal retries and transport metrics are executor-owned.</li>
+          <li>Peak RSS, output size, maximum in-flight response bytes, and plan cache footprint.</li>
+          <li>Complete-segment peak memory/temp-file bytes, stage count, core executor submissions, and read amplification.</li>
+          <li>High-water marks and wait time for active operations, output memory, stage memory/disk, and in-flight object-byte budgets across concurrent callers and retained readers.</li>
+          <li>Cancellation latency and active tasks/connections after failure.</li>
+        </ul>
+
+        <h3>Initial performance gates</h3>
+        <ul>
+          <li><strong>Blocking product-input gate:</strong> before implementation acceptance, product owners approve the maximum object count, maximum segments or encoded list bytes, exact lookup/traversal mix, and process memory envelope. Gate 0 cannot close with any value marked TBD.</li>
+          <li><code>test_large_list_full_traversal_stays_below_approved_latency_and_rss_limits</code> passes at the approved maximum using numeric Gate 0 thresholds.</li>
+          <li><code>test_large_list_exact_lookup_hit_and_miss_stay_below_approved_latency_limits</code> passes with the selected <code>AssemblyListStore</code> implementation.</li>
+          <li><code>test_large_list_batch_decode_peak_rss_stays_below_approved_bytes</code> proves batches do not accumulate accidentally against a concrete byte limit.</li>
+          <li><code>test_approved_max_segments_and_encoded_plan_bytes_meet_latency_and_memory_envelope</code> passes at both exact approved boundaries and rejects one over before I/O.</li>
+          <li>Gate 0 records the permitted planner time ratio between the approved <code>N</code> and <code>2N</code> segment cases; the benchmark fails when that numeric ratio is exceeded.</li>
+          <li>Observed concurrent source reads never exceed the configured client-wide ceiling.</li>
+          <li>Observed top-level operations, output-memory reservations, stage-memory/stage-disk reservations, and in-flight object bytes never exceed their client-wide limits under concurrent read/open/materialize/glob workloads; <code>max_active_operations=1</code> conveniences complete without nested-admission deadlock.</li>
+          <li>Object request count equals the sum of <code>ceil(selected_source_bytes / max_object_read_chunk_bytes)</code> per logical object operation: caller-intersection bytes normally, complete segment bytes when a checksum is supplied. V1 performs no cross-segment coalescing.</li>
+          <li>Peak Python read memory is bounded by up to twice the clamped returned length plus configured in-flight object/service chunks and complete-segment staging limits, not all unexecuted bytes.</li>
+          <li>WHOLE_RESULT core submission count is exactly one <code>execute</code> call per touched operation-local <code>(generation, plan_digest, segment_ordinal)</code> per top-level operation; this key is not reused across providers or bindings. Executor-internal SAFE attempts belong to that executor's own conformance tests. Successful cleanup removes private files; an injected unlink failure remains charged, is retried, and surfaces through the specified redacted error/close record rather than being reported as success.</li>
+          <li>Failure cancellation closes/drains queued work, internal waits, and cooperative service streams within the remaining operation deadline. A synchronous <code>StorageClient.read</code> already in progress is measured separately and is not claimed to be preemptible by Assembly.</li>
+        </ul>
+        <p>
+          Local benchmark throughput absolute numbers are recorded but do not block early pull requests because shared CI is noisy.
+          After Gate 0 records an approved same-machine regression percentage, nightly measurements beyond that numeric
+          threshold trigger investigation rather than an automatic functional failure.
+        </p>
+      </section>
+
+      <section id="rollout">
+        <h2>16. Incremental delivery plan and approval gates</h2>
+
+        <div class="phase">
+          <div class="phase-name">Gate 0<br><span class="small">Contract</span></div>
+          <div><strong>Approve contracts, limits, and product scale inputs.</strong> Freeze <code>assembly-list/v1</code>, expiration/refresh/in-flight semantics, union kinds, complete-plan/global-length invariant, both consistency policies, service range/retry rules, 16/64 KiB inline ceilings, complete-segment staging limits, exception taxonomy, and ownership. Record that v1 has internal cancellation only and that the current synchronous StorageClient call is checked before/after—but cannot be preempted by—the Assembly deadline. Keep the v1 object binding client-only, StorageClients always borrowed, and logical-byte caching disabled. Product owners must approve the proposed object-count, list-size/segment, workload, operational defaults, and memory envelope before those defaults become stable. Add golden fixtures; no runtime integration yet.</div>
+        </div>
+        <div class="phase">
+          <div class="phase-name">Gate 1<br><span class="small">Resolve and view</span></div>
+          <div><strong>Implement the metadata-to-executable pipeline.</strong> List codec/batches, canonical models, <code>resolve_descriptor</code>, complete-plan retrieval, validation, frozen binding registries, capability computation, and <code>AssemblyView.metadata</code>. No view is exposed and no byte I/O occurs before the complete plan passes.</div>
+        </div>
+        <div class="phase">
+          <div class="phase-name">Gate 2<br><span class="small">Core execution</span></div>
+          <div><strong>Implement the complete Python execution path.</strong> Direct StorageClient reads, user-defined ServiceSegmentExecutor wiring, inline bytes, bounded staging, range planning, client/view/reader, lifecycle, and atomic materialization. Core E2E must pass without an HTTP adapter or network server.</div>
+        </div>
+        <div class="phase">
+          <div class="phase-name">Gate 3<br><span class="small">Integration</span></div>
+          <div><strong>Exercise the complete union and third-party conformance.</strong> Range/whole-result user services, multiple StorageClients, inline limits, expiration/refresh, staging, lifecycle, redaction, failure injection, and unchanged existing MSC tests.</div>
+        </div>
+        <div class="phase">
+          <div class="phase-name">Gate 4<br><span class="small">Release</span></div>
+          <div><strong>Complete docs, benchmarks, and packaging.</strong> User guide, API reference, quickstart notebook, benchmark baseline, full build, and opt-in release note.</div>
+        </div>
+
+        <div class="callout info">
+          <strong>Post-core follow-up, not Gate 5:</strong> only after a separate generic HTTP-adapter proposal is approved
+          may work begin on that convenience adapter. Core release and stable-v1 evaluation do not wait for it.
+        </div>
+
+        <h3>Feature rollout</h3>
+        <ul>
+          <li>Ship only from the explicit <code>multistorageclient.assembly</code> namespace.</li>
+          <li>Keep logical output caching disabled throughout v1; descriptor and plan caches remain hard-bounded by descriptor expiration.</li>
+          <li>Keep <code>EXPIRATION_ONLY</code> as the documented default and require explicit construction for <code>SNAPSHOT_PINNED</code>.</li>
+          <li>Mark the distinct browse index optional/experimental until stable cursor and approved scale-envelope tests pass.</li>
+          <li>Do not automatically expose assembly through FUSE, fsspec, pathlib, CLI, sync, or <code>msc://</code>.</li>
+          <li>Collect protocol and performance evidence before considering a stable-v1 designation.</li>
+        </ul>
+      </section>
+
+      <section id="risks">
+        <h2>17. Risk register and definition of done</h2>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Risk</th><th>Mitigation / gate</th></tr></thead>
+            <tbody>
+              <tr><td>Expiration omitted, parsed differently, or extended through cache.</td><td>Mandatory canonical UTC field on batches/descriptors, one admission clock, hard cache expiry, missing/malformed/boundary tests.</td></tr>
+              <tr><td>Default mode is mistaken for snapshot consistency.</td><td>Name it EXPIRATION_ONLY, permit optional selectors/validators/revisions honestly, disable unsafe byte caching, and document same-length mutation risk.</td></tr>
+              <tr><td>Current StorageClient cannot atomically pin a mutable version.</td><td>Default direct read remains allowed; in v1, SNAPSHOT_PINNED requires complete checksum verification for object segments. A later additive conditional-read binding may enforce selectors or validators.</td></tr>
+              <tr><td>Complete service/checksum verification exhausts memory or disk.</td><td>Reserve each complete-segment stage immediately before launch, serialize individually feasible forward stages, enforce memory/result/temp ceilings, and verify length/digest before publication.</td></tr>
+              <tr><td>Unsafe service operation is retried.</td><td>RetrySafety defaults NEVER; NEVER permits one private attempt even if no response bytes arrive, only SAFE permits executor-owned bounded retry, and Assembly adds no outer retry.</td></tr>
+              <tr><td>Inline becomes a bulk-data path.</td><td>Hard 16 KiB per-segment and 64 KiB aggregate upper ceilings (configuration may only lower) plus encoded-plan limits.</td></tr>
+              <tr><td>Large lists make lookup/traversal or memory unusable.</td><td>Versioned batches, bounded public codec, AssemblyListStore contract, bounded small-list provider, and blocking product-envelope tests.</td></tr>
+              <tr><td>Provider returns huge or malicious plans.</td><td>Canonical bounded decoder and semantic validation before allocation/I/O.</td></tr>
+              <tr><td>Remote plans drive authority or credential escape.</td><td>Separate immutable object/service registries, least-privilege bound StorageClient namespaces, no plan-controlled client configuration, and executor-owned operation confinement.</td></tr>
+              <tr><td>Nested retries multiply attempts.</td><td>Assembly performs no outer source retry; SAFE service retries remain executor-owned and bounded, while NEVER remains exactly one attempt.</td></tr>
+              <tr><td>Python sync calls cannot be forcibly cancelled.</td><td>The deadline hard-bounds admission, internal waits, and cooperative provider/service work. Current StorageClient reads are checked before/after, use application-configured underlying timeouts, and may outlive the Assembly deadline; MSC makes no preemption claim.</td></tr>
+              <tr><td>Plan cache mixes bindings/provider generations or survives expiration.</td><td>Frozen concrete bindings, per-client registry-snapshot scope, hard expiry, and commit-after-validation; logical-byte caching is disabled in v1.</td></tr>
+              <tr><td>Scope expands back into StorageClient/provider hierarchy.</td><td>Import-boundary and private-provider regression tests; no factory/config changes in v1.</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Definition of done</h3>
+        <ul class="checklist">
+          <li>High-level API and capability approval gates are signed off.</li>
+          <li>All new public types have complete docstrings and Sphinx reference entries.</li>
+          <li>The versioned language-neutral list codec publishes golden vectors for batches and every explicit segment kind.</li>
+          <li>Provider and ServiceSegmentExecutor conformance suites are reusable outside the MSC repository.</li>
+          <li><code>resolve_descriptor</code> returns metadata only; <code>AssemblyClient.resolve</code> exposes an executable view only after complete-plan validation and binding freeze.</li>
+          <li><code>AssemblyView.metadata</code> returns the exact descriptor used to create that view.</li>
+          <li>Validation proves checked global logical length and rejects expired/malformed plans before object/service I/O.</li>
+          <li>A mixed object/service/inline plan passes full, partial, seekable, and materialization E2E cases through a user-defined in-process service executor with no HTTP-adapter dependency.</li>
+          <li>Expiration-only and snapshot-pinned guarantees are separately tested and documented; refresh always creates a new view for a replacement generation.</li>
+          <li>Range-capable and whole-result services pass stability, retry-safety, bounded complete-segment staging, and cleanup tests. For <code>RetrySafety.NEVER</code>, MSC proves there is no second core <code>execute()</code> invocation after pre-response or partial-stream failure; executor owners separately verify that their opaque implementation performs at most one private attempt.</li>
+          <li>Checksum-bearing object operations carry a complete <code>fetch_range</code> and a distinct <code>selected_range_in_fetch</code>, verify before copying that slice, and ordinary reads fetch only their intersection.</li>
+          <li>Deadline documentation and tests distinguish hard-bounded MSC/cooperative waits from non-preemptible synchronous StorageClient calls, and v1 makes no public caller-cancellation claim.</li>
+          <li>Private stage and materialization files use exclusive no-follow creation where supported and POSIX mode <code>0600</code>; published files retain the effective mode.</li>
+          <li>Every failed one-shot read/current reader call publishes no bytes from that call; a reader may already have returned a successful prefix in earlier calls, and v1 creates no logical-byte cache entry on either path.</li>
+          <li>No existing StorageClient/StorageProvider/config behavior changes.</li>
+          <li>Go/FUSE remains unchanged in the initial release; any future cross-language runtime consumes the normative list schema.</li>
+          <li>Focused Python tests, analyzer, existing unit suites, documentation build, and final repository build pass.</li>
+          <li>Product scale inputs are signed off and large-list traversal/exact-lookup/memory benchmarks are attached.</li>
+        </ul>
+      </section>
+
+      <section id="commands">
+        <h2>18. Verification commands and references</h2>
+        <h3>Focused development commands</h3>
+        <pre><code># Prepare the project environment
+just multi-storage-client/prepare-toolchain
+
+# Pure Python assembly suite
+cd multi-storage-client
+uv run pytest tests/test_multistorageclient/unit/assembly -q
+
+# Reproducible benchmark artifact using the Gate 0 thresholds
+uv run python tests/test_multistorageclient/benchmark/evaluate_assembly.py \
+  --output artifacts/assembly-benchmark.json
+
+# Return to repository root for project gates
+cd ..
+just multi-storage-client/analyze
+just multi-storage-client/run-unit-tests
+just multi-storage-client-docs/build
+just build</code></pre>
+
+        <h3>Current-code checks that informed this plan</h3>
+        <ul>
+          <li><code>client/client.py</code>: StorageClient currently delegates to Single or Composite clients.</li>
+          <li><code>client/types.py</code>: the public StorageClient contract has neither <code>close()</code> nor a per-read deadline/cancellation parameter; v1 therefore borrows clients and cannot preempt an in-progress synchronous read.</li>
+          <li><code>client/composite.py</code>: Composite routes a path to one child client; it is not a byte-assembly graph.</li>
+          <li><code>types.py</code>: StorageProvider is a broad mutable physical-backend contract.</li>
+          <li><code>client/single.py</code>: source version checks protect cache validation but do not supply an expected version to GET.</li>
+          <li><code>file.py</code>: the existing remote reader issues ordinary independent StorageClient range reads.</li>
+        </ul>
+
+        <h3>Core normative reference</h3>
+        <ul>
+          <li><a href="https://www.rfc-editor.org/rfc/rfc8785.html">RFC 8785 — JSON Canonicalization Scheme</a></li>
+        </ul>
+
+        <h3>Optional generic HTTP-adapter references</h3>
+        <p class="small">
+          These references inform only the separately approved transport follow-up. They do not define an Assembly core
+          dependency or an MSC-owned external service contract.
+        </p>
+        <ul>
+          <li><a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110 — HTTP Semantics</a></li>
+          <li><a href="https://www.rfc-editor.org/rfc/rfc9111.html">RFC 9111 — HTTP Caching</a></li>
+          <li><a href="https://www.rfc-editor.org/rfc/rfc8246.html">RFC 8246 — Immutable HTTP Responses</a></li>
+        </ul>
+
+        <p class="small">
+          Architectural rationale and the high-level public contract are in
+          <a href="high-level-design.html">Assembly Module — High-Level Design</a>. Adopter-facing
+          interface implementation and composition are in the
+          <a href="assembly-workflow-user-guide.html">Workflow User Guide</a>.
+        </p>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/specs/2026-07-21-assembly-view/implementation-and-test-plan.html
+++ b/specs/2026-07-21-assembly-view/implementation-and-test-plan.html
@@ -319,7 +319,7 @@
       </p>
       <div class="meta">
         <span>Spec date: 2026-07-21</span>
-        <span>Last revised: 2026-07-22</span>
+        <span>Last revised: 2026-08-25</span>
         <span>Status: Proposed</span>
         <span>Depends on: High-Level Design approval</span>
         <span>Initial release: Read-only and opt-in</span>
@@ -362,7 +362,7 @@
           <strong>Implement an independent Python assembly layer and a language-neutral list codec.</strong>
           The Python layer owns public contracts, expiration, complete-object validation, scheduling, and dispatch. Object
           segments use an injected existing <code>StorageClient</code>; service segments use a separate
-          <code>ServiceSegmentExecutor</code> SPI implemented by the user. The initial core release requires no built-in HTTP
+          <code>ServiceSegmentFetcher</code> SPI implemented by the user. The initial core release requires no built-in HTTP
           adapter. Existing StorageClient and StorageProvider behavior is not modified.
         </div>
 
@@ -374,8 +374,8 @@
           </div>
           <div class="card">
             <span class="label">Execution boundary</span>
-            <span class="value">StorageClient + Service Executor</span>
-            <p class="small">Object bytes use public MSC APIs; synthesized bytes use an independent service SPI.</p>
+            <span class="value">StorageClient + Service Fetcher</span>
+            <p class="small">Object bytes use public MSC APIs; service bytes use an independent fetch SPI.</p>
           </div>
           <div class="card">
             <span class="label">Transport boundary</span>
@@ -389,11 +389,12 @@
           <li>No <code>AssembledStorageProvider</code>, Provider-to-Provider ownership, or access to a client's private provider.</li>
           <li>No <code>StorageClient</code> subclass and no implicit registration in storage profiles, provider factories, or URI routing.</li>
           <li>No MSC-defined HTTP/gRPC contract for the plan service; only the in-process provider SPI is standardized.</li>
-          <li>No plan-supplied credentials, absolute origins, storage profiles, or arbitrary executable callbacks.</li>
+          <li>No plan-supplied credentials, unrestricted origins, storage profiles, or arbitrary executable callbacks. Any future opaque service locator remains subject to local fetcher policy.</li>
           <li>Every descriptor and portable-list snapshot has a mandatory expiration. The default <code>EXPIRATION_ONLY</code> policy does not pretend optional selectors, validators, or operation revisions are enforced; <code>SNAPSHOT_PINNED</code> is an explicit stricter opt-in.</li>
           <li>A read, materialization, or open-reader lifetime may cross expiration only if admitted while the descriptor was valid. New operations on that view fail until the caller explicitly resolves a new view.</li>
-          <li>Object, service, and inline segments remain an explicit public discriminated union; service transport adapters remain application-owned behind the public executor SPI.</li>
-          <li>The initial public API is synchronous, read-only, explicit, and importable from <code>multistorageclient.assembly</code>.</li>
+          <li>Object, service, and inline segments remain an explicit public discriminated union; service transport adapters remain application-owned behind the public fetcher SPI.</li>
+          <li>The initial public façade is synchronous, read-only, explicit, and importable from <code>multistorageclient.assembly</code>; the execution engine must still overlap independent I/O under bounded concurrency.</li>
+          <li><code>assembly-plan/v1</code> always denotes exact final bytes. Format-specific semantic projection is outside v1 and cannot be activated by an optional annotation.</li>
         </ul>
 
         <h3>Requirement alignment and proposal boundaries</h3>
@@ -408,7 +409,7 @@
           </div>
           <div class="card">
             <span class="label">Separate optional follow-up</span>
-            <p class="small">Requirements do not explicitly require a built-in HTTP executor, an MSC-defined external service API, or a format-specific executor. Any generic HTTP convenience adapter requires separate approval.</p>
+            <p class="small">Requirements do not explicitly require a built-in HTTP fetcher, an MSC-defined external service API, or a format-specific projection handler. Any generic HTTP convenience adapter requires separate approval.</p>
           </div>
         </div>
 
@@ -421,9 +422,9 @@
 
       <section id="topology">
         <h2>2. Component topology and dependency direction</h2>
-        <div class="architecture" role="img" aria-label="The application injects an AssemblyPlanProvider, StorageClient bindings, and ServiceSegmentExecutors into AssemblyClient. Python validates a complete object plan and dispatches its explicit segment union. Existing StorageClients remain owners of their StorageProviders.">
+        <div class="architecture" role="img" aria-label="The application injects an AssemblyPlanProvider, StorageClient bindings, and ServiceSegmentFetchers into AssemblyClient. Python validates a complete object plan and dispatches its explicit segment union. Existing StorageClients remain owners of their StorageProviders.">
           <div class="arch-row">
-            <div class="arch-node user"><strong>Plan provider</strong><br><code>AssemblyPlanProvider</code><br><span class="small">logical reference → valid descriptor generation + complete object plan</span></div>
+            <div class="arch-node user"><strong>Plan provider</strong><br><code>AssemblyPlanProvider</code><br><span class="small">logical request → metadata-bearing complete object plan</span></div>
             <div class="arch-node new"><strong>AssemblyClient / View</strong><br><span class="small">expiration policy and user API</span></div>
             <div class="arch-node new"><strong>Assembly caches</strong><br><span class="small">all instruction-derived entries expire with their descriptor</span></div>
           </div>
@@ -431,12 +432,12 @@
           <div class="arch-row">
             <div class="arch-node new"><strong>PlanValidator</strong><br><span class="small">expiration, union, global length, limits</span></div>
             <div class="arch-node new"><strong>ReadPlanner / Executor</strong><br><span class="small">range intersection, bounded fan-out, atomic scatter</span></div>
-            <div class="arch-node new"><strong>Binding registries</strong><br><span class="small">StorageClients and service executors</span></div>
+            <div class="arch-node new"><strong>Binding registries</strong><br><span class="small">StorageClients and service fetchers</span></div>
           </div>
-          <div class="arch-arrow">object reads · service executions · inline copies ↓</div>
+          <div class="arch-arrow">object reads · service fetches · inline copies ↓</div>
           <div class="arch-row">
             <div class="arch-node"><strong>ObjectSegmentExecutor</strong><br><span class="small">existing public StorageClient.read</span></div>
-            <div class="arch-node user"><strong>ServiceSegmentExecutor</strong><br><span class="small">STABLE_SUBRANGES or WHOLE_RESULT</span></div>
+            <div class="arch-node user"><strong>ServiceSegmentFetcher</strong><br><span class="small">STABLE_SUBRANGES or WHOLE_RESULT</span></div>
             <div class="arch-node new"><strong>Inline executor</strong><br><span class="small">bounded literal bytes, no I/O</span></div>
           </div>
           <div class="arch-arrow">↓ existing ownership is preserved</div>
@@ -448,13 +449,13 @@
         </div>
 
         <h3>One-way dependencies</h3>
-        <div class="formula">application → assembly module → public StorageClient API + service executor SPI → physical systems</div>
+        <div class="formula">application → assembly module → public StorageClient API + service fetcher SPI → physical systems</div>
         <ul>
           <li>The assembly package defines a frozen <code>ByteRange</code>. It may accept MSC's existing mutable <code>Range</code> only at a convenience edge and immediately copy it.</li>
           <li>Existing client and provider packages do not import the assembly package.</li>
-          <li>The plan provider does not receive StorageClient objects, service executors, credentials, or an executor.</li>
-          <li>A ServiceSegmentExecutor receives one service operation, never a full AssemblyPlan, and never interprets logical ordering.</li>
-          <li>A user service adapter translates one <code>ServiceExecutionRequest</code> to its own transport and never receives the complete plan.</li>
+          <li>The plan provider does not receive StorageClient objects, service fetchers, credentials, or an executor.</li>
+          <li>A ServiceSegmentFetcher receives one service operation, never a full AssemblyPlan, and never interprets logical ordering.</li>
+          <li>A user service adapter translates one <code>ServiceFetchRequest</code> to its own transport and never receives the complete plan.</li>
           <li>The language-neutral <code>assembly-list/v1</code> codec is independent of provider and service transport implementations.</li>
         </ul>
       </section>
@@ -466,19 +467,15 @@
         <div class="sequence">
           <div class="sequence-item">
             <strong>Normalize the request</strong>
-            <span><code>AssemblyClient.read</code> canonicalizes the reference and range, checks client state, and rejects limits before any provider, StorageClient, or service-executor call.</span>
+            <span><code>AssemblyClient.read</code> canonicalizes the reference and range, checks client state, and rejects limits before any provider, StorageClient, or service-fetcher call.</span>
           </div>
           <div class="sequence-item">
-            <strong>Resolve one valid descriptor generation</strong>
-            <span>The client calls <code>AssemblyPlanProvider.resolve_descriptor</code> once. Its <code>AssemblyDescriptor</code> is metadata only—reference, generation, size, expiration, and optional descriptive fields—and cannot read, open, or materialize bytes. The client rejects a substituted reference or generation and a missing, malformed, or expired <code>expires_at</code>. No view is observable yet.</span>
-          </div>
-          <div class="sequence-item">
-            <strong>Acquire the complete object plan</strong>
-            <span>The client calls <code>get_plan</code> for that exact descriptor. A provider may page its backend internally, but returns all ordered segments for the object and cannot substitute a different generation or a range-specific fragment.</span>
+            <strong>Acquire one complete object plan</strong>
+            <span>The client calls <code>AssemblyPlanProvider.get_plan(request)</code> once. The response contains a metadata-only <code>AssemblyDescriptor</code>—reference, generation, size, expiration, and optional descriptive fields—plus all ordered segments for that generation. A provider may page its backend internally, but it cannot substitute the requested reference or return a range-specific fragment. The client rejects a missing, malformed, or expired <code>expires_at</code>. No view is observable yet.</span>
           </div>
           <div class="sequence-item">
             <strong>Validate and publish the view</strong>
-            <span>The validator checks the segment discriminator, checked global length, hard inline limits, aliases, optional selectors/validators/operation revisions/checksums, and the selected consistency policy. It then freezes the resolved local source/service objects and computes capabilities. Only now does <code>AssemblyClient.resolve</code> return an executable <code>AssemblyView</code> containing the descriptor, validated complete plan, frozen bindings, consistency/capabilities, and lifecycle state. Refresh repeats this pipeline and returns another view.</span>
+            <span>The validator checks exact v1 result semantics, the segment discriminator, checked global length, hard inline limits, aliases, optional selectors/validators/operation revisions/checksums, and the selected consistency policy. It then freezes the resolved local source/service objects and computes capabilities. Only now does <code>AssemblyClient.resolve</code> return an executable <code>AssemblyView</code> containing the descriptor, validated complete plan, frozen bindings, consistency/capabilities, and lifecycle state. Another resolve call repeats this pipeline and returns another view.</span>
           </div>
           <div class="sequence-item">
             <strong>Intersect the caller range</strong>
@@ -486,15 +483,15 @@
           </div>
           <div class="sequence-item">
             <strong>Dispatch bounded operations</strong>
-            <span>Object segments call existing StorageClient APIs directly. Range-capable services receive stable subranges. Each touched WHOLE_RESULT stage key—descriptor generation, plan digest, and segment ordinal—gets one logical request submission per top-level operation and is staged under fixed memory/temp-file bounds before slicing; a SAFE executor may make multiple private transport attempts.</span>
+            <span>Object segments call existing StorageClient APIs directly. Range-capable services receive stable subranges. Each touched WHOLE_RESULT stage key—descriptor generation, plan digest, and segment ordinal—gets one logical fetch submission per top-level operation and is staged under fixed memory/temp-file bounds before slicing; a SAFE fetcher may make multiple private transport attempts.</span>
           </div>
           <div class="sequence-item">
             <strong>Verify every chunk</strong>
-            <span>Each binding enforces only capabilities present in its concrete contract: the initial object binding rejects selectors/enforcing validators, while service executors validate advertised revision and retry semantics. A checksum may be absent, but when supplied MSC always stages and verifies the complete segment before exposing any slice.</span>
+            <span>Each binding enforces only capabilities present in its concrete contract: the initial object binding rejects selectors/enforcing validators, while service fetchers validate advertised revision and retry semantics. A checksum may be absent, but when supplied MSC always stages and verifies the complete segment before exposing any slice.</span>
           </div>
           <div class="sequence-item">
             <strong>Commit atomically</strong>
-            <span>Verified chunks scatter incrementally into a private destination buffer; only after every chunk passes may the executor return immutable bytes. V1 publishes no logical-byte cache entry.</span>
+            <span>Verified chunks scatter incrementally into a private destination buffer; only after every chunk passes may the execution engine return immutable bytes. V1 publishes no logical-byte cache entry.</span>
           </div>
         </div>
 
@@ -504,7 +501,7 @@
           every unpublished chunk and staged output, and returns one stable domain exception. The token is internal in v1: MSC
           signals it after a sibling failure or parent-client close; the synchronous public façade has no caller-supplied
           cancellation input. The absolute operation deadline strictly bounds admission and MSC-owned waits. A provider or
-          service executor receives that deadline and must honor it cooperatively. The current synchronous
+          service fetcher receives that deadline and must honor it cooperatively. The current synchronous
           <code>StorageClient.read</code> accepts neither a deadline nor a cancellation token, so MSC can check the deadline
           before and after the call but cannot preempt an in-progress read. Applications must configure the StorageClient's
           underlying transport timeouts and retry envelope accordingly; a late result is discarded after the deadline is
@@ -531,6 +528,21 @@
           the complete <code>AssemblyPlan</code>, freezes local bindings, computes consistency/capabilities, and initializes
           lifecycle state. <code>AssemblyView.metadata</code> returns the exact descriptor captured by that view.
         </div>
+
+        <div class="callout">
+          <strong>V1 result semantics are exact and permanent.</strong> <code>assembly-plan/v1</code> always describes the
+          caller's complete final logical bytes. Optional application annotations are informational and cannot require a
+          format-specific projection step. Any future carrier-plus-projection contract uses a new plan version, a required
+          capability, and a separate format-aware façade; a v1 client must reject it rather than silently materialize a superset.
+        </div>
+
+        <h3>API and protocol evolution rules</h3>
+        <ul>
+          <li>Unknown list/plan versions, required capabilities, segment kinds, and fields are rejected before binding or byte I/O. Supporting a future version never changes the interpretation of a valid v1 artifact.</li>
+          <li>Published provider and fetcher ABCs never gain a required abstract method within v1. Optional behavior uses a concrete default method or a new versioned SPI.</li>
+          <li>New façade and configuration parameters are keyword-only and carry backward-compatible defaults. New serialized model semantics require a new versioned type.</li>
+          <li>A future format-aware projection façade is additive and separate from <code>AssemblyView</code>; existing callers continue to receive the exact bytes defined by v1.</li>
+        </ul>
 
         <div class="callout info">
           <strong>Gate 0 status.</strong> Numeric operational defaults shown in this section are proposed inputs, not stable API
@@ -680,11 +692,6 @@ class AssemblyDescriptor:
     published_at: datetime | None = None
 
 @dataclass(frozen=True, slots=True)
-class RefreshAssemblyRequest:
-    previous: AssemblyDescriptor
-    deadline_monotonic: float | None = field(default=None, compare=False, hash=False, repr=False)
-
-@dataclass(frozen=True, slots=True)
 class ListAssembliesRequest:
     namespace: str
     prefix: str = ""
@@ -717,7 +724,7 @@ class ObjectSegment:
 @dataclass(frozen=True, slots=True)
 class ServiceSegment:
     kind: Literal["service"]
-    executor_id: str
+    fetcher_id: str
     operation: str
     parameters: FrozenJsonObject
     length: int
@@ -746,6 +753,7 @@ class AssemblyObjectDefinition:
 @dataclass(frozen=True, slots=True)
 class AssemblyPlan:
     schema_version: Literal["assembly-plan/v1"]
+    result_semantics: Literal["exact"]
     descriptor: AssemblyDescriptor
     segments: tuple[AssemblySegment, ...]
     plan_digest: str
@@ -755,6 +763,7 @@ class AssemblyPlan:
         cls,
         *,
         schema_version: Literal["assembly-plan/v1"],
+        result_semantics: Literal["exact"] = "exact",
         descriptor: AssemblyDescriptor,
         segments: Sequence[AssemblySegment],
     ) -> "AssemblyPlan": ...
@@ -814,15 +823,14 @@ def write_assembly_list_batches(
         <h3 id="public-facade-reference">Exact public façade reference</h3>
         <p>
           The high-level design intentionally shows only the common workflow. This subsection is the normative signature
-          reference for the façade, view, reader, optional browsing iterator, and their advertised capabilities. Provider
-          code returns descriptors; only the client returns views.
+          reference for the façade, view, reader, optional browsing iterator, and their advertised capabilities. Providers
+          return metadata-bearing plans; only the client returns views.
         </p>
         <pre><code>RangeLike = ByteRange | multistorageclient.types.Range  # copied immediately to ByteRange
 
 @dataclass(frozen=True, slots=True)
 class AssemblyCapabilities:
     browse: bool
-    refresh: bool
 
 @dataclass(frozen=True, slots=True)
 class AssemblyViewCapabilities:
@@ -837,7 +845,7 @@ class AssemblyClient:
         *,
         plan_provider: AssemblyPlanProvider,
         object_sources: Mapping[str, ObjectSourceBinding],
-        service_executors: Mapping[str, ServiceSegmentExecutor],
+        service_fetchers: Mapping[str, ServiceSegmentFetcher],
         config: AssemblyClientConfig | None = None,
         close_dependencies: bool = False,
     ) -> None: ...
@@ -855,17 +863,15 @@ class AssemblyClient:
         """Return only after descriptor, complete plan, bindings, and capabilities are valid."""
         ...
 
-    def refresh(self, view: AssemblyView, *, required_consistency: AssemblyConsistency | None = None) -> AssemblyView: ...
     def info(
         self,
         reference: AssemblyReference | str,
         *,
         generation: str | None = None,
     ) -> AssemblyDescriptor:
-        """Resolve descriptor metadata only.
+        """Resolve and validate the complete plan, then return its descriptor.
 
-        Do not call get_plan, resolve bindings, compute executable
-        consistency, or perform object/service byte I/O.
+        Do not perform object/service byte I/O.
         """
         ...
     def read(self, reference: AssemblyReference | str, byte_range: RangeLike | None = None, *, generation: str | None = None, required_consistency: AssemblyConsistency | None = None) -> bytes: ...
@@ -920,10 +926,10 @@ class AssemblyGlobIterator(Iterator[AssemblyDescriptor]):
     def __exit__(self, *exc: object) -> None: ...</code></pre>
 
         <p class="small">
-          <code>AssemblyClient.info()</code> is intentionally descriptor-only: it validates the reference, requested generation,
-          descriptor model, and expiration, but never calls <code>get_plan</code>, inspects object or service bindings, computes
-          executable consistency, or performs byte I/O. Call <code>resolve()</code> when a validated executable view or a
-          consistency guarantee is required.
+          <code>AssemblyClient.info()</code> calls the same single <code>get_plan(request)</code> SPI as resolution because the
+          provider has no separate descriptor lookup. It validates the plan and descriptor agreement but does not resolve
+          byte-I/O bindings, compute executable capabilities, or perform object/service byte I/O. Call <code>resolve()</code>
+          when an executable view or consistency guarantee is required.
         </p>
         <p class="small">
           Browsing is optional and is advertised by <code>AssemblyCapabilities.browse</code>. The exact configuration fields,
@@ -939,16 +945,17 @@ class AssemblyGlobIterator(Iterator[AssemblyDescriptor]):
           definition cannot be split between batches. This gives streaming traversal a bounded batch envelope while allowing
           an <code>AssemblyListStore</code> to choose a memory, disk, or remote exact-name index. That executable list is distinct from
           the optional browsing index: browse pages contain names/metadata/cursors and cannot be passed to the executor.
-          The v1 artifact intentionally carries no refresh locator: refresh auth/transport is provider-owned through
-          <code>AssemblyPlanProvider.refresh</code>. StaticAssemblyListProvider is non-refreshable; a custom provider may keep
-          an artifact-carried or out-of-band locator internally and must still return a new identity/expiration.
+          The v1 artifact intentionally carries no refresh locator. A replacement list or plan is obtained by another
+          <code>get_plan(request)</code> through application-owned provider transport and authentication; the previous identity
+          and expiration are never extended in place.
         </p>
         <p>
           <code>plan_digest</code> is a provider-supplied canonical instruction digest that MSC recomputes and verifies; the
           <code>AssemblyPlan.create</code> convenience computes it for direct-model providers. It is not a required expected
           digest of output bytes.
           It is <code>sha256:&lt;64 lowercase hex characters&gt;</code> over the UTF-8 RFC 8785 JSON Canonicalization Scheme
-          projection containing exactly <code>schema_version</code>, <code>descriptor</code>, and the ordered discriminated
+          projection containing exactly <code>schema_version</code>, <code>result_semantics</code>,
+          <code>descriptor</code>, and the ordered discriminated
           <code>segments</code>. It excludes itself and execution-only deadlines. The list codec uses UTC RFC 3339 timestamps
           with exactly six fractional-second digits and <code>Z</code>, rejects timezone-naive values and unknown fields/kinds,
           and represents inline bytes as canonical unpadded base64url. <code>FrozenJsonArray</code> and
@@ -991,7 +998,7 @@ checksum := {"algorithm": "sha256", "value": lower_hex_64_without_prefix}</code>
        "byte_range": {"offset": integer, "size": integer}, "length": integer,
        "selector": source_selector | null, "validator": source_validator | null,
        "checksum": checksum | null},
-      {"kind": "service", "executor_id": string, "operation": string,
+      {"kind": "service", "fetcher_id": string, "operation": string,
        "parameters": json_object, "length": integer,
        "range_mode": "stable_subranges" | "whole_result",
        "retry_safety": "never" | "safe",
@@ -1022,8 +1029,8 @@ checksum := {"algorithm": "sha256", "value": lower_hex_64_without_prefix}</code>
 
         <h3>Local binding authority and hard inline limits</h3>
         <p>
-          Object source and service aliases are local. A list cannot choose a profile, client, endpoint, credentials, or
-          executor implementation. Validation resolves each alias and freezes the concrete local object in the view. An object
+          Object source and service aliases are local. A list cannot choose a profile, client, unrestricted endpoint,
+          credentials, or fetcher implementation. Validation resolves each alias and freezes the concrete local object in the view. An object
           resource is interpreted only through the bound StorageClient's existing public logical-path semantics; it cannot
           reconfigure that client or select authority outside it. Applications must therefore bind a least-privilege logical
           namespace appropriate for every plan they accept. V1 adds no provider-specific narrower-path policy on top of that
@@ -1043,7 +1050,7 @@ checksum := {"algorithm": "sha256", "value": lower_hex_64_without_prefix}</code>
               <tr><td>Optional identity/checksum fields</td><td>All may be absent. The initial object binding rejects selectors/enforcing validators but accepts identity-only metadata; service revisions are enforced only when advertised. Identity-only values cannot imply snapshot safety.</td><td>Each object segment needs a verified complete checksum in v1; each service segment needs an advertised enforced revision or verified complete checksum.</td></tr>
               <tr><td>Same-length mutation</td><td>May be undetectable and is documented as such.</td><td>Must fail closed before publishing bytes.</td></tr>
               <tr><td>Cross-operation byte cache</td><td colspan="2">Disabled in v1. Consistency computation still determines what the view may claim, but it does not enable a logical-byte cache.</td></tr>
-              <tr><td>Refresh</td><td colspan="2"><code>AssemblyClient.refresh(view)</code> resolves a replacement and returns a new view with a new <code>generation</code>/<code>expires_at</code>; it never extends or mutates the old view, and a None consistency argument preserves the old view's originally requested minimum.</td></tr>
+              <tr><td>Replacement</td><td colspan="2">There is no public refresh operation. Another <code>resolve(reference)</code> obtains and validates a replacement plan/view with its own <code>generation</code> and <code>expires_at</code>; it never extends or mutates the old view.</td></tr>
               <tr><td>In-flight expiration</td><td colspan="2">An operation admitted while valid may finish. A subsequent operation on the old view is rejected.</td></tr>
             </tbody>
           </table>
@@ -1071,26 +1078,12 @@ checksum := {"algorithm": "sha256", "value": lower_hex_64_without_prefix}</code>
         </p>
 
 <pre><code>class AssemblyPlanProvider(ABC):
-    @property
-    def supports_refresh(self) -> bool:
-        """Immutable explicit capability; override together with refresh."""
-        return False
-
-    @abstractmethod
-    def resolve_descriptor(self, request: ResolveAssemblyRequest) -> AssemblyDescriptor:
-        """Resolve a named object as one fixed, unexpired generation."""
-
     @abstractmethod
     def get_plan(
         self,
-        descriptor: AssemblyDescriptor,
-        *,
-        deadline_monotonic: float | None = None,
+        request: ResolveAssemblyRequest,
     ) -> AssemblyPlan:
-        """Return every ordered segment for the descriptor's complete object."""
-
-    def refresh(self, request: RefreshAssemblyRequest) -> AssemblyDescriptor:
-        raise AssemblyCapabilityError()
+        """Return descriptor metadata and every ordered segment."""
 
     def close(self) -> None:
         pass
@@ -1138,17 +1131,17 @@ class StaticAssemblyListProvider(BrowsableAssemblyPlanProvider):
 
         <h3>Contract choices</h3>
         <ul>
-          <li><code>resolve_descriptor</code> and <code>get_plan</code> are separate provider calls so metadata pins one descriptor generation before plan retrieval. <code>resolve_descriptor</code> returns only an <code>AssemblyDescriptor</code>; it never returns an executable object or exposes <code>read</code>, <code>open</code>, or <code>materialize</code>. <code>AssemblyClient.resolve</code> invokes both provider calls, validates the complete plan, freezes local bindings, computes capabilities, and returns no <code>AssemblyView</code> until every step succeeds. <code>get_plan(descriptor, *, deadline_monotonic=...)</code> receives the pinned descriptor directly and no byte range.</li>
-          <li><code>AssemblyCapabilities.refresh</code> captures the provider's immutable exact-bool <code>supports_refresh</code> value at construction. <code>refresh</code> rejects false before a provider call; StaticAssemblyListProvider advertises false, and a refreshable provider overrides both property and method.</li>
+          <li><code>get_plan(request)</code> is the single required provider call. It returns a metadata-only <code>AssemblyDescriptor</code> inside one complete exact-result plan and never returns an executable object or a range-specific fragment. <code>AssemblyClient.resolve</code> validates the response, freezes local bindings, computes capabilities, and returns no <code>AssemblyView</code> until every step succeeds.</li>
+          <li>There is no public provider or client refresh method. Another <code>resolve(reference)</code> repeats the same single-call pipeline and returns a distinct view. Any future automatic re-resolution policy is separately approved and must never start work from a hard-expired plan.</li>
           <li>No provider binding revision is required or echoed by the descriptor. Core instruction caches are scoped to one <code>AssemblyClient</code> and its concrete provider instance; they are never reused across provider instances.</li>
           <li><code>get_plan</code> returns one complete object plan. Backend/list batching is an implementation detail; a partial segment page never enters the validator or executor.</li>
-          <li><code>StaticAssemblyListProvider</code> is the reference concrete-list surface. For each object definition it sets <code>descriptor.generation = snapshot.list_id</code> and <code>descriptor.expires_at = snapshot.expires_at</code>; reference, size, ETag, content type, and publication time come from that object definition. It constructs the plan with <code>assembly-plan/v1</code> and computes the canonical plan digest locally. The batch-iterator convenience applies default or supplied <code>AssemblyListDecodeLimits</code> structurally even to direct-model batches, then enforces <code>InMemoryAssemblyListLimits</code> over aggregate objects, segments, and canonical bytes before commit. Exact canonical bytes exclude newline framing, but measurement streams into a capped counter/digest sink using the smaller remaining per-batch/aggregate allowance; it aborts at one over and never materializes a full encoding only to measure. Large deployments inject a replayable <code>AssemblyListStore</code>.</li>
+          <li><code>StaticAssemblyListProvider</code> is the reference concrete-list surface. For each object definition it sets <code>descriptor.generation = snapshot.list_id</code> and <code>descriptor.expires_at = snapshot.expires_at</code>; reference, size, ETag, content type, and publication time come from that object definition. It constructs an exact-result <code>assembly-plan/v1</code> and computes the canonical plan digest locally. The batch-iterator convenience applies default or supplied <code>AssemblyListDecodeLimits</code> structurally even to direct-model batches, then enforces <code>InMemoryAssemblyListLimits</code> over aggregate objects, segments, and canonical bytes before commit. Exact canonical bytes exclude newline framing, but measurement streams into a capped counter/digest sink using the smaller remaining per-batch/aggregate allowance; it aborts at one over and never materializes a full encoding only to measure. Large deployments inject a replayable <code>AssemblyListStore</code>.</li>
           <li>An <code>AssemblyListStore</code> declares one immutable snapshot, exact lookup, and traversal. Its conformance suite verifies stable results, fully validated batch provenance, close behavior, and the approved cost/memory envelope.</li>
           <li>Browsing is a separate optional <code>BrowsableAssemblyPlanProvider</code> capability. Its pages and cursors are stable metadata views, not fragments of executable assembly lists.</li>
-          <li><code>resolve_descriptor</code>, <code>get_plan</code>, and optional <code>list</code> are unconditionally thread-safe in v1; close begins only after the application stops new operations.</li>
-          <li>The synchronous v1 contract matches the current StorageClient surface. A later async API must use separate classes/methods, not silently change blocking behavior.</li>
+          <li><code>get_plan</code> and optional <code>list</code> are unconditionally thread-safe in v1; close begins only after the application stops new operations.</li>
+          <li>The synchronous provider and public façade contracts match the current StorageClient style. Internally, Assembly overlaps independent source/fetcher I/O; the exact async fetcher surface is a separate approval gate and does not imply a Rust implementation.</li>
           <li>Provider retries are internal and bounded. AssemblyClient does not layer general retries around provider calls.</li>
-          <li>There is no automatic refresh. <code>AssemblyClient.refresh(view)</code> asks the provider for a replacement and returns a distinct view; a None consistency argument preserves the old view's originally requested minimum, while only an explicit override changes it. Failure leaves the old view unchanged: a still-valid, open view remains usable, while an expired or closed view remains unusable.</li>
+          <li>Until automatic re-resolution is approved, expiration remains a hard admission check. A caller obtains a replacement through another resolve call; failure leaves the old view unchanged and an expired or closed view remains unusable.</li>
         </ul>
 
         <h3 id="provider-error-contract">Provider error contract</h3>
@@ -1161,7 +1154,7 @@ class StaticAssemblyListProvider(BrowsableAssemblyPlanProvider):
               <tr><td><code>AssemblyProviderAuthenticationError</code></td><td>The provider backend rejected credentials after its own safe refresh attempt.</td><td>Do not add an authentication retry.</td></tr>
               <tr><td><code>AssemblyProviderRetryableError</code></td><td>The provider exhausted its bounded retries on a transient failure.</td><td>Do not add an outer retry loop.</td></tr>
               <tr><td><code>InvalidAssemblyPlanError</code></td><td>The provider returned a structurally or semantically invalid plan.</td><td>Fail before source I/O and record a contract violation.</td></tr>
-              <tr><td><code>AssemblyCapabilityError</code></td><td>Refresh, browsing, or requested consistency is unsupported.</td><td>Fail without fallback or implicit downgrade.</td></tr>
+              <tr><td><code>AssemblyCapabilityError</code></td><td>Browsing or requested consistency is unsupported.</td><td>Fail without fallback or implicit downgrade.</td></tr>
               <tr><td><code>AssemblyProviderError</code></td><td>An unexpected provider <code>Exception</code>.</td><td>Retain only a safe type token and discard the original object and message.</td></tr>
             </tbody>
           </table>
@@ -1175,7 +1168,7 @@ class StaticAssemblyListProvider(BrowsableAssemblyPlanProvider):
         <p>
           <code>multistorageclient.assembly.testing</code> exposes reusable pytest cases/factories. It proves behavior rather
           than transport shape: mandatory expiration, stable descriptor generation, complete-object coverage, deterministic exceptions,
-          limits, concurrency claims, and lifecycle. A separate suite covers <code>ServiceSegmentExecutor</code>; neither suite
+          limits, concurrency claims, and lifecycle. A separate suite covers <code>ServiceSegmentFetcher</code>; neither suite
           is coupled to HTTP payloads or endpoint names.
         </p>
 
@@ -1227,11 +1220,11 @@ class StaticAssemblyListProvider(BrowsableAssemblyPlanProvider):
         <h3>Validation order</h3>
         <ol>
           <li>Validate reference, schema/list versions, mandatory <code>expires_at</code>, and configured limits. Require <code>descriptor.reference == request.reference</code> and, when <code>request.generation</code> is non-None, <code>descriptor.generation == request.generation</code>; reject a silent fall-forward before plan/source I/O. Text limits count strict UTF-8 bytes; semantic parameter depth includes the parameter root object, while codec depth includes the complete document root (default 64 versus semantic 32). Recursive item count includes object members/array elements, and parameter bytes use exact RFC 8785 encoding.</li>
-          <li>At operation admission, compare one captured UTC clock value with <code>expires_at</code>; equality is expired. Reject before provider plan lookup when a cached descriptor is already expired.</li>
+          <li>At plan or view-operation admission, compare one captured UTC clock value with <code>expires_at</code>; equality is expired. Reject a newly returned plan or cached validated plan/view before binding or source/service byte I/O. An explicit later <code>resolve(reference)</code> may call the provider to obtain a replacement generation.</li>
           <li>Validate that the complete plan echoes the descriptor, then perform cheap structural checks before canonical encoding: exact model types, segment tuple count, discriminator, strict integers, text byte limits, parameter depth/item/canonical-byte limits, inline decoded limits, and checksum/revision grammar. Reject immediately on the first bound violation.</li>
           <li>Tuple order is logical order. Validate every positive length/object range with checked arithmetic; compute the checked sum of every segment length and require it to equal <code>descriptor.size</code>, including for a partial caller read.</li>
-          <li>Stream the exact RFC 8785 digest projection (schema version, descriptor, ordered segments; no digest/deadline) into both SHA-256 and a capped byte counter. Do not construct a second complete encoding. Equality with <code>max_plan_bytes</code> is accepted; abort as soon as byte <code>max_plan_bytes + 1</code> would be emitted, then verify <code>plan_digest</code>. The same bounded path handles decoded and direct-model providers.</li>
-          <li>Resolve object aliases to existing StorageClients and service aliases to ServiceSegmentExecutors, then freeze those concrete local objects. Instruction caches remain scoped to this client and frozen registry snapshot; v1 exposes no binding identity for cross-registry reuse.</li>
+          <li>Stream the exact RFC 8785 digest projection (schema version, result semantics, descriptor, ordered segments; no digest/deadline) into both SHA-256 and a capped byte counter. Do not construct a second complete encoding. Equality with <code>max_plan_bytes</code> is accepted; abort as soon as byte <code>max_plan_bytes + 1</code> would be emitted, then verify <code>plan_digest</code>. The same bounded path handles decoded and direct-model providers.</li>
+          <li>Resolve object aliases to existing StorageClients and service aliases to ServiceSegmentFetchers, then freeze those concrete local objects. Instruction caches remain scoped to this client and frozen registry snapshot; v1 exposes no binding identity for cross-registry reuse.</li>
           <li>Validate service modes/retry declarations, binding support for optional selectors/validators/operation revisions/checksums, staging feasibility, computed capabilities, and the selected <code>AssemblyConsistency</code> requirements.</li>
           <li>Normalize and bounds-check the caller's half-open logical range, intersect it with the already validated full plan, then allocate or stage output and begin I/O.</li>
         </ol>
@@ -1241,7 +1234,7 @@ class StaticAssemblyListProvider(BrowsableAssemblyPlanProvider):
         <p>
           Python checks every canonical integer and addition against the interoperable <code>2**53 - 1</code> ceiling before
           allocation or dispatch. A zero-length logical read returns <code>b""</code> without segment I/O, but plan validation
-          still occurs when required to prove the descriptor's complete-object definition and global length. A user executor
+          still occurs when required to prove the descriptor's complete-object definition and global length. A user fetcher
           owns any conversion to its transport's range convention.
         </p>
 
@@ -1259,7 +1252,7 @@ class ObjectReadOperation:
 
 @dataclass(frozen=True, slots=True)
 class ServiceReadOperation:
-    executor_id: str
+    fetcher_id: str
     operation: str
     parameters: FrozenJsonObject
     full_result_length: int
@@ -1294,7 +1287,7 @@ class ServiceReadOperation:
       </section>
 
       <section id="sources">
-        <h2>7. Object bindings and ServiceSegmentExecutor SPI</h2>
+        <h2>7. Object bindings and ServiceSegmentFetcher SPI</h2>
 
         <p>
           The complete v1 public object-binding surface is <code>ObjectSourceBinding(client=storage_client)</code>. The binding
@@ -1302,10 +1295,10 @@ class ServiceReadOperation:
           provider, cache-identity, ownership, or provider-specific path-policy controls.
         </p>
         <p>
-          For service fulfillment, only <code>range_modes</code> and <code>execute</code> are abstract. The optional
+          For service fulfillment, only <code>range_modes</code> and <code>fetch</code> are abstract. The optional
           <code>snapshot_revision_kinds</code> and <code>thread_safe</code> capabilities have conservative defaults, and
           <code>close</code> is an optional lifecycle hook. Every capability property must remain immutable for the lifetime of
-          the injected executor; AssemblyClient captures and validates those values before exposing a view.
+          the injected fetcher; AssemblyClient captures and validates those values before exposing a view.
         </p>
 
         <pre><code>class CancellationToken(Protocol):
@@ -1325,14 +1318,14 @@ class ObjectSourceBinding:
     client: StorageClient = field(repr=False, compare=False, hash=False)
 
 @dataclass(frozen=True, slots=True)
-class ServiceExecutionRequest:
+class ServiceFetchRequest:
     segment: ServiceSegment
     requested_range: ByteRange | None  # non-None only for STABLE_SUBRANGES
 
 class ServiceResultStream(Iterator[bytes], Protocol):
     def close(self) -> None: ...
 
-class ServiceSegmentExecutor(ABC):
+class ServiceSegmentFetcher(ABC):
     @property
     @abstractmethod
     def range_modes(self) -> frozenset[ServiceRangeMode]: ...
@@ -1347,9 +1340,9 @@ class ServiceSegmentExecutor(ABC):
         return False
 
     @abstractmethod
-    def execute(
+    def fetch(
         self,
-        request: ServiceExecutionRequest,
+        request: ServiceFetchRequest,
         *,
         context: SourceReadContext,
     ) -> ServiceResultStream:
@@ -1359,28 +1352,36 @@ class ServiceSegmentExecutor(ABC):
         pass</code></pre>
 
         <div class="callout info">
-          The core release expects a user-owned implementation such as <code>MyServiceExecutor</code>. It translates one
-          <code>ServiceExecutionRequest</code> into the user's HTTP, gRPC, SDK, or local-service call. It never receives an
+          The core release expects a user-owned implementation such as <code>MyServiceFetcher</code>. It translates one
+          <code>ServiceFetchRequest</code> into the user's HTTP, gRPC, SDK, or local-service call. It never receives an
           <code>AssemblyPlan</code>, never decides segment ordering, and returns only the byte stream for one service segment
           while honoring declared length/range mode, the shared deadline, and cooperative cancellation. MSC standardizes
           this in-process SPI, not the user's external wire contract.
         </div>
 
+        <div class="callout">
+          <strong>One request means one independently executable segment.</strong> V1 has no multi-range service batch call
+          and assumes no sticky session or hidden ordering state. The client overlaps independent fetches under bounded
+          concurrency and relies on the application transport for connection pooling or multiplexing. The service
+          <code>operation</code> and <code>parameters</code> are interpreted and confined by the locally selected fetcher;
+          plans never supply credentials. Any future locator requires separate approval and the same local-policy boundary.
+        </div>
+
         <h3>Frozen binding registries</h3>
         <ul>
-          <li>AssemblyClient defensively copies separate <code>object_sources: Mapping[str, ObjectSourceBinding]</code> and <code>service_executors: Mapping[str, ServiceSegmentExecutor]</code>; malformed or duplicate aliases fail construction. Either mapping may be empty when the resolved plan uses none of that segment kind.</li>
-          <li>Plans select only aliases. They cannot construct a client/executor or mutate endpoint, profile, prefix, credentials, or retry policy.</li>
+          <li>AssemblyClient defensively copies separate <code>object_sources: Mapping[str, ObjectSourceBinding]</code> and <code>service_fetchers: Mapping[str, ServiceSegmentFetcher]</code>; malformed or duplicate aliases fail construction. Either mapping may be empty when the resolved plan uses none of that segment kind.</li>
+          <li>Plans select only aliases. They cannot construct a client/fetcher or mutate endpoint, profile, prefix, credentials, or retry policy.</li>
           <li>The complete public object binding is <code>ObjectSourceBinding(client=storage_client)</code>. MSC freezes that concrete association in each view. The plan's <code>resource</code> is a logical path inside that client's already configured public namespace; it cannot reconfigure or expand the client authority. Applications bind a least-privilege namespace suitable for every accepted plan. V1 adds no provider-specific narrower path policy.</li>
           <li>StorageClients are always borrowed and never closed by AssemblyClient. Calls to each distinct StorageClient object are conservatively serialized across aliases and views.</li>
-          <li><code>snapshot_revision_kinds</code> defaults empty. A kind may be advertised only when the executor enforces that revision and it is sufficient, with operation and parameters, to pin the complete result bytes.</li>
-          <li><code>range_modes</code>, <code>snapshot_revision_kinds</code>, and <code>thread_safe</code> are immutable for the injected executor's lifetime. AssemblyClient captures exact validated values before view exposure. <code>thread_safe=False</code> serializes calls to the same executor across aliases and views; an exact <code>True</code> opts that executor into client-wide concurrency.</li>
-          <li>The same client or executor may appear under multiple aliases. A transferred service executor is closed at most once; a StorageClient remains borrowed under every alias.</li>
-          <li>The same Python object identity cannot occupy different dependency roles (plan provider, service executor, StorageClient). A backend serving multiple roles uses distinct adapters; construction rejects cross-role identity reuse so ownership and <code>CloseFailure</code> remain unambiguous.</li>
-          <li>The plan provider and service executors are borrowed by default. <code>close_dependencies=True</code> transfers only those dependencies to AssemblyClient; it never transfers a StorageClient.</li>
-          <li>On failure AssemblyClient signals the shared cancellation token, attempts every service-stream close and shared-stage cleanup, and cancels queued work. A user executor observes that token through <code>SourceReadContext</code>; custom blocking I/O remains cooperative and must obey the context deadline. Failed stage artifacts follow the retained-reservation/orphan rules below.</li>
+          <li><code>snapshot_revision_kinds</code> defaults empty. A kind may be advertised only when the fetcher enforces that revision and it is sufficient, with operation and parameters, to pin the complete result bytes.</li>
+          <li><code>range_modes</code>, <code>snapshot_revision_kinds</code>, and <code>thread_safe</code> are immutable for the injected fetcher's lifetime. AssemblyClient captures exact validated values before view exposure. <code>thread_safe=False</code> serializes calls to the same fetcher across aliases and views; an exact <code>True</code> opts that fetcher into client-wide concurrency.</li>
+          <li>The same client or fetcher may appear under multiple aliases. A transferred service fetcher is closed at most once; a StorageClient remains borrowed under every alias.</li>
+          <li>The same Python object identity cannot occupy different dependency roles (plan provider, service fetcher, StorageClient). A backend serving multiple roles uses distinct adapters; construction rejects cross-role identity reuse so ownership and <code>CloseFailure</code> remain unambiguous.</li>
+          <li>The plan provider and service fetchers are borrowed by default. <code>close_dependencies=True</code> transfers only those dependencies to AssemblyClient; it never transfers a StorageClient.</li>
+          <li>On failure AssemblyClient signals the shared cancellation token, attempts every service-stream close and shared-stage cleanup, and cancels queued work. A user fetcher observes that token through <code>SourceReadContext</code>; custom blocking I/O remains cooperative and must obey the context deadline. Failed stage artifacts follow the retained-reservation/orphan rules below.</li>
           <li>Every yielded item is non-empty <code>bytes</code> with length ≤ <code>SourceReadContext.max_chunk_bytes</code> (from <code>AssemblyClientConfig.max_service_chunk_bytes</code>). Wrong type, empty, or oversized chunks attempt stream close and raise the primary <code>ServiceProtocolError</code> before copy/staging.</li>
-          <li>Exact allowlisted <code>ServiceSegmentError</code>, <code>AssemblyCancelledError</code>, and <code>AssemblyTimeoutError</code> outcomes are copied into fresh canonical instances using only validated safe fields. Subclasses, malformed typed errors, and any other custom-executor <code>Exception</code> become <code>ServiceExecutorError(cause_type=safe_type_token(...))</code>. Capture only the safe classification in the catch, discard the caught object, and raise after leaving the handler so neither <code>__cause__</code> nor <code>__context__</code> retains it. Checks outside the catch give cancellation/deadline precedence, and <code>BaseException</code> is never wrapped.</li>
-          <li>Cleanup attempts executor-owned result streams first in reverse registration-token order, then MSC-owned stage sink/fd/path resources in reverse registration-token order. A primary execution error takes precedence. With otherwise successful bytes, the first result-stream close failure becomes redacted <code>ServiceExecutorError</code> and the current private output is discarded. If private-stage cleanup also fails, <code>ServiceExecutorError</code> retains precedence while the artifact/reservation transfers to the orphan registry. A sole MSC-stage cleanup failure is <code>AssemblyStagingError</code>.</li>
+          <li>Exact allowlisted <code>ServiceSegmentError</code>, <code>AssemblyCancelledError</code>, and <code>AssemblyTimeoutError</code> outcomes are copied into fresh canonical instances using only validated safe fields. Subclasses, malformed typed errors, and any other custom-fetcher <code>Exception</code> become <code>ServiceFetchError(cause_type=safe_type_token(...))</code>. Capture only the safe classification in the catch, discard the caught object, and raise after leaving the handler so neither <code>__cause__</code> nor <code>__context__</code> retains it. Checks outside the catch give cancellation/deadline precedence, and <code>BaseException</code> is never wrapped.</li>
+          <li>Cleanup attempts fetcher-owned result streams first in reverse registration-token order, then MSC-owned stage sink/fd/path resources in reverse registration-token order. A primary execution error takes precedence. With otherwise successful bytes, the first result-stream close failure becomes redacted <code>ServiceFetchError</code> and the current private output is discarded. If private-stage cleanup also fails, <code>ServiceFetchError</code> retains precedence while the artifact/reservation transfers to the orphan registry. A sole MSC-stage cleanup failure is <code>AssemblyStagingError</code>.</li>
         </ul>
 
         <h3>Core segment dispatch</h3>
@@ -1389,7 +1390,7 @@ class ServiceSegmentExecutor(ABC):
             <thead><tr><th>Segment</th><th>Implementation</th><th>Required behavior</th><th>Primary purpose</th></tr></thead>
             <tbody>
               <tr><td><code>ObjectSegment</code></td><td>Python dispatcher → existing <code>StorageClient.read</code></td><td>Exact public range read; short reads fail. Initial v1 rejects selectors/enforcing validators; identity-only validators remain weak.</td><td>Bulk bytes travel directly from configured storage to MSC.</td></tr>
-              <tr><td><code>ServiceSegment</code></td><td>User <code>ServiceSegmentExecutor</code></td><td>Advertise supported range modes, enforce exact length, operation-revision/checksum and retry declarations honestly.</td><td>Transport-neutral synthesized bytes.</td></tr>
+              <tr><td><code>ServiceSegment</code></td><td>User <code>ServiceSegmentFetcher</code></td><td>Advertise supported range modes, enforce exact length, operation-revision/checksum and retry declarations honestly.</td><td>Transport-neutral synthesized bytes.</td></tr>
               <tr><td><code>InlineSegment</code></td><td>Python memory copy</td><td>Decode/validate before I/O; enforce 16 KiB segment and 64 KiB object aggregate ceilings.</td><td>Small constants only.</td></tr>
             </tbody>
           </table>
@@ -1450,16 +1451,16 @@ class ServiceSegmentExecutor(ABC):
 
         <h3>Service range, staging, stability, and retry</h3>
         <ul>
-          <li><code>STABLE_SUBRANGES</code> is allowed only when both the segment and executor explicitly support it. Every requested subrange must belong to one stable logical byte string for the duration of the operation.</li>
-          <li><code>WHOLE_RESULT</code> is the default. Within one resolved view and top-level operation, MSC submits one logical <code>ServiceExecutionRequest</code> through one <code>execute</code> call for each stage key <code>(generation, plan_digest, segment_ordinal)</code>, where the ordinal is the zero-based position in the validated <code>AssemblyPlan.segments</code> tuple, even when several requested slices touch it. This key is operation-local and does not authorize cross-provider or cross-binding cache reuse. Different ordinals remain distinct even when every segment value is equal. Executor-owned SAFE retry may turn that submission into multiple private transport attempts.</li>
+          <li><code>STABLE_SUBRANGES</code> is allowed only when both the segment and fetcher explicitly support it. Every requested subrange must belong to one stable logical byte string for the duration of the operation.</li>
+          <li><code>WHOLE_RESULT</code> is the default. Within one resolved view and top-level operation, MSC submits one logical <code>ServiceFetchRequest</code> through one <code>fetch</code> call for each stage key <code>(generation, plan_digest, segment_ordinal)</code>, where the ordinal is the zero-based position in the validated <code>AssemblyPlan.segments</code> tuple, even when several requested slices touch it. This key is operation-local and does not authorize cross-provider or cross-binding cache reuse. Different ordinals remain distinct even when every segment value is equal. Fetcher-owned SAFE retry may turn that submission into multiple private transport attempts.</li>
           <li>A checksum may be omitted, but when supplied it is normative in every consistency mode. For a partial STABLE_SUBRANGES access, request/stage the complete segment, verify the digest, and only then slice; never compare the complete checksum with a partial response. Another enforcing revision does not waive this instruction.</li>
           <li><code>max_complete_segment_memory_bytes</code> is a per-complete-segment memory threshold and <code>max_complete_segment_staged_bytes</code> is the per-complete-segment hard cap. Before launch, reserve declared length against both per-operation and client-wide stage-byte totals. Use memory only when both memory totals also have capacity; otherwise use a unique private file. Multi-budget acquisition is all-or-none; temporary contention waits/serializes until the operation deadline and maps to <code>AssemblyTimeoutError</code>, while a complete segment larger than an applicable per-segment, per-operation, or client-wide hard cap fails before I/O.</li>
-          <li><code>AssemblyClientConfig.staging_directory</code> selects the optional private-file parent for any complete-segment staging, including WHOLE_RESULT service output and checksum verification. A user executor may impose a stricter result limit, but it cannot weaken the AssemblyClient staging ceilings.</li>
-          <li>The result is length-checked while staging, optionally digest-checked, then sliced. Before external launch, each stage receives a deterministic registration token in logical scheduling order. Exact-length mismatch raises <code>ServiceLengthMismatchError</code>; complete checksum mismatch raises <code>ServiceIntegrityError</code>. Either failure attempts every MSC-owned stage sink/fd close and private-path unlink in reverse token order before bytes from that stage/current call are published; executor-owned result streams follow their separate rule above. Earlier successful reader calls may already be observed. Staged data is never reused across top-level operations in v1.</li>
+          <li><code>AssemblyClientConfig.staging_directory</code> selects the optional private-file parent for any complete-segment staging, including WHOLE_RESULT service output and checksum verification. A user fetcher may impose a stricter result limit, but it cannot weaken the AssemblyClient staging ceilings.</li>
+          <li>The result is length-checked while staging, optionally digest-checked, then sliced. Before external launch, each stage receives a deterministic registration token in logical scheduling order. Exact-length mismatch raises <code>ServiceLengthMismatchError</code>; complete checksum mismatch raises <code>ServiceIntegrityError</code>. Either failure attempts every MSC-owned stage sink/fd close and private-path unlink in reverse token order before bytes from that stage/current call are published; fetcher-owned result streams follow their separate rule above. Earlier successful reader calls may already be observed. Staged data is never reused across top-level operations in v1.</li>
           <li>Private-stage allocation/create/write/flush/close/unlink failures use redacted <code>AssemblyStagingError(cause_type=...)</code>; no private path or OS message is public. A cleanup failure never masks or chains onto an already-selected execution error: the primary typed error wins, while the failed artifact stays in a private orphan registry. If the operation would otherwise succeed, cleanup completes before returning bytes or publishing a destination; failure discards private output and raises <code>AssemblyStagingError</code> with the first safe failure type in deterministic cleanup order after every action was attempted. Reader close follows the same selection.</li>
           <li>A file-backed stage reservation is released only after <em>all</em> owned sinks/file descriptors are closed <em>and</em> every private pathname is unlinked; an in-memory reservation waits for all owned sinks/buffers to release. Allocation/create failure before an artifact exists releases immediately. A partially cleaned artifact remains charged against the matching client-wide memory/disk total and is retried on reader/client close, preventing repeated failures from creating unbounded unaccounted storage. When an operation/reader ends, its per-operation charge ends only after ownership of the continuously held client-wide charge atomically transfers to the orphan ledger. Reader close marks the reader closed and releases its active-operation slot even when cleanup raises. Parent close attempts every retained artifact and adds at most one aggregate <code>CloseFailure(dependency_kind="staging_artifact", aliases=(), ...)</code> for the first safe failure type if any remain.</li>
           <li>Destination failures use the exact redacted <code>AssemblyMaterializationError(phase=..., cause_type=..., committed=...)</code> contract. Before the atomic commit point <code>committed=False</code> and the prior/concurrently-created destination is preserved; cleanup or directory-fsync failure after publication reports <code>committed=True</code> and never falsely claims rollback.</li>
-          <li><code>RetrySafety.NEVER</code> permits exactly one private attempt once the logical submission starts, regardless of whether that attempt produces any response bytes. <code>RetrySafety.SAFE</code> permits only the executor's documented bounded retry under the shared deadline; the assembly executor adds no outer retry.</li>
+          <li><code>RetrySafety.NEVER</code> permits exactly one private attempt once the logical submission starts, regardless of whether that attempt produces any response bytes. <code>RetrySafety.SAFE</code> permits only the fetcher's documented bounded retry under the shared deadline; the assembly execution engine adds no outer retry.</li>
           <li>Service operation revisions are optional. Identity-only revisions may classify metrics but cannot satisfy <code>SNAPSHOT_PINNED</code>. An enforcing revision qualifies only when its kind appears in <code>snapshot_revision_kinds</code>; a fully verified complete-result checksum qualifies independently.</li>
         </ul>
       </section>
@@ -1468,7 +1469,7 @@ class ServiceSegmentExecutor(ABC):
         <h2>8. Executor, AssemblyView, seekable reader, and materialization</h2>
         <h3>Client-wide admission and byte reservations</h3>
         <ul>
-          <li>Acquire exactly one <code>max_active_operations</code> slot before provider/source I/O or large allocation for each top-level resolve, info, refresh, list page, one-shot read, materialization, or open. A glob iterator holds one from first advancement through exhaustion/close. A successfully opened reader holds its slot until reader/parent close; a passive view holds none.</li>
+          <li>Acquire exactly one <code>max_active_operations</code> slot before provider/source I/O or large allocation for each top-level resolve, info, list page, one-shot read, materialization, or open. A glob iterator holds one from first advancement through exhaustion/close. A successfully opened reader holds its slot until reader/parent close; a passive view holds none.</li>
           <li>Convenience methods propagate the admitted operation context into a private resolve/plan helper; that helper never reacquires. Glob's private page fetches reuse its iterator slot instead of calling the public admitted list path, and materialization windows/reader calls reuse their operation's existing slot. This rule is required for every convenience at <code>max_active_operations=1</code>.</li>
           <li>Slot waiters allocate no large buffer, observe the shared deadline/cancellation, and are awakened by parent close. Capture the expiration admission clock only after slot acquisition; timeout maps to <code>AssemblyTimeoutError</code>, cancellation to <code>AssemblyCancelledError</code>, and parent close to <code>AssemblyClosedError</code>.</li>
           <li><code>AssemblyGlobIterator</code> is a public idempotently closeable context manager. It acquires on first advancement, and exhaustion, explicit close, iterator error, cancellation/deadline, or parent close releases exactly once; close before first advancement acquires nothing. Early-breaking callers use <code>with</code> or <code>close()</code>. Its own close/exhaustion makes later advancement return <code>StopIteration</code>; parent close maps later use to <code>AssemblyClosedError</code>.</li>
@@ -1481,7 +1482,7 @@ class ServiceSegmentExecutor(ABC):
           <li>Receive one fully validated complete object plan plus the caller's requested range; expiration has already passed the operation-admission check.</li>
           <li>Create one SourceReadContext with the operation's absolute monotonic deadline and thread-safe internal cancellation token. MSC signals that token after a sibling failure or parent close; v1 has no caller-supplied cancellation input.</li>
           <li>Allocate one private pre-sized output buffer after all size/coverage limits pass.</li>
-          <li>Intersect the range with the three segment kinds; group object operations by StorageClient binding, service operations by executor, and copy inline slices locally.</li>
+          <li>Intersect the range with the three segment kinds; group object operations by StorageClient binding, service operations by fetcher, and copy inline slices locally.</li>
           <li>Acquire a client-wide concurrency budget shared across concurrent views and reads.</li>
           <li>For each object operation, split <code>fetch_range</code> into consecutive chunks no larger than <code>max_object_read_chunk_bytes</code>. Before each public <code>StorageClient.read</code>, check the absolute deadline and reserve the declared chunk length from the client-wide <code>max_inflight_object_bytes</code> budget. The call has no deadline parameter and cannot be preempted; after it returns, check the deadline again, discard late bytes, require exact length, and release the reservation. Hold one concurrency permit and any per-client serialization lock across the ordered sequence. An ordinary operation fetches only its intersection. A checksum-bearing operation stages the complete <code>fetch_range</code>, hashes it, then copies <code>selected_range_in_fetch</code>, so temp-file staging never requires a complete StorageClient result in memory. Call range-capable services with exact subranges and key each WHOLE_RESULT stage by descriptor generation, validated plan digest, and segment ordinal.</li>
           <li>As each chunk or staged slice completes, verify exact length. When a checksum is supplied, first stage and verify the complete segment (never a partial body against a complete digest), then copy the requested slice into the non-overlapping private destination and release it when lifecycle rules permit.</li>
@@ -1491,22 +1492,22 @@ class ServiceSegmentExecutor(ABC):
 
         <p>
           The AssemblyClient semaphore is client-wide and bounds active StorageClient and service executions; a streaming
-          service result retains its permit and any per-executor lock until staging completes or closes. Creating a per-read pool would allow
-          <code>concurrent callers × max_concurrency</code> active executions. A user-owned executor may impose a stricter
+          service result retains its permit and any per-fetcher lock until staging completes or closes. Creating a per-read pool would allow
+          <code>concurrent callers × max_concurrency</code> active executions. A user-owned fetcher may impose a stricter
           transport-specific limit, but that implementation detail neither replaces nor multiplies the AssemblyClient budget.
         </p>
 
         <h3>AssemblyView and reader state</h3>
         <ul>
-          <li>An AssemblyView is the executable handle. It retains one metadata-only <code>AssemblyDescriptor</code>, the complete validated <code>AssemblyPlan</code>, frozen concrete source/service bindings, mandatory expiration, originally selected <code>required_consistency</code> minimum, computed consistency/capabilities, and lifecycle state. <code>AssemblyView.metadata</code> returns that exact descriptor. None of this executable state is exposed by <code>AssemblyPlanProvider.resolve_descriptor</code>.</li>
-          <li>It never mutates or refreshes itself. <code>AssemblyClient.refresh(view)</code> returns a new view and requires a replacement generation and expiration. With <code>required_consistency=None</code>, refresh preserves the old view's originally required minimum; it never derives the minimum from the computed consistency or a later client default. Only an explicit argument changes it.</li>
+          <li>An AssemblyView is the executable handle. It retains one metadata-only <code>AssemblyDescriptor</code>, the complete exact-result validated <code>AssemblyPlan</code>, frozen concrete source/service bindings, mandatory expiration, originally selected <code>required_consistency</code> minimum, computed consistency/capabilities, and lifecycle state. <code>AssemblyView.metadata</code> returns that exact descriptor. None of this executable state is exposed before <code>get_plan(request)</code> returns and complete-plan validation succeeds.</li>
+          <li>It never mutates or replaces its own generation. Another <code>AssemblyClient.resolve(reference)</code> returns a distinct view with its own generation and expiration. Until automatic re-resolution is approved, an expired view rejects new work before I/O.</li>
           <li>Each public <code>read</code>, <code>materialize</code>, and <code>open</code> admission captures the clock once and rejects an expired view before range planning or source/service work. Once admitted, that operation may finish after expiration.</li>
           <li>Concurrent <code>view.read</code> calls are supported; an individual seekable reader is not thread-safe.</li>
           <li>An AssemblyReader is one admitted operation from successful <code>open</code> until <code>close</code>. It owns the pinned descriptor/validated plan, SourceReadContext, operation-local complete-segment stage registry, cursor, and closed state.</li>
           <li>Closing the originating AssemblyView rejects new work through that view but does not cancel an already opened reader. The reader survives independently until its own close or parent-client close.</li>
           <li>Reader <code>read</code>/<code>seek</code> calls do not recheck descriptor expiration or resolve another generation. A reader opened while valid may continue after expiration; a new <code>open</code> on that view fails.</li>
           <li>Each reader read intersects its minimal logical range with the same validated complete-object plan. Any complete-segment stage required by a WHOLE_RESULT service or checksum-bearing object/service segment is created at most once per descriptor generation, validated plan digest, and segment ordinal for that reader and retained across seeks until close.</li>
-          <li>Capability computation is total. Validation rejects a WHOLE_RESULT or checksum-bearing full stage when its declared complete length exceeds its applicable per-result hard cap or <code>max_staging_bytes_per_operation</code>. Executor-advertised range modes are included in the computation but cannot weaken client limits. Every successfully resolved v1 view therefore has <code>byte_range_read=True</code> and <code>streaming_open=True</code>; a future false flag raises <code>AssemblyCapabilityError</code> before execution I/O.</li>
+          <li>Capability computation is total. Validation rejects a WHOLE_RESULT or checksum-bearing full stage when its declared complete length exceeds its applicable per-result hard cap or <code>max_staging_bytes_per_operation</code>. Fetcher-advertised range modes are included in the computation but cannot weaken client limits. Every successfully resolved v1 view therefore has <code>byte_range_read=True</code> and <code>streaming_open=True</code>; a future false flag raises <code>AssemblyCapabilityError</code> before execution I/O.</li>
           <li>Seek is true only when the checked sum of all distinct potentially retained stages is at most <code>max_staging_bytes_per_operation</code>. Equality is accepted. Seekable readers retain encountered stages; forward-only readers and materialization release a stage immediately after the cursor/last window passes its final logical byte, allowing several individually feasible stages to serialize even when their sum exceeds the cap. V1 never evicts and replays a stage behind a seekable cursor.</li>
           <li>Using a view or reader after parent close raises <code>AssemblyClosedError</code>.</li>
           <li>After non-negative/checked validation, explicit ByteRange reads clamp at EOF: zero size or offset at/past EOF returns empty, and a crossing range ends at object size. Negative/overflowing input raises <code>InvalidAssemblyRangeError</code>. Reader seeks beyond EOF are allowed; a target below zero raises that error, and subsequent reads beyond EOF are empty. The clamped output length must not exceed <code>max_read_bytes</code>.</li>
@@ -1563,9 +1564,9 @@ class ServiceSegmentExecutor(ABC):
         <h2>9. Optional phase-two generic HTTP adapter</h2>
         <div class="decision">
           <strong>The Assembly core does not require or ship an HTTP service adapter.</strong>
-          The initial feature is complete when a user-defined <code>ServiceSegmentExecutor</code> can execute service segments
+          The initial feature is complete when a user-defined <code>ServiceSegmentFetcher</code> can execute service segments
           through HTTP, gRPC, an SDK, or a local call without any MSC-defined wire protocol. A possible generic
-          <code>HttpServiceSegmentExecutor</code> is a separate phase-two convenience adapter, subject to approval of its own
+          <code>HttpServiceSegmentFetcher</code> is a separate phase-two convenience adapter, subject to approval of its own
           format-neutral contract.
         </div>
 
@@ -1574,7 +1575,7 @@ class ServiceSegmentExecutor(ABC):
           <table>
             <thead><tr><th>Concern</th><th>Initial Assembly core</th><th>Optional HTTP adapter</th></tr></thead>
             <tbody>
-              <tr><td>Service extension contract</td><td><code>ServiceSegmentExecutor</code> and <code>ServiceExecutionRequest</code>.</td><td>Implements that same SPI; introduces no second assembly model.</td></tr>
+              <tr><td>Service extension contract</td><td><code>ServiceSegmentFetcher</code> and <code>ServiceFetchRequest</code>.</td><td>Implements that same SPI; introduces no second assembly model.</td></tr>
               <tr><td>External API</td><td>User-owned and transport neutral.</td><td>MSC still defines no server endpoints, payload schema, or authentication API.</td></tr>
               <tr><td>Protocol translation</td><td>User implementation owns it.</td><td>A user-provided translation hook would map one service request to a bounded HTTP request.</td></tr>
               <tr><td>Assembly semantics</td><td>Validation, planning, bounds, staging, lifecycle, and errors.</td><td>Must not receive a complete plan or decide segment ordering.</td></tr>
@@ -1586,7 +1587,7 @@ class ServiceSegmentExecutor(ABC):
         <h3>Approval conditions for a future adapter</h3>
         <ul>
           <li>Approve a separately versioned, format-neutral generic HTTP adapter contract. This document intentionally does not freeze its config class, request/response payloads, endpoints, authentication callbacks, status mappings, or retry defaults.</li>
-          <li>Keep origin, credentials, allowed paths, and translation code in trusted local configuration. An assembly plan may select only a locally registered executor alias and opaque operation/parameters.</li>
+          <li>Keep origin, credentials, allowed paths, and translation code in trusted local configuration. An assembly plan may select only a locally registered fetcher alias and bounded opaque operation/parameters that the selected fetcher validates.</li>
           <li>Require the adapter to obey the existing service SPI: one segment request, exact declared bytes, explicit range mode, shared deadline/cancellation, bounded chunks, redacted errors, and no access to the complete plan or segment ordering.</li>
           <li>Demonstrate that the contract is generic rather than tied to a particular data format or one application's service API.</li>
         </ul>
@@ -1600,7 +1601,7 @@ class ServiceSegmentExecutor(ABC):
 
         <div class="callout info">
           None of these open decisions blocks the core module. Core E2E tests use an in-process user-defined
-          <code>ServiceSegmentExecutor</code> and pass with no HTTP adapter or network server.
+          <code>ServiceSegmentFetcher</code> and pass with no HTTP adapter or network server.
         </div>
       </section>
 
@@ -1628,7 +1629,7 @@ class ServiceSegmentExecutor(ABC):
             <tbody>
               <tr><td>Descriptor</td><td>reference + generation + internal provider-instance scope</td><td>After model/expiration validation; lookup rechecks expiration. The entry never crosses provider instances without a separately approved trustworthy identity.</td><td>Per-client bounded LRU with hard expiry no later than the descriptor's <code>expires_at</code>.</td></tr>
               <tr><td>Validated complete plan</td><td>descriptor/generation + plan digest + consistency policy + this client's frozen local registry snapshot</td><td>Only after complete-object/global-length/union validation and binding freeze. Entries never cross an AssemblyClient or registry-snapshot boundary.</td><td>Small bounded LRU; hard expiry at the captured descriptor expiration, never sliding.</td></tr>
-              <tr><td>Logical bytes</td><td>Not applicable in v1.</td><td>No logical-byte cache is populated.</td><td>Disabled; v1 exposes no object-binding or executor cache identity.</td></tr>
+              <tr><td>Logical bytes</td><td>Not applicable in v1.</td><td>No logical-byte cache is populated.</td><td>Disabled; v1 exposes no object-binding or fetcher cache identity.</td></tr>
               <tr><td>Complete-segment staging</td><td>top-level operation + generation + plan digest + segment ordinal</td><td>After exact length and optional digest validation.</td><td>Memory/temp-file staging for WHOLE_RESULT service segments and complete checksum verification is local to the current resolved view and operation. Different ordinals never deduplicate; cleanup failure remains explicitly tracked and charged until retry.</td></tr>
               <tr><td>Completed materialized file</td><td>Application-selected destination</td><td>Only after the atomic commit operation succeeds.</td><td>Not an assembly cache. Lifetime is application-owned and independent of descriptor expiration.</td></tr>
             </tbody>
@@ -1638,10 +1639,10 @@ class ServiceSegmentExecutor(ABC):
         <ul>
           <li>Provider adapter retries its own transport without changing the exact request.</li>
           <li>StorageClient retains its documented retry behavior; AssemblyClient adds no outer object-read retry. Because the current read API accepts no deadline, applications configure its underlying transport timeout and retry envelope with the Assembly operation budget in mind.</li>
-          <li>A ServiceSegmentExecutor may create more than one private attempt only when the segment says <code>RetrySafety.SAFE</code>, using its documented bound under the shared deadline. <code>RetrySafety.NEVER</code> permits exactly one private attempt once submission starts, even when that attempt fails before any response byte is observed.</li>
+          <li>A ServiceSegmentFetcher may create more than one private attempt only when the segment says <code>RetrySafety.SAFE</code>, using its documented bound under the shared deadline. <code>RetrySafety.NEVER</code> permits exactly one private attempt once submission starts, even when that attempt fails before any response byte is observed.</li>
           <li>The assembly executor never retries an object or service submission. It owns concurrency, internal cancellation, staging cleanup, atomic publication, and hard deadline enforcement for admission and MSC-owned waits; it can only observe the deadline before and after a synchronous StorageClient call.</li>
           <li>No layer retries invalid/expired plans, binding mismatches, enforced revision mismatches, digest failures, unknown kinds, or protocol violations.</li>
-          <li>Defaults prevent multiplicative retries: every nested operation receives one absolute monotonic deadline and each WHOLE_RESULT stage key has one logical executor submission. Only its explicit SAFE policy may create multiple private attempts inside that submission; NEVER always remains one attempt.</li>
+          <li>Defaults prevent multiplicative retries: every nested operation receives one absolute monotonic deadline and each WHOLE_RESULT stage key has one logical fetch submission. Only its explicit SAFE policy may create multiple private attempts inside that submission; NEVER always remains one attempt.</li>
           <li><code>AssemblyTimeoutError</code> (also <code>TimeoutError</code>) is the sole public outcome once the shared absolute deadline is observed exhausted at provider, scheduling, object, service, or staging boundaries. The deadline hard-bounds admission, MSC-owned waits, and cooperative provider/service work. An in-progress synchronous StorageClient call cannot be preempted and may return after that instant; MSC checks immediately afterward, discards late bytes/errors, and then raises <code>AssemblyTimeoutError</code>. While budget remains, a provider-local transient timeout maps to <code>AssemblyProviderRetryableError</code>, and object/service local timeouts map to their transport classes. The v1 façade has no caller-cancellation argument: its internal token is signaled by sibling failure or parent close, and cooperative code checks it between attempts or chunks.</li>
         </ul>
 
@@ -1666,9 +1667,9 @@ class ServiceSegmentExecutor(ABC):
 ├── InvalidAssemblyPlanError
 │   └── UnsupportedAssemblySchemaError
 ├── UnknownObjectSourceError
-├── UnknownServiceExecutorError
+├── UnknownServiceFetcherError
 ├── ServiceSegmentError
-│   ├── ServiceExecutorError
+│   ├── ServiceFetchError
 │   ├── ServiceAuthenticationError
 │   ├── ServiceAuthorizationError
 │   ├── ServiceNotFoundError
@@ -1703,7 +1704,7 @@ class ServiceSegmentExecutor(ABC):
 
 @dataclass(frozen=True, slots=True)
 class CloseFailure:
-    dependency_kind: Literal["staging_artifact", "plan_provider", "service_executor"]
+    dependency_kind: Literal["staging_artifact", "plan_provider", "service_fetcher"]
     aliases: tuple[str, ...]  # sorted configured aliases; empty for staging and the plan provider
     error_type: str          # safe_type_token(type(exc)); never its message
 
@@ -1727,7 +1728,7 @@ class SourceReadError(ObjectSourceError):
 
     def __init__(self, *, cause_type: str) -> None: ...
 
-class ServiceExecutorError(ServiceSegmentError):
+class ServiceFetchError(ServiceSegmentError):
     cause_type: str
 
     def __init__(self, *, cause_type: str) -> None: ...
@@ -1761,7 +1762,7 @@ class AssemblyMaterializationError(AssemblyError):
           This hierarchy and these structured constructors are normative. Every fieldless public leaf inherits the no-message
           constructor. Each structured leaf accepts only its documented bounded keyword fields,
           calls the no-argument base initializer, and never puts arbitrary caller text in <code>args</code>,
-          <code>str</code>, or <code>repr</code>. At provider, validator, object-client, executor, stream-close, and
+          <code>str</code>, or <code>repr</code>. At provider, validator, object-client, fetcher, stream-close, and
           dependency-close boundaries, only exact allowlisted public classes are recognized. MSC copies their validated safe
           fields into a fresh canonical instance; subclasses or malformed fields normalize to that boundary's generic error.
           Classification occurs inside <code>except Exception</code>, but the caught object is discarded and the fresh error is
@@ -1775,7 +1776,7 @@ class AssemblyMaterializationError(AssemblyError):
           integers; phases and dependency kinds are the documented literals; and input sequences are defensively copied and
           bounded before assignment. <code>safe_type_token(T)</code> returns <code>T.__name__</code> only when it matches
           <code>[A-Za-z_][A-Za-z0-9_]{0,127}</code>, otherwise <code>Exception</code>. Close failures use deterministic order:
-          at most one aggregate staging-artifact record, then the plan provider and distinct service executors by first alias.
+          at most one aggregate staging-artifact record, then the plan provider and distinct service fetchers by first alias.
           Alias tuples are sorted and deduplicated. Public formatting never
           includes a logical key, resource, URL, parameters, credential, response body, or nested exception message.
           <code>AssemblyTimeoutError</code> normalizes exhaustion of the shared deadline and remains distinct from MSC's internal
@@ -1785,20 +1786,20 @@ class AssemblyMaterializationError(AssemblyError):
         <h3>Lifecycle and ownership</h3>
         <ul>
           <li>StorageClients are always borrowed because the existing public StorageClient API has no close lifecycle. AssemblyClient never attempts to close one.</li>
-          <li><code>close_dependencies=False</code> also borrows the plan provider and service executors.</li>
-          <li>With <code>close_dependencies=True</code>, close the provider and each distinct service executor only. A Static provider honors its separate <code>close_store</code> flag.</li>
+          <li><code>close_dependencies=False</code> also borrows the plan provider and service fetchers.</li>
+          <li>With <code>close_dependencies=True</code>, close the provider and each distinct service fetcher only. A Static provider honors its separate <code>close_store</code> flag.</li>
           <li>Close sequence: reject new work, cancel queued operations, signal and close active service result streams/internal iterators, drain cooperative work to its deadline, and wait for any already-running synchronous StorageClient call to return under its configured underlying timeout. Then attempt every retained staging artifact, clear caches/views, and optionally close dependencies.</li>
-          <li>Close is state-idempotent: the first call permanently rejects new work. It retries retained artifacts in reverse deterministic registration-token order, then attempts all owned dependencies in deterministic plan-provider then service-executor first-alias order. Every artifact/dependency is attempted; at most one leading <code>staging_artifact</code> record captures the first safe cleanup failure type, then each distinct dependency appears once with sorted/deduplicated aliases. If cleanup fails, the client remains closed and raises one redacted <code>AssemblyCloseError</code>. A later <code>close()</code> retries only outstanding orphan artifacts and never re-closes an already attempted dependency; once no artifact remains, subsequent calls are no-ops.</li>
+          <li>Close is state-idempotent: the first call permanently rejects new work. It retries retained artifacts in reverse deterministic registration-token order, then attempts all owned dependencies in deterministic plan-provider then service-fetcher first-alias order. Every artifact/dependency is attempted; at most one leading <code>staging_artifact</code> record captures the first safe cleanup failure type, then each distinct dependency appears once with sorted/deduplicated aliases. If cleanup fails, the client remains closed and raises one redacted <code>AssemblyCloseError</code>. A later <code>close()</code> retries only outstanding orphan artifacts and never re-closes an already attempted dependency; once no artifact remains, subsequent calls are no-ops.</li>
           <li>Live clients/views/readers are non-pickleable by default; only explicit configuration/factory wrappers may reconstruct them.</li>
           <li>Expiration does not close an in-flight operation or a successfully materialized file. It rejects subsequent operations and invalidates instruction-derived caches.</li>
         </ul>
 
         <h3>Telemetry</h3>
         <ul>
-          <li>Spans: <code>assembly.resolve</code>, <code>assembly.plan</code>, <code>assembly.read</code>, <code>assembly.object.read</code>, <code>assembly.service.execute</code>, and <code>assembly.materialize</code>.</li>
-          <li>Metrics: list batches/objects, plan segments by kind, inline bytes, object/service bytes, core service-executor submissions, complete-segment staging bytes/backend, amplification, expiration rejection, cooperative cancellation latency, cache hit/miss, and failure class.</li>
+          <li>Spans: <code>assembly.resolve</code>, <code>assembly.plan</code>, <code>assembly.read</code>, <code>assembly.object.read</code>, <code>assembly.service.fetch</code>, and <code>assembly.materialize</code>.</li>
+          <li>Metrics: list batches/objects, plan segments by kind, inline bytes, object/service bytes, core service-fetcher submissions, complete-segment staging bytes/backend, amplification, expiration rejection, cooperative cancellation latency, cache hit/miss, and failure class.</li>
           <li>Low-cardinality labels only: segment kind, configured alias, range mode, result class, and staging backend.</li>
-          <li>Executor-internal retries and transport-specific telemetry remain owned by the user implementation because the core SPI does not expose them.</li>
+          <li>Fetcher-internal retries and transport-specific telemetry remain owned by the user implementation because the core SPI does not expose them.</li>
           <li>No logical keys, resources, credentials, ETags, or auth revisions as metric labels. Trace attributes are redacted and bounded.</li>
         </ul>
 
@@ -1807,7 +1808,7 @@ class AssemblyMaterializationError(AssemblyError):
           <li>Treat provider output as untrusted and validate before allocation or I/O.</li>
           <li>Limit list batch/object count, logical object size, one read, segment count, encoded bytes, decoded inline bytes, resource/parameter length, source/service result range, complete-segment staging memory/temp bytes, concurrency, retries, and time.</li>
           <li>Use separate local object/service aliases and frozen local binding objects; instruction caches never cross an AssemblyClient or frozen registry snapshot, and logical-byte caching is disabled in v1.</li>
-          <li>Interpret object resources only through each least-privilege bound StorageClient's public logical namespace. Service executors confine operations to their locally configured authority; transport-specific controls belong to that implementation.</li>
+          <li>Interpret object resources only through each least-privilege bound StorageClient's public logical namespace. Service fetchers confine operations to their locally configured authority; transport-specific controls belong to that implementation.</li>
           <li>Create every MSC-owned private stage/materialization file exclusively, use no-follow creation where supported, and use POSIX mode <code>0600</code>; publication retains that inode's effective mode.</li>
           <li>Make all errors/reprs safe by construction and test redaction with canary secrets.</li>
         </ul>
@@ -1824,11 +1825,11 @@ class AssemblyMaterializationError(AssemblyError):
 ├── models.py                # frozen list/plan/segment-union models and policies
 ├── provider.py              # AssemblyPlanProvider + StaticAssemblyListProvider
 ├── browsing.py              # optional BrowsableAssemblyPlanProvider capability
-├── service.py               # ServiceSegmentExecutor and requests
+├── service.py               # ServiceSegmentFetcher and requests
 ├── bindings.py              # immutable StorageClient/service alias bindings
 ├── config.py                # limits, consistency, retry, staging, ownership, cache policy
 ├── errors.py                # stable public exception hierarchy
-├── testing.py               # provider/service-executor conformance helpers
+├── testing.py               # provider/service-fetcher conformance helpers
 ├── list_codec.py            # public bounded assembly-list/v1 encode/decode/streaming API
 ├── list_store.py            # AssemblyListStore + bounded in-memory small-list implementation
 ├── _canonical.py            # RFC 8785 plan projection and instruction digest
@@ -1859,7 +1860,7 @@ class AssemblyMaterializationError(AssemblyError):
 ├── test_models.py
 ├── test_provider_conformance.py
 ├── test_static_list_provider.py
-├── test_service_executor_conformance.py
+├── test_service_fetcher_conformance.py
 ├── test_expiration.py
 ├── test_consistency.py
 ├── test_validation.py
@@ -1893,7 +1894,7 @@ multi-storage-client-docs/examples/
             <thead><tr><th>Concern</th><th>Primary file</th></tr></thead>
             <tbody>
               <tr><td>Portable codec, canonical models, and limits</td><td><code>test_list_codec.py</code>, <code>test_canonical.py</code>, <code>test_models.py</code>, <code>test_validation.py</code></td></tr>
-              <tr><td>Reusable adopter contracts</td><td><code>test_provider_conformance.py</code>, <code>test_service_executor_conformance.py</code></td></tr>
+              <tr><td>Reusable adopter contracts</td><td><code>test_provider_conformance.py</code>, <code>test_service_fetcher_conformance.py</code></td></tr>
               <tr><td>MSC-supplied static provider and bindings</td><td><code>test_static_list_provider.py</code>, <code>test_bindings.py</code>, <code>test_storage_client_object.py</code></td></tr>
               <tr><td>Planning and MSC execution internals</td><td><code>test_planning.py</code>, <code>test_planning_properties.py</code>, <code>test_executor.py</code>, <code>test_service_staging.py</code></td></tr>
               <tr><td>Public client, view, reader, and lifecycle</td><td><code>test_client.py</code>, <code>test_view.py</code>, <code>test_reader.py</code>, <code>test_expiration.py</code>, <code>test_consistency.py</code></td></tr>
@@ -1921,11 +1922,11 @@ multi-storage-client-docs/examples/
           </div>
           <div class="card">
             <h4>Component/conformance</h4>
-            <p>Plan providers, StaticAssemblyListProvider, StorageClient bindings, user-defined ServiceSegmentExecutors, bounded staging, and lifecycle.</p>
+            <p>Plan providers, StaticAssemblyListProvider, StorageClient bindings, user-defined ServiceSegmentFetchers, bounded staging, and lifecycle.</p>
           </div>
           <div class="card">
             <h4>Local integration</h4>
-            <p>In-process user service adapter, mixed object/service/inline objects, expiration/refresh, materialization, and existing suite compatibility.</p>
+            <p>In-process user service adapter, mixed object/service/inline objects, expiration/replacement resolution, materialization, and existing suite compatibility.</p>
           </div>
         </div>
 
@@ -1934,21 +1935,21 @@ multi-storage-client-docs/examples/
           <li><code>logical_payload</code>: deterministic bytes with recognizable boundaries.</li>
           <li><code>fake_utc_clock</code>: advances exactly across expiration boundaries without sleeps.</li>
           <li><code>valid_list_batch_factory</code>, <code>valid_descriptor</code>, and <code>valid_plan_factory</code>: complete canonical object definitions for all three union arms.</li>
-          <li><code>recording_provider</code>: records calls and can issue a replacement descriptor generation/expiration on refresh.</li>
+          <li><code>recording_provider</code>: records each <code>get_plan(request)</code> call and can issue a replacement generation/expiration on a later resolution.</li>
           <li><code>recording_storage_client</code>: records public range reads and can mutate same-length bytes.</li>
-          <li><code>recording_service_executor</code>: records the exact request, context, advertised range modes, active count, yielded chunks, stream close, and cancellation.</li>
+          <li><code>recording_service_fetcher</code>: records the exact request, context, advertised range modes, active count, yielded chunks, stream close, and cancellation.</li>
           <li><code>whole_result_stream</code>: configurable length/failure/replay behavior with memory/temp staging observation.</li>
-          <li><code>minimal_user_executor</code>: a test-only implementation of only <code>range_modes</code> and <code>execute</code>, proving that no optional hook or concrete MSC executor is required.</li>
-          <li><code>canary_secret</code>: deliberately placed in executor state and rejected resource text to verify redaction.</li>
+          <li><code>minimal_user_fetcher</code>: a test-only implementation of only <code>range_modes</code> and <code>fetch</code>, proving that no optional hook or concrete MSC fetcher is required.</li>
+          <li><code>canary_secret</code>: deliberately placed in fetcher state and rejected resource text to verify redaction.</li>
         </ul>
 
         <p>
-          Core tests use only application-supplied in-process providers and executors. Concrete transport adapters and their
+          Core tests use only application-supplied in-process providers and fetchers. Concrete transport adapters and their
           wire-level behavior are outside this test plan and cannot block or substitute for core acceptance.
         </p>
 
         <div class="callout info">
-          Reusable conformance tests exercise only behavior an adopter can observe through the provider or executor SPI.
+          Reusable conformance tests exercise only behavior an adopter can observe through the provider or fetcher SPI.
           Intentionally malformed doubles, stream cleanup, error normalization, staging, scheduling, and redaction remain MSC
           unit tests; they are not obligations imposed by the reusable conformance harness.
         </div>
@@ -1982,7 +1983,7 @@ multi-storage-client-docs/examples/
               <tr><td><code>test_assembly_list_v1_matches_published_language_neutral_golden_vectors</code></td><td>Python encoding and decoding match the shared canonical bytes for all three segment kinds, Unicode, timestamps, and base64; each future consumer language validates the same fixtures in its own suite.</td></tr>
               <tr><td><code>test_multi_batch_list_requires_shared_metadata_declared_count_and_contiguous_indexes</code></td><td>Mixed list IDs/issuance/expiration/counts, gaps, duplicates, missing batches, indexes outside the declared count, and batch-digest mismatch fail closed.</td></tr>
               <tr><td><code>test_multi_batch_list_rejects_duplicate_reference_across_batches</code></td><td>One canonical <code>AssemblyReference</code> identifies at most one complete object definition in the validated snapshot.</td></tr>
-              <tr><td><code>test_v1_portable_list_omits_refresh_locator_and_static_provider_is_non_refreshable</code></td><td>Refresh routing remains provider-owned rather than a dead portable field.</td></tr>
+              <tr><td><code>test_v1_portable_list_omits_replacement_locator</code></td><td>Replacement transport remains provider-owned and uses another <code>get_plan(request)</code> rather than a dead portable field.</td></tr>
               <tr><td><code>test_batch_never_splits_one_object_definition</code></td><td>A partial/carry-over object is not representable or executable.</td></tr>
               <tr><td><code>test_rejects_missing_expires_at</code>, <code>test_rejects_malformed_expires_at</code></td><td>Both canonical decoder and direct model construction reject before provider/executor I/O.</td></tr>
               <tr><td><code>test_expires_at_requires_timezone_and_canonicalizes_to_utc</code></td><td>Equivalent instants have one representation and equality with the clock is expired.</td></tr>
@@ -1996,6 +1997,12 @@ multi-storage-client-docs/examples/
               <tr><td><code>test_frozen_json_array_and_object_are_distinct_for_pair_shaped_values</code></td><td><code>[["a", 1]]</code> and <code>{"a": 1}</code> never collapse to the same Python model or digest.</td></tr>
               <tr><td><code>test_service_parameters_require_frozen_json_object_root</code></td><td>Nested arrays/objects round-trip injectively while the operation parameter root remains an object.</td></tr>
               <tr><td><code>test_rejects_unknown_list_or_plan_schema_version</code></td><td>Fails closed with <code>UnsupportedAssemblySchemaError</code>.</td></tr>
+              <tr><td><code>test_v1_plan_requires_exact_result_semantics</code></td><td>Missing or non-<code>exact</code> semantics fails before binding or byte I/O; informational annotations cannot request projection.</td></tr>
+              <tr><td><code>test_future_projection_plan_requires_new_version_and_capability</code></td><td>A v1 client rejects carrier-plus-projection semantics instead of silently materializing a semantic superset.</td></tr>
+              <tr><td><code>test_supporting_future_plan_version_does_not_change_v1_exact_interpretation</code></td><td>The same valid v1 golden vector continues to produce identical final bytes after a newer decoder is introduced.</td></tr>
+              <tr><td><code>test_unknown_required_capability_rejects_before_binding_or_io</code></td><td>A client never ignores a capability that is required to interpret a newer plan safely.</td></tr>
+              <tr><td><code>test_v1_provider_and_fetcher_spis_gain_no_required_abstract_members</code></td><td>The minimal v1 adopter implementations remain constructible as the package evolves.</td></tr>
+              <tr><td><code>test_additive_public_parameters_are_keyword_only_with_defaults</code></td><td>Existing façade calls retain their behavior when optional parameters are added.</td></tr>
               <tr><td><code>test_rejects_unknown_fields_or_segment_kind</code></td><td>Forward-incompatible input is not silently ignored or reinterpreted.</td></tr>
               <tr><td><code>test_decodes_object_service_and_inline_discriminated_union</code></td><td>Each kind has its exact fields and cannot borrow fields from another kind.</td></tr>
               <tr><td><code>test_rejects_inline_segment_over_16_kib</code>, <code>test_rejects_inline_total_over_64_kib</code></td><td>Decoded-byte hard limits apply before allocation/scheduling, independent of base64 size.</td></tr>
@@ -2008,27 +2015,26 @@ multi-storage-client-docs/examples/
           </table>
         </div>
 
-        <h3>14.2 Provider contract, client refresh, and static-provider behavior</h3>
+        <h3>14.2 Provider contract, replacement resolution, and static-provider behavior</h3>
         <p>
-          Descriptor, complete-plan, deadline, concurrency, and public-error cases form the reusable provider suite.
-          Expiration/refresh/cache cases are MSC client tests, while static-provider and list-store cases target the
+          Metadata-bearing complete-plan, deadline, concurrency, and public-error cases form the reusable provider suite.
+          Expiration/replacement/cache cases are MSC client tests, while static-provider and list-store cases target the
           MSC-supplied implementation.
         </p>
         <div class="table-wrap">
           <table>
             <thead><tr><th>Test</th><th>Primary assertion</th></tr></thead>
             <tbody>
-              <tr><td><code>test_provider_resolve_descriptor_returns_metadata_only_with_mandatory_expiration</code></td><td>The result is an <code>AssemblyDescriptor</code> with no <code>read</code>, <code>open</code>, or <code>materialize</code>; it cannot omit/malformed expiration and is bound to one fixed generation.</td></tr>
-              <tr><td><code>test_provider_resolve_descriptor_must_echo_exact_reference_and_requested_generation</code></td><td>A substituted reference or silent pinned-generation fall-forward is rejected before plan/source calls; latest is allowed only when generation was None.</td></tr>
-              <tr><td><code>test_provider_get_plan_echoes_exact_descriptor_without_byte_range</code></td><td>The provider receives the descriptor directly plus the optional absolute deadline; it cannot return a range-specific fragment or substitute a different generation.</td></tr>
+              <tr><td><code>test_provider_get_plan_returns_metadata_and_complete_exact_plan</code></td><td>One call returns an <code>AssemblyPlan</code> with an embedded metadata-only descriptor, mandatory future expiration, exact v1 result semantics, and no executable byte methods.</td></tr>
+              <tr><td><code>test_provider_get_plan_must_echo_exact_reference_and_requested_generation</code></td><td>A substituted reference or silent pinned-generation fall-forward is rejected before source calls; latest is allowed only when generation was None.</td></tr>
+              <tr><td><code>test_resolve_invokes_get_plan_once_and_no_descriptor_spi</code></td><td>The public provider contract has one resolution method and never performs a preliminary metadata lookup.</td></tr>
               <tr><td><code>test_provider_plan_is_complete_object_not_transport_page</code></td><td>Segments globally cover <code>[0, descriptor.size)</code> even when caller later reads a small range.</td></tr>
-              <tr><td><code>test_expired_view_does_not_fall_forward_or_auto_refresh</code></td><td>Raises <code>AssemblyExpiredError</code>; provider is not asked for latest implicitly.</td></tr>
-              <tr><td><code>test_refresh_returns_distinct_view_for_replacement_generation</code></td><td>The returned view has the provider's replacement generation and expiration; the old view retains its descriptor, validated plan, capabilities, and frozen routing. Under <code>EXPIRATION_ONLY</code>, the test makes no claim that mutable source bytes remain unchanged.</td></tr>
-              <tr><td><code>test_refresh_capability_captures_exact_immutable_provider_property_true_and_false</code></td><td>False rejects before a provider call; a provider advertising true implements refresh, and StaticAssemblyListProvider remains false.</td></tr>
-              <tr><td><code>test_refresh_failure_leaves_valid_old_view_unchanged_and_usable</code></td><td>A proactive refresh failure does not change metadata, plan, capabilities, expiration, or source routing; the still-valid old view remains usable through that same frozen execution state. Exact bytes are asserted only in an immutable or <code>SNAPSHOT_PINNED</code> fixture.</td></tr>
-              <tr><td><code>test_refresh_failure_does_not_revive_expired_old_view</code>, <code>test_refresh_failure_does_not_reopen_closed_old_view</code></td><td>Failure never extends expiration or changes lifecycle state; subsequent work raises the original expired/closed outcome without stale fallback.</td></tr>
+              <tr><td><code>test_expired_view_does_not_fall_forward_or_auto_resolve</code></td><td>Raises <code>AssemblyExpiredError</code>; under the proposed v1 policy the provider is not asked for latest implicitly.</td></tr>
+              <tr><td><code>test_second_resolve_returns_distinct_view_for_replacement_generation</code></td><td>The returned view has the later plan's generation and expiration; the old view retains its descriptor, validated plan, capabilities, and frozen routing.</td></tr>
+              <tr><td><code>test_replacement_resolve_failure_never_mutates_or_revives_old_view</code></td><td>Failure never extends expiration, changes routing, or reopens closed state; an independently still-valid old view remains usable.</td></tr>
+              <tr><td><code>test_public_capabilities_have_no_refresh_member</code></td><td>Provider and client expose no separate refresh method or capability.</td></tr>
               <tr><td><code>test_provider_instruction_cache_is_scoped_to_concrete_provider_instance</code></td><td>No provider revision is required in metadata and instructions are never reused across provider instances.</td></tr>
-              <tr><td><code>test_provider_supports_concurrent_resolve_descriptor_and_get_plan</code></td><td>Required provider methods are thread-safe without an undeclared capability.</td></tr>
+              <tr><td><code>test_provider_supports_concurrent_get_plan</code></td><td>The required provider method is thread-safe without an undeclared capability.</td></tr>
               <tr><td><code>test_provider_honors_expired_monotonic_deadline_without_backend_call</code></td><td>Retries cannot outlive the AssemblyClient operation budget.</td></tr>
               <tr><td><code>test_provider_exact_public_exception_contract</code></td><td>Not-found, unavailable generation, auth, exhausted retryable backend, malformed output, unsupported capability, unexpected exception, and deadline each map to the frozen hierarchy with no fallback.</td></tr>
               <tr><td><code>test_provider_unexpected_error_uses_fresh_sanitized_cause_without_original_context</code></td><td>Only the bounded safe type token is reachable; backend text/reference and the original object are absent from cause, context, args, attributes, repr, and traceback.</td></tr>
@@ -2064,14 +2070,14 @@ multi-storage-client-docs/examples/
               <tr><td><code>test_snapshot_pinned_rejects_unenforceable_object_selector_or_validator</code>, <code>test_snapshot_pinned_rejects_unenforceable_service_revision</code></td><td>Strict opt-in fails before I/O; no HEAD/read/HEAD substitution.</td></tr>
               <tr><td><code>test_snapshot_pinned_accepts_verified_complete_checksum_for_object</code></td><td>The client-only initial binding accepts snapshot-pinned object bytes only after the complete segment checksum is verified; no unapproved validator or policy hook is required.</td></tr>
               <tr><td><code>test_any_supplied_checksum_forces_bounded_complete_segment_verification_before_partial_slice</code></td><td>The rule applies in both consistency modes and even alongside an enforcing revision; a complete checksum is never compared to a partial body, and over-limit verification fails before I/O.</td></tr>
-              <tr><td><code>test_rejects_service_range_mode_not_supported_by_executor</code></td><td>Support is determined only by the injected executor's advertised SPI capability; rejection performs zero service calls.</td></tr>
+              <tr><td><code>test_rejects_service_range_mode_not_supported_by_fetcher</code></td><td>Support is determined only by the injected fetcher's advertised SPI capability; rejection performs zero service calls.</td></tr>
               <tr><td><code>test_enforces_max_segments</code>, <code>test_enforces_max_plan_bytes</code>, <code>test_enforces_max_logical_size</code>, <code>test_enforces_max_read_bytes</code>, <code>test_enforces_inline_hard_limits</code></td><td>Correct limit name/value and zero downstream calls.</td></tr>
               <tr><td><code>test_plan_size_streaming_counter_accepts_exact_limit_and_aborts_at_one_over</code>, <code>test_huge_direct_model_fails_cheap_structure_before_full_canonical_encoding</code></td><td>No second complete plan encoding/allocation; direct and decoded paths share exact canonical size semantics.</td></tr>
               <tr><td><code>test_config_integer_and_timeout_hard_bounds_accept_exact_and_reject_one_over</code></td><td>Strict integers stop at <code>2**53-1</code>, seconds stop at 604800, and invalid values fail before allocation or dependency I/O.</td></tr>
               <tr><td><code>test_client_wide_budget_relationships_accept_exact_boundaries_and_reject_one_over</code></td><td>Twice the read/window maxima fit output total; per-operation staging memory/disk fit their totals; object chunks fit read/window/in-flight/staging-memory bounds.</td></tr>
-              <tr><td><code>test_plan_rejects_individually_unstageable_full_result_before_execution</code></td><td>A stage above its per-result or aggregate client cap yields a typed limit error with no service/object call; a user executor may enforce an additional private cap.</td></tr>
-              <tr><td><code>test_client_resolve_exposes_no_view_before_complete_plan_validation</code></td><td><code>AssemblyClient.resolve</code> performs <code>resolve_descriptor</code>, exact-generation plan retrieval, global validation, binding freeze, and capability computation before exposing a view; any failure returns no partial view and performs no object or service byte I/O.</td></tr>
-              <tr><td><code>test_plan_validation_failure_performs_no_byte_io</code></td><td>Malformed global length, digest, alias, mode, or consistency fails before any StorageClient or ServiceSegmentExecutor byte call.</td></tr>
+              <tr><td><code>test_plan_rejects_individually_unstageable_full_result_before_execution</code></td><td>A stage above its per-result or aggregate client cap yields a typed limit error with no service/object call; a user fetcher may enforce an additional private cap.</td></tr>
+              <tr><td><code>test_client_resolve_exposes_no_view_before_complete_plan_validation</code></td><td><code>AssemblyClient.resolve</code> performs one <code>get_plan(request)</code>, exact-generation/global validation, binding freeze, and capability computation before exposing a view; any failure returns no partial view and performs no object or service byte I/O.</td></tr>
+              <tr><td><code>test_plan_validation_failure_performs_no_byte_io</code></td><td>Malformed global length, digest, alias, mode, or consistency fails before any StorageClient or ServiceSegmentFetcher byte call.</td></tr>
               <tr><td><code>test_valid_v1_view_always_advertises_range_read_and_forward_open</code></td><td>Successfully resolved v1 plans have both flags true; a synthetic future false capability rejects the operation before I/O.</td></tr>
               <tr><td><code>test_rejects_resource_or_reference_over_length_limit</code></td><td>No unbounded logging/cache key or URL creation.</td></tr>
               <tr><td><code>test_unassigned_identity_metadata_strings_accept_exact_utf8_cap_and_reject_one_over_or_lone_surrogate</code></td><td>Decoded and direct/live provider models fail before cache, digest, alias lookup, or external I/O for every covered field family.</td></tr>
@@ -2102,24 +2108,24 @@ multi-storage-client-docs/examples/
           <li><code>test_malformed_numeric_input_always_raises_domain_error</code>.</li>
         </ul>
 
-        <h3>14.5 Bindings, direct object reads, and the service-executor boundary</h3>
+        <h3>14.5 Bindings, direct object reads, and the service-fetcher boundary</h3>
         <p>
           Binding tests use only the existing public <code>StorageClient</code> contract. StorageClients are always borrowed;
-          optional Assembly ownership applies only to the plan provider and service executors.
+          optional Assembly ownership applies only to the plan provider and service fetchers.
         </p>
         <ul>
           <li><code>test_binding_registries_copy_mappings_and_reject_late_mutation</code></li>
           <li><code>test_binding_registries_reject_empty_or_malformed_alias_names</code></li>
-          <li><code>test_dependency_object_identity_cannot_be_reused_across_provider_executor_or_client_roles</code></li>
-          <li><code>test_plan_schema_has_no_endpoint_profile_credentials_or_executor_implementation_fields</code></li>
+          <li><code>test_dependency_object_identity_cannot_be_reused_across_provider_fetcher_or_client_roles</code></li>
+          <li><code>test_plan_schema_has_no_unrestricted_endpoint_profile_credentials_or_fetcher_implementation_fields</code></li>
           <li><code>test_object_source_binding_minimum_constructor_requires_only_client</code></li>
-          <li><code>test_default_client_close_borrows_provider_storage_clients_and_executors</code></li>
-          <li><code>test_close_dependencies_closes_provider_and_distinct_executors_once</code></li>
+          <li><code>test_default_client_close_borrows_provider_storage_clients_and_fetchers</code></li>
+          <li><code>test_close_dependencies_closes_provider_and_distinct_fetchers_once</code></li>
           <li><code>test_close_dependencies_never_closes_storage_clients</code></li>
-          <li><code>test_close_attempts_all_owned_provider_and_executor_dependencies_then_raises_redacted_assembly_close_error</code></li>
+          <li><code>test_close_attempts_all_owned_provider_and_fetcher_dependencies_then_raises_redacted_assembly_close_error</code></li>
           <li><code>test_close_failure_records_are_deduplicated_sorted_and_publicly_typed</code></li>
           <li><code>test_storage_client_calls_are_serialized_across_aliases_and_views</code></li>
-          <li><code>test_non_thread_safe_service_executor_serializes_calls_and_opt_in_allows_concurrency</code></li>
+          <li><code>test_non_thread_safe_service_fetcher_serializes_calls_and_opt_in_allows_concurrency</code></li>
           <li><code>test_object_segment_uses_only_public_storage_client_contract</code></li>
           <li><code>test_client_only_binding_uses_exact_configured_storage_client_authority</code> — a plan selects a local alias and resource only; it cannot replace the bound client, endpoint, profile, credentials, root, or provider.</li>
           <li><code>test_plan_resource_is_sent_only_to_selected_binding</code> — only the client selected by <code>source_id</code> receives the resource and all other clients record zero calls.</li>
@@ -2139,19 +2145,22 @@ multi-storage-client-docs/examples/
           <li><code>test_private_storage_provider_is_never_accessed</code></li>
         </ul>
 
-        <p>The reusable <code>ServiceSegmentExecutor</code> conformance suite contains only adopter-observable SPI behavior:</p>
+        <p>The reusable <code>ServiceSegmentFetcher</code> conformance suite contains only adopter-observable SPI behavior:</p>
         <ul>
-          <li><code>test_minimal_executor_implements_only_range_modes_and_execute</code> — a class overriding only those two abstract members is constructible and completes the acceptance read.</li>
-          <li><code>test_assembly_package_exports_no_concrete_service_executor</code></li>
-          <li><code>test_service_executor_receives_one_segment_request_not_complete_plan_or_ordering</code></li>
-          <li><code>test_executor_receives_exact_deadline_cancellation_and_chunk_limit_context</code></li>
-          <li><code>test_executor_range_modes_are_exact_immutable_and_captured_before_view_exposure</code></li>
-          <li><code>test_optional_executor_capabilities_are_immutable_for_injected_lifetime</code> — optional revision-kind and thread-safety declarations cannot change after injection.</li>
-          <li><code>test_service_executor_declared_range_modes_match_observed_behavior</code></li>
+          <li><code>test_minimal_fetcher_implements_only_range_modes_and_fetch</code> — a class overriding only those two abstract members is constructible and completes the acceptance read.</li>
+          <li><code>test_assembly_package_exports_no_concrete_service_fetcher</code></li>
+          <li><code>test_service_fetcher_receives_one_segment_request_not_complete_plan_or_ordering</code></li>
+          <li><code>test_service_fetch_request_is_independently_executable_without_sticky_state</code></li>
+          <li><code>test_v1_core_never_batches_multiple_service_segments_into_one_fetch</code></li>
+          <li><code>test_fetcher_confines_operation_and_parameters_under_local_policy</code></li>
+          <li><code>test_fetcher_receives_exact_deadline_cancellation_and_chunk_limit_context</code></li>
+          <li><code>test_fetcher_range_modes_are_exact_immutable_and_captured_before_view_exposure</code></li>
+          <li><code>test_optional_fetcher_capabilities_are_immutable_for_injected_lifetime</code> — optional revision-kind and thread-safety declarations cannot change after injection.</li>
+          <li><code>test_service_fetcher_declared_range_modes_match_observed_behavior</code></li>
           <li><code>test_stable_subranges_returns_exact_first_middle_and_last_ranges</code></li>
           <li><code>test_stable_subranges_denotes_one_stable_logical_string_per_operation</code></li>
-          <li><code>test_whole_result_executor_receives_no_requested_range</code></li>
-          <li><code>test_executor_result_must_be_closeable_before_publish</code> — a non-closeable result raises <code>ServiceProtocolError</code> and publishes no bytes.</li>
+          <li><code>test_whole_result_fetcher_receives_no_requested_range</code></li>
+          <li><code>test_fetcher_result_must_be_closeable_before_publish</code> — a non-closeable result raises <code>ServiceProtocolError</code> and publishes no bytes.</li>
           <li><code>test_whole_result_length_mismatch_fails_before_slice_publish</code></li>
           <li><code>test_service_optional_revision_absent_under_expiration_only</code></li>
           <li><code>test_snapshot_revision_kinds_defaults_empty_and_is_immutable</code></li>
@@ -2159,21 +2168,21 @@ multi-storage-client-docs/examples/
           <li><code>test_verified_complete_service_checksum_qualifies_without_operation_revision</code></li>
           <li><code>test_service_enforced_revision_or_digest_mismatch_fails_closed</code></li>
           <li><code>test_service_checksum_mismatch_raises_service_integrity_error_before_publish</code></li>
-          <li><code>test_retry_safety_never_pre_response_reset_is_not_retried_by_core</code> — the executor is invoked once and the typed fixture failure is surfaced even before any chunk is yielded.</li>
-          <li><code>test_retry_safety_never_partial_stream_failure_is_not_retried_by_core</code> — the executor is invoked once and the current call publishes no bytes.</li>
-          <li><code>test_retry_safety_safe_does_not_add_outer_core_retry</code> — MSC invokes <code>execute</code> once; the test makes no claim about private work inside the user implementation.</li>
+          <li><code>test_retry_safety_never_pre_response_reset_is_not_retried_by_core</code> — the fetcher is invoked once and the typed fixture failure is surfaced even before any chunk is yielded.</li>
+          <li><code>test_retry_safety_never_partial_stream_failure_is_not_retried_by_core</code> — the fetcher is invoked once and the current call publishes no bytes.</li>
+          <li><code>test_retry_safety_safe_does_not_add_outer_core_retry</code> — MSC invokes <code>fetch</code> once; the test makes no claim about private work inside the user implementation.</li>
         </ul>
 
-        <p>MSC executor-internal boundary tests, which are not part of the reusable adopter suite, include:</p>
+        <p>MSC execution-engine boundary tests, which are not part of the reusable adopter suite, include:</p>
         <ul>
           <li><code>test_stream_cleanup_attempts_all_in_reverse_order_and_primary_execution_error_wins</code></li>
-          <li><code>test_sole_stream_close_failure_becomes_sanitized_service_executor_error_and_discards_output</code></li>
-          <li><code>test_result_stream_and_private_stage_cleanup_failures_select_service_executor_error_and_retain_stage_orphan</code></li>
+          <li><code>test_sole_stream_close_failure_becomes_sanitized_service_fetch_error_and_discards_output</code></li>
+          <li><code>test_result_stream_and_private_stage_cleanup_failures_select_service_fetch_error_and_retain_stage_orphan</code></li>
           <li><code>test_custom_stream_rejects_nonbytes_empty_and_over_context_chunk_limit_before_copy_or_stage</code></li>
           <li><code>test_service_errors_and_repr_redact_parameters_and_credentials</code></li>
           <li><code>test_public_error_constructors_reject_arbitrary_messages_and_keep_args_str_repr_canonical</code></li>
           <li><code>test_custom_typed_error_is_normalized_and_subclass_or_malformed_fields_cannot_bypass_redaction</code></li>
-          <li><code>test_unexpected_custom_executor_exception_maps_to_service_executor_error_without_original_cause_or_context</code></li>
+          <li><code>test_unexpected_custom_fetcher_exception_maps_to_service_fetch_error_without_original_cause_or_context</code></li>
           <li><code>test_redaction_walks_cause_context_args_attributes_and_full_formatted_traceback</code></li>
           <li><code>test_service_deadline_internal_cancellation_and_base_exception_are_not_wrapped</code></li>
         </ul>
@@ -2184,24 +2193,24 @@ multi-storage-client-docs/examples/
             <thead><tr><th>Area</th><th>Tests and key assertions</th></tr></thead>
             <tbody>
               <tr><td>Ordering</td><td><code>test_reassembles_out_of_order_completions_in_logical_order</code>; result equals reference bytes.</td></tr>
-              <tr><td>Concurrency</td><td><code>test_never_exceeds_client_wide_concurrency_across_callers</code>; <code>test_streaming_service_result_holds_permit_and_executor_lock_until_closed</code>; <code>test_object_chunk_memory_reservation_never_exceeds_client_wide_byte_budget</code>; <code>test_active_operation_slots_bound_one_shots_and_open_readers_and_release_on_all_exit_paths</code>.</td></tr>
+              <tr><td>Concurrency</td><td><code>test_never_exceeds_client_wide_concurrency_across_callers</code>; <code>test_independent_service_fetches_overlap_without_manual_batching</code>; <code>test_streaming_service_result_holds_permit_and_fetcher_lock_until_closed</code>; <code>test_object_chunk_memory_reservation_never_exceeds_client_wide_byte_budget</code>; <code>test_active_operation_slots_bound_one_shots_and_open_readers_and_release_on_all_exit_paths</code>.</td></tr>
               <tr><td>Admission reentrancy</td><td><code>test_resolve_info_read_open_materialize_and_glob_do_not_reacquire_at_max_active_operations_one</code>; every convenience completes without self-deadlock and performs only one resolution/list-page sequence.</td></tr>
               <tr><td>Admission wait</td><td><code>test_slot_wait_allocates_no_output_or_stage_and_observes_deadline_cancel_and_parent_close</code>; <code>test_slot_wait_time_is_followed_by_fresh_expiration_admission_check</code>.</td></tr>
               <tr><td>Global byte budgets</td><td><code>test_output_total_bounds_concurrent_reads_and_materialization_windows_then_releases</code>; <code>test_staging_memory_and_disk_totals_bound_concurrent_callers_and_retained_readers</code>; <code>test_multi_budget_reservation_is_all_or_none_and_cannot_deadlock</code>.</td></tr>
               <tr><td>Atomicity</td><td><code>test_short_long_digest_or_enforced_revision_failure_returns_no_bytes_from_current_call</code>; <code>test_reader_prefix_may_be_observed_before_later_call_fails_and_poison_closes_reader</code>; <code>test_reader_read_all_late_segment_failure_returns_nothing_and_commits_cursor_once</code>; cursor/readinto buffer is unchanged for the failed public call and its private output is not published.</td></tr>
               <tr><td>Cancellation</td><td><code>test_first_terminal_error_signals_shared_token_attempts_every_cleanup_and_cancels_queued_reads</code>; successful cleanup removes the stage, injected cleanup failure follows orphan accounting, and cooperative user calls observe the operation deadline.</td></tr>
-              <tr><td>Retry</td><td><code>test_assembly_executor_never_retries_object_or_service_call</code>; both NEVER and SAFE fixtures observe exactly one core <code>execute</code> invocation. Work internal to the user implementation is out of scope.</td></tr>
-              <tr><td>Composition</td><td><code>test_object_inline_plan_accepts_empty_service_executor_registry</code>; <code>test_inline_only_plan_accepts_empty_object_and_service_registries</code>; <code>test_service_only_plan_accepts_empty_object_source_registry</code>; only aliases actually referenced by the complete plan are required.</td></tr>
-              <tr><td>Resolution</td><td><code>test_one_shot_read_calls_resolve_descriptor_once</code>; <code>test_info_returns_descriptor_without_get_plan_or_byte_io</code>; <code>test_view_operations_reuse_frozen_plan_without_provider_calls</code>; <code>test_open_keeps_one_generation_across_seek_and_read</code>. After resolve, view operations never replan.</td></tr>
+              <tr><td>Retry</td><td><code>test_assembly_executor_never_retries_object_or_service_call</code>; both NEVER and SAFE fixtures observe exactly one core <code>fetch</code> invocation. Work internal to the user implementation is out of scope.</td></tr>
+              <tr><td>Composition</td><td><code>test_object_inline_plan_accepts_empty_service_fetcher_registry</code>; <code>test_inline_only_plan_accepts_empty_object_and_service_registries</code>; <code>test_service_only_plan_accepts_empty_object_source_registry</code>; only aliases actually referenced by the complete plan are required.</td></tr>
+              <tr><td>Resolution</td><td><code>test_one_shot_read_calls_get_plan_once</code>; <code>test_info_calls_get_plan_once_without_byte_io</code>; <code>test_view_operations_reuse_frozen_plan_without_provider_calls</code>; <code>test_open_keeps_one_generation_across_seek_and_read</code>. After resolve, view operations never replan under the proposed v1 policy.</td></tr>
               <tr><td>Segment-free I/O</td><td><code>test_inline_segment_emits_exact_bytes_without_object_or_service_io</code>; <code>test_zero_length_read_validates_complete_plan_then_performs_no_segment_io</code>.</td></tr>
               <tr><td>Reader expiration</td><td><code>test_reader_opened_while_valid_reads_and_seeks_after_expiration_until_close</code>; <code>test_new_open_after_expiration_fails_before_plan_or_service_io</code>.</td></tr>
-              <tr><td>View/reader close</td><td><code>test_reader_survives_originating_view_close_until_reader_or_parent_close</code>; <code>test_reader_close_result_stream_failure_maps_to_service_executor_error_but_still_releases_slot</code>; reader uses pinned capabilities/state, the view rejects new work, all cleanup is attempted, and parent close cancels both.</td></tr>
+              <tr><td>View/reader close</td><td><code>test_reader_survives_originating_view_close_until_reader_or_parent_close</code>; <code>test_reader_close_result_stream_failure_maps_to_service_fetch_error_but_still_releases_slot</code>; reader uses pinned capabilities/state, the view rejects new work, all cleanup is attempted, and parent close cancels both.</td></tr>
               <tr><td>Reader service stage</td><td><code>test_reader_reuses_one_whole_result_stage_across_reads_and_seeks</code>; <code>test_seek_true_when_retained_stage_sum_equals_cap_and_false_at_cap_plus_one</code>; <code>test_forward_reader_releases_passed_stages_and_does_not_self_deadlock_when_sum_exceeds_cap</code>; <code>test_seekable_reader_retains_stages_without_replay</code>; stage/context close exactly once.</td></tr>
               <tr><td>Expiration</td><td><code>test_operation_rejects_when_clock_equals_expiration</code>; <code>test_operation_started_valid_may_finish_after_expiration</code>; the next operation fails with <code>AssemblyExpiredError</code>.</td></tr>
-              <tr><td>Refresh</td><td><code>test_client_refresh_returns_new_view_and_never_mutates_old_view</code>; <code>test_refresh_requires_replacement_generation</code>; <code>test_refresh_none_preserves_original_required_minimum_not_computed_or_client_default</code>; <code>test_refresh_explicit_consistency_override_is_intentional</code>.</td></tr>
+              <tr><td>Replacement resolution</td><td><code>test_second_resolve_returns_new_view_and_never_mutates_old_view</code>; <code>test_replacement_plan_has_its_own_generation_and_expiration</code>; <code>test_public_client_and_provider_have_no_refresh_method</code>.</td></tr>
               <tr><td>Reference shorthand</td><td><code>test_string_reference_normalizes_to_empty_namespace_key</code>; parameters remain explicit-only.</td></tr>
               <tr><td>Browsing</td><td><code>test_list_requires_browse_index</code>, <code>test_cursor_is_bound_to_listing_request</code>, <code>test_browse_page_cannot_execute</code>; <code>test_list_page_size_zero_exact_max_and_one_over</code>; <code>test_list_cursor_utf8_exact_cap_one_over_and_lone_surrogate</code>; <code>test_provider_page_rejects_requested_plus_one_items_or_oversized_next_cursor_before_cache</code>; <code>test_glob_no_match_and_late_match_stop_at_exact_scan_budget_without_extra_provider_call</code>; <code>test_glob_result_budget_raises_before_yielding_one_over</code>; <code>test_glob_close_before_start_acquires_none_and_early_close_error_or_exhaustion_releases_slot_once</code>; <code>test_glob_context_manager_releases_slot_when_loop_breaks</code>.</td></tr>
-              <tr><td>Views</td><td><code>test_assembly_view_metadata_returns_exact_resolved_descriptor</code>; <code>test_existing_view_never_switches_generation</code>; <code>test_closing_one_view_rejects_that_view_and_leaves_sibling_view_usable</code>; metadata remains control-plane-only and only a refreshed/new view may observe a replacement generation.</td></tr>
+              <tr><td>Views</td><td><code>test_assembly_view_metadata_returns_exact_resolved_descriptor</code>; <code>test_existing_view_never_switches_generation</code>; <code>test_closing_one_view_rejects_that_view_and_leaves_sibling_view_usable</code>; metadata remains control-plane-only and only a newly resolved view may observe a replacement generation.</td></tr>
               <tr><td>Read-only façade</td><td><code>test_assembly_view_exposes_no_write_delete_copy_sync_or_presign_operations</code>; reader writes and truncate raise <code>UnsupportedOperation</code>.</td></tr>
               <tr><td>Consistency truthfulness</td><td><code>test_expiration_only_same_length_source_mutation_may_change_bytes_without_snapshot_claim</code>; two admitted operations may differ, the view remains <code>EXPIRATION_ONLY</code>, and stale mutable bytes are not reused.</td></tr>
               <tr><td>Reader</td><td><code>test_reader_supports_seek_tell_readinto_and_eof</code>; <code>test_range_zero_at_eof_past_eof_crossing_eof_negative_and_overflow_boundaries</code>; <code>test_reader_overrides_read_and_readall_instead_of_rawio_looping_default</code>; seek past EOF is allowed, seek before zero fails, and writes/truncate raise <code>UnsupportedOperation</code>.</td></tr>
@@ -2235,7 +2244,7 @@ multi-storage-client-docs/examples/
 
         <div class="callout info">
           Concrete transport-adapter behavior is outside the Assembly core test plan. Core acceptance proves the public SPI
-          with the minimal application-supplied in-process executor and contains no tests for hypothetical adapter modules.
+          with the minimal application-supplied in-process fetcher and contains no tests for hypothetical adapter modules.
         </div>
 
         <h3>14.8 In-process acceptance and compatibility</h3>
@@ -2254,9 +2263,9 @@ multi-storage-client-docs/examples/
           <li><code>test_range_capable_and_whole_result_services_both_pass_acceptance_flow</code></li>
           <li><code>test_enforced_service_revision_changes_between_plan_and_read_fail_atomically</code></li>
           <li><code>test_existing_open_handle_stays_on_original_generation_and_continues_after_expiration_until_close</code></li>
-          <li><code>test_expired_view_refresh_creates_replacement_generation_and_new_bytes</code></li>
-          <li><code>test_plan_cannot_select_executor_implementation_endpoint_or_credentials</code></li>
-          <li><code>test_in_process_acceptance_uses_minimal_application_executor</code></li>
+          <li><code>test_second_resolve_after_expiration_creates_replacement_generation_and_new_bytes</code></li>
+          <li><code>test_plan_cannot_select_fetcher_implementation_endpoint_or_credentials</code></li>
+          <li><code>test_in_process_acceptance_uses_minimal_application_fetcher</code></li>
           <li><code>test_assembly_import_is_opt_in_and_does_not_change_storage_client</code></li>
           <li><code>test_assembly_is_not_registered_in_storage_provider_enum_or_factory</code></li>
         </ul>
@@ -2276,7 +2285,6 @@ multi-storage-client-docs/examples/
             <thead><tr><th>Dimension</th><th>Values</th></tr></thead>
             <tbody>
               <tr><td>Objects per list</td><td>1, 1K, 100K, and the approved product maximum</td></tr>
-              <tr><td>List batching</td><td>1 object/batch, 1K objects/batch, encoded-byte-limited batches</td></tr>
               <tr><td>Segments / encoded plan</td><td>1, 8, 64, 512, 4,096, 16,384, configured 100K boundary, and the approved product segment/encoded-byte maxima</td></tr>
               <tr><td>Segment kind</td><td>object-only, service-only, inline-heavy at legal limit, mixed union</td></tr>
               <tr><td>Logical read</td><td>4 KiB, 1 MiB, 64 MiB</td></tr>
@@ -2297,9 +2305,9 @@ multi-storage-client-docs/examples/
           <li>List decode/traversal objects per second, exact-name lookup median/p95, time to first object, encoded bytes, and index build time.</li>
           <li>Peak RSS for streaming codec traversal, scan-backed store, exact-name store, and browse pages as object count grows.</li>
           <li>End-to-end median/p95, throughput, time to first internal chunk, and completion latency.</li>
-          <li>Core calls to <code>ServiceSegmentExecutor.execute</code>, result bytes, and source-byte amplification; executor-internal retries and transport metrics are executor-owned.</li>
+          <li>Core calls to <code>ServiceSegmentFetcher.fetch</code>, result bytes, and source-byte amplification; fetcher-internal retries and transport metrics are fetcher-owned.</li>
           <li>Peak RSS, output size, maximum in-flight response bytes, and plan cache footprint.</li>
-          <li>Complete-segment peak memory/temp-file bytes, stage count, core executor submissions, and read amplification.</li>
+          <li>Complete-segment peak memory/temp-file bytes, stage count, core fetch submissions, and read amplification.</li>
           <li>High-water marks and wait time for active operations, output memory, stage memory/disk, and in-flight object-byte budgets across concurrent callers and retained readers.</li>
           <li>Cancellation latency and active tasks/connections after failure.</li>
         </ul>
@@ -2316,7 +2324,7 @@ multi-storage-client-docs/examples/
           <li>Observed top-level operations, output-memory reservations, stage-memory/stage-disk reservations, and in-flight object bytes never exceed their client-wide limits under concurrent read/open/materialize/glob workloads; <code>max_active_operations=1</code> conveniences complete without nested-admission deadlock.</li>
           <li>Object request count equals the sum of <code>ceil(selected_source_bytes / max_object_read_chunk_bytes)</code> per logical object operation: caller-intersection bytes normally, complete segment bytes when a checksum is supplied. V1 performs no cross-segment coalescing.</li>
           <li>Peak Python read memory is bounded by up to twice the clamped returned length plus configured in-flight object/service chunks and complete-segment staging limits, not all unexecuted bytes.</li>
-          <li>WHOLE_RESULT core submission count is exactly one <code>execute</code> call per touched operation-local <code>(generation, plan_digest, segment_ordinal)</code> per top-level operation; this key is not reused across providers or bindings. Executor-internal SAFE attempts belong to that executor's own conformance tests. Successful cleanup removes private files; an injected unlink failure remains charged, is retried, and surfaces through the specified redacted error/close record rather than being reported as success.</li>
+          <li>WHOLE_RESULT core submission count is exactly one <code>fetch</code> call per touched operation-local <code>(generation, plan_digest, segment_ordinal)</code> per top-level operation; this key is not reused across providers or bindings. Fetcher-internal SAFE attempts belong to that fetcher's own conformance tests. Successful cleanup removes private files; an injected unlink failure remains charged, is retried, and surfaces through the specified redacted error/close record rather than being reported as success.</li>
           <li>Failure cancellation closes/drains queued work, internal waits, and cooperative service streams within the remaining operation deadline. A synchronous <code>StorageClient.read</code> already in progress is measured separately and is not claimed to be preemptible by Assembly.</li>
         </ul>
         <p>
@@ -2331,19 +2339,19 @@ multi-storage-client-docs/examples/
 
         <div class="phase">
           <div class="phase-name">Gate 0<br><span class="small">Contract</span></div>
-          <div><strong>Approve contracts, limits, and product scale inputs.</strong> Freeze <code>assembly-list/v1</code>, expiration/refresh/in-flight semantics, union kinds, complete-plan/global-length invariant, both consistency policies, service range/retry rules, 16/64 KiB inline ceilings, complete-segment staging limits, exception taxonomy, and ownership. Record that v1 has internal cancellation only and that the current synchronous StorageClient call is checked before/after—but cannot be preempted by—the Assembly deadline. Keep the v1 object binding client-only, StorageClients always borrowed, and logical-byte caching disabled. Product owners must approve the proposed object-count, list-size/segment, workload, operational defaults, and memory envelope before those defaults become stable. Add golden fixtures; no runtime integration yet.</div>
+          <div><strong>Approve contracts, limits, and product scale inputs.</strong> Freeze <code>assembly-list/v1</code>, exact-result semantics, expiration/re-resolution/in-flight semantics, union kinds, complete-plan/global-length invariant, both consistency policies, service range/retry rules, 16/64 KiB inline ceilings, complete-segment staging limits, exception taxonomy, and ownership. Record that v1 has internal cancellation only and that the current synchronous StorageClient call is checked before/after—but cannot be preempted by—the Assembly deadline. Keep the v1 object binding client-only, StorageClients always borrowed, and logical-byte caching disabled. Product owners must approve the proposed object-count, list-size/segment, workload, operational defaults, and memory envelope before those defaults become stable. Add golden fixtures; no runtime integration yet.</div>
         </div>
         <div class="phase">
           <div class="phase-name">Gate 1<br><span class="small">Resolve and view</span></div>
-          <div><strong>Implement the metadata-to-executable pipeline.</strong> List codec/batches, canonical models, <code>resolve_descriptor</code>, complete-plan retrieval, validation, frozen binding registries, capability computation, and <code>AssemblyView.metadata</code>. No view is exposed and no byte I/O occurs before the complete plan passes.</div>
+          <div><strong>Implement the metadata-to-executable pipeline.</strong> List codec/batches, canonical models, the single <code>get_plan(request)</code> provider call, validation, frozen binding registries, capability computation, and <code>AssemblyView.metadata</code>. No view is exposed and no byte I/O occurs before the returned complete plan passes validation.</div>
         </div>
         <div class="phase">
           <div class="phase-name">Gate 2<br><span class="small">Core execution</span></div>
-          <div><strong>Implement the complete Python execution path.</strong> Direct StorageClient reads, user-defined ServiceSegmentExecutor wiring, inline bytes, bounded staging, range planning, client/view/reader, lifecycle, and atomic materialization. Core E2E must pass without an HTTP adapter or network server.</div>
+          <div><strong>Implement the complete Python execution path.</strong> Direct StorageClient reads, user-defined ServiceSegmentFetcher wiring, inline bytes, bounded staging, range planning, client/view/reader, lifecycle, and atomic materialization. Core E2E must pass without an HTTP adapter or network server.</div>
         </div>
         <div class="phase">
           <div class="phase-name">Gate 3<br><span class="small">Integration</span></div>
-          <div><strong>Exercise the complete union and third-party conformance.</strong> Range/whole-result user services, multiple StorageClients, inline limits, expiration/refresh, staging, lifecycle, redaction, failure injection, and unchanged existing MSC tests.</div>
+          <div><strong>Exercise the complete union and third-party conformance.</strong> Range/whole-result user services, multiple StorageClients, inline limits, expiration/re-resolution, staging, lifecycle, redaction, failure injection, and unchanged existing MSC tests.</div>
         </div>
         <div class="phase">
           <div class="phase-name">Gate 4<br><span class="small">Release</span></div>
@@ -2376,12 +2384,12 @@ multi-storage-client-docs/examples/
               <tr><td>Default mode is mistaken for snapshot consistency.</td><td>Name it EXPIRATION_ONLY, permit optional selectors/validators/revisions honestly, disable unsafe byte caching, and document same-length mutation risk.</td></tr>
               <tr><td>Current StorageClient cannot atomically pin a mutable version.</td><td>Default direct read remains allowed; in v1, SNAPSHOT_PINNED requires complete checksum verification for object segments. A later additive conditional-read binding may enforce selectors or validators.</td></tr>
               <tr><td>Complete service/checksum verification exhausts memory or disk.</td><td>Reserve each complete-segment stage immediately before launch, serialize individually feasible forward stages, enforce memory/result/temp ceilings, and verify length/digest before publication.</td></tr>
-              <tr><td>Unsafe service operation is retried.</td><td>RetrySafety defaults NEVER; NEVER permits one private attempt even if no response bytes arrive, only SAFE permits executor-owned bounded retry, and Assembly adds no outer retry.</td></tr>
+              <tr><td>Unsafe service operation is retried.</td><td>RetrySafety defaults NEVER; NEVER permits one private attempt even if no response bytes arrive, only SAFE permits fetcher-owned bounded retry, and Assembly adds no outer retry.</td></tr>
               <tr><td>Inline becomes a bulk-data path.</td><td>Hard 16 KiB per-segment and 64 KiB aggregate upper ceilings (configuration may only lower) plus encoded-plan limits.</td></tr>
               <tr><td>Large lists make lookup/traversal or memory unusable.</td><td>Versioned batches, bounded public codec, AssemblyListStore contract, bounded small-list provider, and blocking product-envelope tests.</td></tr>
               <tr><td>Provider returns huge or malicious plans.</td><td>Canonical bounded decoder and semantic validation before allocation/I/O.</td></tr>
-              <tr><td>Remote plans drive authority or credential escape.</td><td>Separate immutable object/service registries, least-privilege bound StorageClient namespaces, no plan-controlled client configuration, and executor-owned operation confinement.</td></tr>
-              <tr><td>Nested retries multiply attempts.</td><td>Assembly performs no outer source retry; SAFE service retries remain executor-owned and bounded, while NEVER remains exactly one attempt.</td></tr>
+              <tr><td>Remote plans drive authority or credential escape.</td><td>Separate immutable object/service registries, least-privilege bound StorageClient namespaces, no plan-controlled client configuration, and fetcher-owned operation confinement.</td></tr>
+              <tr><td>Nested retries multiply attempts.</td><td>Assembly performs no outer source retry; SAFE service retries remain fetcher-owned and bounded, while NEVER remains exactly one attempt.</td></tr>
               <tr><td>Python sync calls cannot be forcibly cancelled.</td><td>The deadline hard-bounds admission, internal waits, and cooperative provider/service work. Current StorageClient reads are checked before/after, use application-configured underlying timeouts, and may outlive the Assembly deadline; MSC makes no preemption claim.</td></tr>
               <tr><td>Plan cache mixes bindings/provider generations or survives expiration.</td><td>Frozen concrete bindings, per-client registry-snapshot scope, hard expiry, and commit-after-validation; logical-byte caching is disabled in v1.</td></tr>
               <tr><td>Scope expands back into StorageClient/provider hierarchy.</td><td>Import-boundary and private-provider regression tests; no factory/config changes in v1.</td></tr>
@@ -2394,13 +2402,13 @@ multi-storage-client-docs/examples/
           <li>High-level API and capability approval gates are signed off.</li>
           <li>All new public types have complete docstrings and Sphinx reference entries.</li>
           <li>The versioned language-neutral list codec publishes golden vectors for batches and every explicit segment kind.</li>
-          <li>Provider and ServiceSegmentExecutor conformance suites are reusable outside the MSC repository.</li>
-          <li><code>resolve_descriptor</code> returns metadata only; <code>AssemblyClient.resolve</code> exposes an executable view only after complete-plan validation and binding freeze.</li>
+          <li>Provider and ServiceSegmentFetcher conformance suites are reusable outside the MSC repository.</li>
+          <li><code>AssemblyPlanProvider.get_plan(request)</code> returns descriptor metadata and a complete exact-result plan in one call; <code>AssemblyClient.resolve</code> exposes an executable view only after validation and binding freeze.</li>
           <li><code>AssemblyView.metadata</code> returns the exact descriptor used to create that view.</li>
           <li>Validation proves checked global logical length and rejects expired/malformed plans before object/service I/O.</li>
-          <li>A mixed object/service/inline plan passes full, partial, seekable, and materialization E2E cases through a user-defined in-process service executor with no HTTP-adapter dependency.</li>
-          <li>Expiration-only and snapshot-pinned guarantees are separately tested and documented; refresh always creates a new view for a replacement generation.</li>
-          <li>Range-capable and whole-result services pass stability, retry-safety, bounded complete-segment staging, and cleanup tests. For <code>RetrySafety.NEVER</code>, MSC proves there is no second core <code>execute()</code> invocation after pre-response or partial-stream failure; executor owners separately verify that their opaque implementation performs at most one private attempt.</li>
+          <li>A mixed object/service/inline plan passes full, partial, seekable, and materialization E2E cases through a user-defined in-process service fetcher with no HTTP-adapter dependency.</li>
+          <li>Expiration-only and snapshot-pinned guarantees are separately tested and documented; another <code>resolve(reference)</code> creates a distinct replacement view without mutating the expired generation.</li>
+          <li>Range-capable and whole-result services pass stability, retry-safety, bounded complete-segment staging, and cleanup tests. For <code>RetrySafety.NEVER</code>, MSC proves there is no second core <code>fetch()</code> invocation after pre-response or partial-stream failure; fetcher owners separately verify that their opaque implementation performs at most one private attempt.</li>
           <li>Checksum-bearing object operations carry a complete <code>fetch_range</code> and a distinct <code>selected_range_in_fetch</code>, verify before copying that slice, and ordinary reads fetch only their intersection.</li>
           <li>Deadline documentation and tests distinguish hard-bounded MSC/cooperative waits from non-preemptible synchronous StorageClient calls, and v1 makes no public caller-cancellation claim.</li>
           <li>Private stage and materialization files use exclusive no-follow creation where supported and POSIX mode <code>0600</code>; published files retain the effective mode.</li>

--- a/specs/2026-07-21-assembly-view/implementation-and-test-plan.html
+++ b/specs/2026-07-21-assembly-view/implementation-and-test-plan.html
@@ -321,7 +321,7 @@
         <span>Spec date: 2026-07-21</span>
         <span>Last revised: 2026-08-25</span>
         <span>Status: Proposed</span>
-        <span>Depends on: High-Level Design approval</span>
+        <span>Baseline: approved High-Level Design</span>
         <span>Initial release: Read-only and opt-in</span>
       </div>
       <div class="doc-links">
@@ -343,16 +343,15 @@
       <a href="#validation">6. Validation and planning</a>
       <a href="#sources">7. Object and service bindings</a>
       <a href="#executor">8. Executor, view, reader</a>
-      <a href="#http-adapter">9. Optional HTTP adapter</a>
-      <a href="#python-scope">10. Python-only scope</a>
-      <a href="#operations">11. Operational semantics</a>
-      <a href="#files">12. File-level plan</a>
-      <a href="#test-architecture">13. Test architecture</a>
-      <a href="#test-cases">14. Detailed test cases</a>
-      <a href="#performance">15. Performance plan</a>
-      <a href="#rollout">16. Delivery gates</a>
-      <a href="#risks">17. Risks and completion</a>
-      <a href="#commands">18. Commands and references</a>
+      <a href="#python-scope">9. Python-only scope</a>
+      <a href="#operations">10. Operational semantics</a>
+      <a href="#files">11. File-level plan</a>
+      <a href="#test-architecture">12. Test architecture</a>
+      <a href="#test-cases">13. Detailed test cases</a>
+      <a href="#performance">14. Performance plan</a>
+      <a href="#rollout">15. Delivery gates</a>
+      <a href="#risks">16. Risks and completion</a>
+      <a href="#commands">17. Commands and references</a>
     </nav>
 
     <main>
@@ -390,7 +389,7 @@
           <li>No <code>StorageClient</code> subclass and no implicit registration in storage profiles, provider factories, or URI routing.</li>
           <li>No MSC-defined HTTP/gRPC contract for the plan service; only the in-process provider SPI is standardized.</li>
           <li>No plan-supplied credentials, unrestricted origins, storage profiles, or arbitrary executable callbacks. Any future opaque service locator remains subject to local fetcher policy.</li>
-          <li>Every descriptor and portable-list snapshot has a mandatory expiration. The default <code>EXPIRATION_ONLY</code> policy does not pretend optional selectors, validators, or operation revisions are enforced; <code>SNAPSHOT_PINNED</code> is an explicit stricter opt-in.</li>
+          <li>Every descriptor and portable-list batch set has a mandatory expiration. V1 validates expiration and exact lengths; source selectors, validators, revisions, and checksums are deferred.</li>
           <li>A read, materialization, or open-reader lifetime may cross expiration only if admitted while the descriptor was valid. New operations on that view fail until the caller explicitly resolves a new view.</li>
           <li>Object, service, and inline segments remain an explicit public discriminated union; service transport adapters remain application-owned behind the public fetcher SPI.</li>
           <li>The initial public façade is synchronous, read-only, explicit, and importable from <code>multistorageclient.assembly</code>; the execution engine must still overlap independent I/O under bounded concurrency.</li>
@@ -405,18 +404,18 @@
           </div>
           <div class="card">
             <span class="label">Defensive design, not a requirement</span>
-            <p class="small">Requirements do not explicitly require <code>binding_revision</code> or <code>resource_validator</code>. V1 keeps <code>ObjectSourceBinding</code> client-only, scopes instruction caches to one client and frozen registry snapshot, disables logical-byte caching, and adds no public provider-specific resource-policy hook.</p>
+            <p class="small">Requirements do not explicitly require <code>binding_revision</code> or <code>resource_validator</code>. V1 keeps <code>ObjectSourceBinding</code> client-only, disables logical-byte caching, and adds no public provider-specific resource-policy hook.</p>
           </div>
           <div class="card">
-            <span class="label">Separate optional follow-up</span>
-            <p class="small">Requirements do not explicitly require a built-in HTTP fetcher, an MSC-defined external service API, or a format-specific projection handler. Any generic HTTP convenience adapter requires separate approval.</p>
+            <span class="label">Explicit non-goals</span>
+            <p class="small">V1 defines no built-in service fetcher, external service API, or format-specific projection handler. Applications supply service integrations behind <code>ServiceSegmentFetcher</code>.</p>
           </div>
         </div>
 
         <div class="callout">
-          This is an implementation proposal, not implementation authorization. Public types, capability semantics, strict
-          expiration behavior, consistency policies, inline limits, service capabilities, and product scale inputs are
-          approval gates before core source code changes begin. The optional generic HTTP adapter contract is not a core approval gate.
+          This document records the approved v1 architectural direction. Public SPI or schema changes still receive normal API
+          review during implementation, while private safety constants are verified by focused tests and benchmarks.
+          Concrete transport adapters are outside this specification.
         </div>
       </section>
 
@@ -426,7 +425,7 @@
           <div class="arch-row">
             <div class="arch-node user"><strong>Plan provider</strong><br><code>AssemblyPlanProvider</code><br><span class="small">logical request → metadata-bearing complete object plan</span></div>
             <div class="arch-node new"><strong>AssemblyClient / View</strong><br><span class="small">expiration policy and user API</span></div>
-            <div class="arch-node new"><strong>Assembly caches</strong><br><span class="small">all instruction-derived entries expire with their descriptor</span></div>
+            <div class="arch-node new"><strong>Frozen AssemblyView</strong><br><span class="small">one validated plan and binding snapshot</span></div>
           </div>
           <div class="arch-arrow">provider output → validate complete object → intersect caller range → dispatch segment kinds</div>
           <div class="arch-row">
@@ -462,12 +461,12 @@
 
       <section id="runtime">
         <h2>3. Runtime flow from public entry point to bytes</h2>
-        <p>The complete call path for <code>assembly.read(reference, ByteRange(28672, 20480))</code> is:</p>
+        <p>The complete call path for <code>view = assembly.resolve(reference)</code> followed by <code>view.read(ByteRange(28672, 20480))</code> is:</p>
 
         <div class="sequence">
           <div class="sequence-item">
-            <strong>Normalize the request</strong>
-            <span><code>AssemblyClient.read</code> canonicalizes the reference and range, checks client state, and rejects limits before any provider, StorageClient, or service-fetcher call.</span>
+            <strong>Resolve the reference</strong>
+            <span><code>AssemblyClient.resolve</code> canonicalizes the reference, checks client state, and rejects request limits before any provider, StorageClient, or service-fetcher call.</span>
           </div>
           <div class="sequence-item">
             <strong>Acquire one complete object plan</strong>
@@ -475,7 +474,7 @@
           </div>
           <div class="sequence-item">
             <strong>Validate and publish the view</strong>
-            <span>The validator checks exact v1 result semantics, the segment discriminator, checked global length, hard inline limits, aliases, optional selectors/validators/operation revisions/checksums, and the selected consistency policy. It then freezes the resolved local source/service objects and computes capabilities. Only now does <code>AssemblyClient.resolve</code> return an executable <code>AssemblyView</code> containing the descriptor, validated complete plan, frozen bindings, consistency/capabilities, and lifecycle state. Another resolve call repeats this pipeline and returns another view.</span>
+            <span>The validator checks exact v1 result semantics, the segment discriminator, checked global length, hard inline limits, and aliases. It then snapshots JSON inputs and freezes the resolved local source/service objects. Only now does <code>AssemblyClient.resolve</code> return an executable <code>AssemblyView</code> containing the descriptor, validated complete plan, frozen bindings, and lifecycle state. Another resolve call repeats this pipeline and returns another view.</span>
           </div>
           <div class="sequence-item">
             <strong>Intersect the caller range</strong>
@@ -483,11 +482,11 @@
           </div>
           <div class="sequence-item">
             <strong>Dispatch bounded operations</strong>
-            <span>Object segments call existing StorageClient APIs directly. Range-capable services receive stable subranges. Each touched WHOLE_RESULT stage key—descriptor generation, plan digest, and segment ordinal—gets one logical fetch submission per top-level operation and is staged under fixed memory/temp-file bounds before slicing; a SAFE fetcher may make multiple private transport attempts.</span>
+            <span>Object segments call existing StorageClient APIs directly. Range-capable services receive stable subranges. Each touched WHOLE_RESULT segment gets one core fetch call per view operation and is staged under fixed memory/temp-file bounds before slicing. Any private retry remains opaque fetcher behavior.</span>
           </div>
           <div class="sequence-item">
             <strong>Verify every chunk</strong>
-            <span>Each binding enforces only capabilities present in its concrete contract: the initial object binding rejects selectors/enforcing validators, while service fetchers validate advertised revision and retry semantics. A checksum may be absent, but when supplied MSC always stages and verifies the complete segment before exposing any slice.</span>
+            <span>Object bindings return exact requested ranges through StorageClient. Service fetchers advertise only their supported range modes and must return the exact required length. Stronger source identity and fetcher-internal retry policy remain application concerns.</span>
           </div>
           <div class="sequence-item">
             <strong>Commit atomically</strong>
@@ -510,132 +509,73 @@
         <div class="callout info">
           Expiration is an admission check, not an in-flight cancellation deadline. An operation admitted while the descriptor is
           valid may finish after <code>expires_at</code>. Its result may be published to the caller or atomically materialized,
-          but no instruction-derived cache entry is usable after expiration. A completed materialized file has an independent,
+          but a new operation cannot start on that view after expiration. A completed materialized file has an independent,
           application-owned retention lifetime and does not become invalid merely because its source descriptor later expires.
         </div>
       </section>
 
       <section id="contracts">
-        <h2>4. Concrete contracts and immutable models</h2>
+        <h2>4. Concrete MVP contracts and models</h2>
         <p>
-          Public models live in Python, use frozen slotted dataclasses, and are validated at construction and again at trust
-          boundaries. <code>assembly-list/v1</code> is a normative, versioned, language-neutral JSON representation; providers
-          may construct the equivalent models directly, but they do not get a private Python-only semantic contract.
+          Public models live in Python and use small frozen slotted dataclasses for their top-level fields. Nested JSON inputs
+          stay ordinary mappings and lists for usability; they are validated and copied into a private immutable execution
+          representation at the trust boundary. <code>assembly-list/v1</code> is a normative, versioned, language-neutral JSON
+          representation, and providers may construct the equivalent public models directly.
         </p>
         <div class="callout info">
           <strong>Descriptor is not view.</strong> <code>AssemblyDescriptor</code> is immutable control-plane metadata and has
           no byte-I/O methods. <code>AssemblyView</code> is the executable handle created only after MSC retrieves and validates
-          the complete <code>AssemblyPlan</code>, freezes local bindings, computes consistency/capabilities, and initializes
+          the complete <code>AssemblyPlan</code>, freezes local bindings, and initializes
           lifecycle state. <code>AssemblyView.metadata</code> returns the exact descriptor captured by that view.
         </div>
 
         <div class="callout">
           <strong>V1 result semantics are exact and permanent.</strong> <code>assembly-plan/v1</code> always describes the
           caller's complete final logical bytes. Optional application annotations are informational and cannot require a
-          format-specific projection step. Any future carrier-plus-projection contract uses a new plan version, a required
-          capability, and a separate format-aware façade; a v1 client must reject it rather than silently materialize a superset.
+          format-specific projection step. Any future carrier-plus-projection contract uses a new plan version and a separate
+          format-aware façade; a v1 client must reject it rather than silently materialize a superset.
         </div>
 
         <h3>API and protocol evolution rules</h3>
         <ul>
-          <li>Unknown list/plan versions, required capabilities, segment kinds, and fields are rejected before binding or byte I/O. Supporting a future version never changes the interpretation of a valid v1 artifact.</li>
+          <li>Unknown list/plan versions, segment kinds, and fields are rejected before binding or byte I/O. Supporting a future version never changes the interpretation of a valid v1 artifact.</li>
           <li>Published provider and fetcher ABCs never gain a required abstract method within v1. Optional behavior uses a concrete default method or a new versioned SPI.</li>
-          <li>New façade and configuration parameters are keyword-only and carry backward-compatible defaults. New serialized model semantics require a new versioned type.</li>
+          <li>New façade parameters are keyword-only and carry backward-compatible defaults. New serialized model semantics require a new versioned type.</li>
           <li>A future format-aware projection façade is additive and separate from <code>AssemblyView</code>; existing callers continue to receive the exact bytes defined by v1.</li>
         </ul>
 
         <div class="callout info">
-          <strong>Gate 0 status.</strong> Numeric operational defaults shown in this section are proposed inputs, not stable API
-          defaults, until the product scale and memory envelope is approved. The 16 KiB per-inline-segment and 64 KiB
-          inline-per-object values are different: they are normative hard upper ceilings, and configuration may only lower them.
+          <strong>MVP configuration rule.</strong> Users configure only concurrency and operation timeout. Size, nesting,
+          inline-data, buffering, and staging safeguards are private module constants. Changing one is an implementation
+          review, not an expansion of the public API.
         </div>
 
-        <pre><code>JsonScalarInput = str | int | float | bool | None
-JsonInput = JsonScalarInput | Sequence["JsonInput"] | Mapping[str, "JsonInput"]
-
-@dataclass(frozen=True, slots=True)
-class FrozenJsonScalar:
-    kind: Literal["null", "boolean", "number", "string"]
-    value: None | bool | str  # number stores its canonical RFC 8785 spelling
-
-    @classmethod
-    def from_value(cls, value: JsonScalarInput) -> "FrozenJsonScalar": ...
-
-@dataclass(frozen=True, slots=True)
-class FrozenJsonArray:
-    items: tuple["JsonValue", ...]
-
-@dataclass(frozen=True, slots=True)
-class FrozenJsonObject:
-    items: tuple[tuple[str, "JsonValue"], ...]
-
-    @classmethod
-    def from_mapping(cls, value: Mapping[str, JsonInput]) -> "FrozenJsonObject": ...
-
-JsonValue = FrozenJsonScalar | FrozenJsonArray | FrozenJsonObject
+        <pre><code>JsonScalar: TypeAlias = None | bool | int | float | str
+JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
 ASSEMBLY_LIST_SCHEMA_V1: Final = "assembly-list/v1"
 ASSEMBLY_PLAN_SCHEMA_V1: Final = "assembly-plan/v1"
-
-class AssemblyConsistency(Enum):
-    EXPIRATION_ONLY = "expiration_only"       # default
-    SNAPSHOT_PINNED = "snapshot_pinned"       # explicit stricter opt-in
 
 class ServiceRangeMode(Enum):
     STABLE_SUBRANGES = "stable_subranges"
     WHOLE_RESULT = "whole_result"
 
-class RetrySafety(Enum):
-    NEVER = "never"
-    SAFE = "safe"
-
-class RevisionUse(Enum):
-    ENFORCE_DURING_READ = "enforce_during_read"
-    IDENTITY_ONLY = "identity_only"
-
 StrPath = str | os.PathLike[str]
 
-# Gate 0 must approve the proposed operational defaults below before they
-# become stable API defaults. The 16 KiB per-segment and 64 KiB per-object
-# inline values are normative hard upper ceilings; configuration may lower
-# but never raise them.
-@dataclass(frozen=True, slots=True)
-class AssemblyClientConfig:
-    max_concurrency: int = 16
-    max_active_operations: int = 64
-    max_segments_per_object: int = 100_000
-    max_plan_bytes: int = 16 * 1024 * 1024
-    max_read_bytes: int = 512 * 1024 * 1024
-    max_output_memory_bytes_total: int = 2 * 1024**3
-    materialization_window_bytes: int = 64 * 1024 * 1024
-    max_object_read_chunk_bytes: int = 64 * 1024 * 1024
-    max_inflight_object_bytes: int = 256 * 1024 * 1024
-    max_service_chunk_bytes: int = 1024 * 1024
-    max_object_bytes: int = 16 * 1024**4
-    max_namespace_utf8_bytes: int = 1024
-    max_key_utf8_bytes: int = 16 * 1024
-    max_reference_parameters: int = 128
-    max_resource_utf8_bytes: int = 16 * 1024
-    max_operation_utf8_bytes: int = 1024
-    max_identity_metadata_utf8_bytes: int = 64 * 1024
-    max_parameter_depth: int = 32
-    max_parameter_items: int = 10_000
-    max_parameter_canonical_bytes: int = 1024 * 1024
-    max_inline_segment_bytes: int = 16 * 1024
-    max_inline_bytes_per_object: int = 64 * 1024
-    max_complete_segment_memory_bytes: int = 64 * 1024 * 1024
-    max_complete_segment_staged_bytes: int = 16 * 1024**3
-    max_staging_memory_bytes_per_operation: int = 256 * 1024 * 1024
-    max_staging_bytes_per_operation: int = 32 * 1024**3
-    max_staging_memory_bytes_total: int = 1024**3
-    max_staging_bytes_total: int = 128 * 1024**3
-    staging_directory: StrPath | None = None
-    operation_timeout_seconds: float = 300.0
-    max_list_page_size: int = 10_000
-    max_cursor_utf8_bytes: int = 16 * 1024
-    max_glob_results: int = 100_000
-    max_glob_scanned_items: int = 1_000_000
-    plan_cache_entries: int = 256
-    required_consistency: AssemblyConsistency = AssemblyConsistency.EXPIRATION_ONLY
+# Internal safeguards in multistorageclient.assembly.limits.
+MAX_SEGMENTS_PER_OBJECT: Final = 100_000
+MAX_PLAN_BYTES: Final = 16 * 1024 * 1024
+MAX_READ_BYTES: Final = 512 * 1024 * 1024
+MAX_OBJECT_BYTES: Final = 16 * 1024**4
+OBJECT_READ_CHUNK_BYTES: Final = 64 * 1024 * 1024
+SERVICE_CHUNK_BYTES: Final = 1024 * 1024
+MATERIALIZATION_WINDOW_BYTES: Final = 64 * 1024 * 1024
+MAX_INLINE_SEGMENT_BYTES: Final = 16 * 1024
+MAX_INLINE_BYTES_PER_OBJECT: Final = 64 * 1024
+MAX_WHOLE_RESULT_BYTES: Final = 1024**3
+MAX_BATCH_BYTES: Final = 64 * 1024 * 1024
+MAX_OBJECTS_PER_BATCH: Final = 100_000
+MAX_STATIC_OBJECTS: Final = 1_000_000
+MAX_JSON_DEPTH: Final = 64
 
 @dataclass(frozen=True, slots=True)
 class ByteRange:
@@ -646,39 +586,13 @@ class ByteRange:
 class AssemblyReference:
     namespace: str
     key: str
-    parameters: tuple[tuple[str, FrozenJsonScalar], ...] = ()
-
-    @classmethod
-    def from_mapping(
-        cls,
-        *,
-        namespace: str,
-        key: str,
-        parameters: Mapping[str, JsonScalarInput] | None = None,
-    ) -> "AssemblyReference": ...
+    parameters: Mapping[str, JsonScalar] = field(default_factory=dict)
 
 @dataclass(frozen=True, slots=True)
 class ResolveAssemblyRequest:
     reference: AssemblyReference
     generation: str | None = None
     deadline_monotonic: float | None = field(default=None, compare=False, hash=False, repr=False)
-
-@dataclass(frozen=True, slots=True)
-class SourceSelector:
-    kind: str
-    value: str
-
-@dataclass(frozen=True, slots=True)
-class SourceValidator:
-    kind: str
-    value: str
-    use: RevisionUse
-
-@dataclass(frozen=True, slots=True)
-class OperationRevision:
-    kind: str
-    value: str
-    use: RevisionUse
 
 @dataclass(frozen=True, slots=True)
 class AssemblyDescriptor:
@@ -692,46 +606,21 @@ class AssemblyDescriptor:
     published_at: datetime | None = None
 
 @dataclass(frozen=True, slots=True)
-class ListAssembliesRequest:
-    namespace: str
-    prefix: str = ""
-    cursor: str | None = None
-    page_size: int = 1000
-    deadline_monotonic: float | None = field(default=None, compare=False, hash=False, repr=False)
-
-@dataclass(frozen=True, slots=True)
-class AssemblyPage:
-    listing_generation: str
-    items: tuple[AssemblyDescriptor, ...]
-    next_cursor: str | None = None
-
-@dataclass(frozen=True, slots=True)
-class Checksum:
-    algorithm: Literal["sha256"]
-    value: str  # 64 lowercase hexadecimal characters
-
-@dataclass(frozen=True, slots=True)
 class ObjectSegment:
     kind: Literal["object"]
     source_id: str
     resource: str
     byte_range: ByteRange
     length: int
-    selector: SourceSelector | None = None
-    validator: SourceValidator | None = None
-    checksum: Checksum | None = None
 
 @dataclass(frozen=True, slots=True)
 class ServiceSegment:
     kind: Literal["service"]
     fetcher_id: str
     operation: str
-    parameters: FrozenJsonObject
+    parameters: Mapping[str, JsonValue]
     length: int
     range_mode: ServiceRangeMode = ServiceRangeMode.WHOLE_RESULT
-    retry_safety: RetrySafety = RetrySafety.NEVER
-    operation_revision: OperationRevision | None = None
-    checksum: Checksum | None = None
 
 @dataclass(frozen=True, slots=True)
 class InlineSegment:
@@ -756,7 +645,6 @@ class AssemblyPlan:
     result_semantics: Literal["exact"]
     descriptor: AssemblyDescriptor
     segments: tuple[AssemblySegment, ...]
-    plan_digest: str
 
     @classmethod
     def create(
@@ -772,47 +660,26 @@ class AssemblyPlan:
 class AssemblyListBatch:
     schema_version: Literal["assembly-list/v1"]
     list_id: str
-    issued_at: datetime
     expires_at: datetime
     batch_index: int
     batch_count: int
-    objects: tuple[AssemblyObjectDefinition, ...]  # never split across batches
-    batch_digest: str</code></pre>
+    objects: tuple[AssemblyObjectDefinition, ...]  # never split across batches</code></pre>
 
-        <pre><code>@dataclass(frozen=True, slots=True)
-class AssemblyListSnapshot:
-    list_id: str
-    issued_at: datetime
-    expires_at: datetime
-    batch_count: int
+        <p>
+          <code>JsonValue</code> is only a typing alias for transport-neutral service parameters; it is not a runtime wrapper
+          hierarchy. At <code>resolve()</code>, MSC validates JSON types and nesting, deep-copies parameters and reference
+          scalars, and stores them in a private immutable execution plan. Provider-owned dictionaries can therefore change
+          later without mutating an existing view.
+        </p>
 
-@dataclass(frozen=True, slots=True)
-class AssemblyListDecodeLimits:
-    max_encoded_batch_bytes: int = 64 * 1024 * 1024
-    max_objects_per_batch: int = 100_000
-    max_segments_per_object: int = 100_000
-    max_json_depth: int = 64
-    max_json_string_utf8_bytes: int = 1024 * 1024
-    max_json_nodes_per_batch: int = 2_000_000
-
-@dataclass(frozen=True, slots=True)
-class InMemoryAssemblyListLimits:
-    max_objects: int = 100_000
-    max_segments: int = 1_000_000
-    max_canonical_bytes: int = 256 * 1024 * 1024
-
-def decode_assembly_list_batch(
+        <pre><code>def decode_assembly_list_batch(
     data: bytes | bytearray | memoryview | str,
-    *,
-    limits: AssemblyListDecodeLimits | None = None,
 ) -> AssemblyListBatch: ...
 
 def encode_assembly_list_batch(batch: AssemblyListBatch) -> bytes: ...
 
 def iter_decode_assembly_list_batches(
     stream: BinaryIO,
-    *,
-    limits: AssemblyListDecodeLimits | None = None,
 ) -> Iterator[AssemblyListBatch]: ...
 
 def write_assembly_list_batches(
@@ -823,21 +690,10 @@ def write_assembly_list_batches(
         <h3 id="public-facade-reference">Exact public façade reference</h3>
         <p>
           The high-level design intentionally shows only the common workflow. This subsection is the normative signature
-          reference for the façade, view, reader, optional browsing iterator, and their advertised capabilities. Providers
+          reference for the façade, view, and forward-only reader. Providers
           return metadata-bearing plans; only the client returns views.
         </p>
         <pre><code>RangeLike = ByteRange | multistorageclient.types.Range  # copied immediately to ByteRange
-
-@dataclass(frozen=True, slots=True)
-class AssemblyCapabilities:
-    browse: bool
-
-@dataclass(frozen=True, slots=True)
-class AssemblyViewCapabilities:
-    byte_range_read: bool
-    streaming_open: bool
-    seek: bool
-    consistency: AssemblyConsistency
 
 class AssemblyClient:
     def __init__(
@@ -846,39 +702,19 @@ class AssemblyClient:
         plan_provider: AssemblyPlanProvider,
         object_sources: Mapping[str, ObjectSourceBinding],
         service_fetchers: Mapping[str, ServiceSegmentFetcher],
-        config: AssemblyClientConfig | None = None,
-        close_dependencies: bool = False,
+        max_concurrency: int = 16,
+        timeout_seconds: float = 300.0,
     ) -> None: ...
-
-    @property
-    def capabilities(self) -> AssemblyCapabilities: ...
 
     def resolve(
         self,
         reference: AssemblyReference | str,
         *,
         generation: str | None = None,
-        required_consistency: AssemblyConsistency | None = None,
     ) -> AssemblyView:
-        """Return only after descriptor, complete plan, bindings, and capabilities are valid."""
+        """Return only after descriptor, complete plan, and bindings are valid."""
         ...
 
-    def info(
-        self,
-        reference: AssemblyReference | str,
-        *,
-        generation: str | None = None,
-    ) -> AssemblyDescriptor:
-        """Resolve and validate the complete plan, then return its descriptor.
-
-        Do not perform object/service byte I/O.
-        """
-        ...
-    def read(self, reference: AssemblyReference | str, byte_range: RangeLike | None = None, *, generation: str | None = None, required_consistency: AssemblyConsistency | None = None) -> bytes: ...
-    def open(self, reference: AssemblyReference | str, *, generation: str | None = None, required_consistency: AssemblyConsistency | None = None) -> AssemblyReader: ...
-    def materialize(self, reference: AssemblyReference | str, destination: StrPath, *, generation: str | None = None, required_consistency: AssemblyConsistency | None = None, overwrite: bool = False, fsync: bool = False) -> None: ...
-    def list(self, *, namespace: str, prefix: str = "", cursor: str | None = None, page_size: int = 1000) -> AssemblyPage: ...
-    def glob(self, *, namespace: str, pattern: str) -> "AssemblyGlobIterator": ...
     def close(self) -> None: ...
     def __enter__(self) -> "AssemblyClient": ...
     def __exit__(self, *exc: object) -> None: ...
@@ -889,18 +725,9 @@ class AssemblyView:
         """Return this executable view's immutable control-plane descriptor."""
         ...
 
-    @property
-    def consistency(self) -> AssemblyConsistency: ...
-
-    @property
-    def required_consistency(self) -> AssemblyConsistency: ...
-
-    @property
-    def capabilities(self) -> AssemblyViewCapabilities: ...
-
     def read(self, byte_range: RangeLike | None = None) -> bytes: ...
     def open(self) -> AssemblyReader: ...
-    def materialize(self, destination: StrPath, *, overwrite: bool = False, fsync: bool = False) -> None: ...
+    def materialize(self, destination: StrPath, *, overwrite: bool = False) -> None: ...
     def close(self) -> None: ...
     def __enter__(self) -> "AssemblyView": ...
     def __exit__(self, *exc: object) -> None: ...
@@ -910,81 +737,40 @@ class AssemblyReader(io.RawIOBase):
     def metadata(self) -> AssemblyDescriptor: ...
 
     def readable(self) -> bool: return True
-    def seekable(self) -> bool: return self._capabilities.seek
+    def seekable(self) -> bool: return False
     def writable(self) -> bool: return False
     def read(self, size: int = -1) -> bytes: ...
     def readall(self) -> bytes: ...
     def readinto(self, buffer: bytearray | memoryview) -> int: ...
-    def seek(self, offset: int, whence: int = os.SEEK_SET) -> int: ...
-    def tell(self) -> int: ...
-
-class AssemblyGlobIterator(Iterator[AssemblyDescriptor]):
-    def __iter__(self) -> "AssemblyGlobIterator": ...
-    def __next__(self) -> AssemblyDescriptor: ...
-    def close(self) -> None: ...
-    def __enter__(self) -> "AssemblyGlobIterator": ...
-    def __exit__(self, *exc: object) -> None: ...</code></pre>
+    def tell(self) -> int: ...</code></pre>
 
         <p class="small">
-          <code>AssemblyClient.info()</code> calls the same single <code>get_plan(request)</code> SPI as resolution because the
-          provider has no separate descriptor lookup. It validates the plan and descriptor agreement but does not resolve
-          byte-I/O bindings, compute executable capabilities, or perform object/service byte I/O. Call <code>resolve()</code>
-          when an executable view or consistency guarantee is required.
-        </p>
-        <p class="small">
-          Browsing is optional and is advertised by <code>AssemblyCapabilities.browse</code>. The exact configuration fields,
-          defaults, validation rules, admission semantics, and cursor/glob limits are specified in the surrounding
-          implementation sections rather than in the high-level document.
+          The MVP intentionally has no capability objects, browsing methods, or seek contract. Random access is explicit
+          through <code>AssemblyView.read(range)</code>; <code>open()</code> is always forward-only. The two constructor knobs
+          are validated eagerly and govern all client operations.
         </p>
 
-        <h3>Language-neutral list and canonical plan digest</h3>
+        <h3>Language-neutral assembly-list batches</h3>
         <p>
-          An assembly list is one or more ordered <code>AssemblyListBatch</code> values with one <code>list_id</code>, issuance,
-          mandatory <code>expires_at</code>, batch count, contiguous zero-based batch indexes, and
-          exactly the declared number of batches. An object
-          definition cannot be split between batches. This gives streaming traversal a bounded batch envelope while allowing
-          an <code>AssemblyListStore</code> to choose a memory, disk, or remote exact-name index. That executable list is distinct from
-          the optional browsing index: browse pages contain names/metadata/cursors and cannot be passed to the executor.
-          The v1 artifact intentionally carries no refresh locator. A replacement list or plan is obtained by another
-          <code>get_plan(request)</code> through application-owned provider transport and authentication; the previous identity
-          and expiration are never extended in place.
+          An assembly list is one or more ordered <code>AssemblyListBatch</code> values with one <code>list_id</code>, mandatory
+          <code>expires_at</code>, contiguous zero-based indexes, and exactly the declared batch count. An object definition
+          cannot be split between batches. The artifact exists so another process or language can exchange many named object
+          definitions without requiring MSC to define the producer's service API. It is not a pagination, listing, or glob contract.
         </p>
         <p>
-          <code>plan_digest</code> is a provider-supplied canonical instruction digest that MSC recomputes and verifies; the
-          <code>AssemblyPlan.create</code> convenience computes it for direct-model providers. It is not a required expected
-          digest of output bytes.
-          It is <code>sha256:&lt;64 lowercase hex characters&gt;</code> over the UTF-8 RFC 8785 JSON Canonicalization Scheme
-          projection containing exactly <code>schema_version</code>, <code>result_semantics</code>,
-          <code>descriptor</code>, and the ordered discriminated
-          <code>segments</code>. It excludes itself and execution-only deadlines. The list codec uses UTC RFC 3339 timestamps
-          with exactly six fractional-second digits and <code>Z</code>, rejects timezone-naive values and unknown fields/kinds,
-          and represents inline bytes as canonical unpadded base64url. <code>FrozenJsonArray</code> and
-          <code>FrozenJsonObject</code> preserve JSON kind identity even for pair-shaped values; service parameters require an
-          object root, while reference parameters allow scalar values only. Both parameter forms reject non-finite numbers
-          and normalize negative zero. All object-key tuples use RFC 8785 UTF-16 code-unit order in memory and on the wire;
-          lone surrogates are rejected and no Unicode normalization is performed. Frozen scalar equality/hash includes JSON
-          kind plus canonical value: booleans differ from numbers, while <code>1</code>/<code>1.0</code> and
-          <code>0</code>/<code>-0.0</code> normalize equal. Every non-JSON schema integer requires
-          <code>type(value) is int</code>, rejecting bool and integral float. Every integer
-          is in <code>[-(2**53)+1, (2**53)-1]</code>; offsets, lengths, sizes, and
-          batch indexes are additionally non-negative.
+          The codec accepts strict UTF-8 JSON, rejects duplicate or unknown fields and non-finite numbers, uses RFC 3339 UTC
+          timestamps, and represents inline bytes as unpadded base64url. Internal constants bound encoded bytes, nesting,
+          object count, and segment count before allocation. No public decode-limit classes or per-call limit arguments are exposed.
         </p>
         <pre><code>assembly_reference := {
   "namespace": string,
   "key": string,
-  "parameters": { string: json_scalar }  # scalar values only; RFC 8785 UTF-16 key order
-}
-source_selector := {"kind": string, "value": string}
-source_validator := {"kind": string, "value": string,
-                     "use": "enforce_during_read" | "identity_only"}
-operation_revision := {"kind": string, "value": string,
-                       "use": "enforce_during_read" | "identity_only"}
-checksum := {"algorithm": "sha256", "value": lower_hex_64_without_prefix}</code></pre>
+  "parameters": { string: json_scalar }
+}</code></pre>
         <pre><code>{
   "schema_version": "assembly-list/v1",
   "list_id": string,
-  "issued_at": utc_rfc3339_microseconds,
-  "expires_at": utc_rfc3339_microseconds,
+  "expires_at": utc_rfc3339,
   "batch_index": integer,
   "batch_count": integer,
   "objects": [{
@@ -995,36 +781,28 @@ checksum := {"algorithm": "sha256", "value": lower_hex_64_without_prefix}</code>
     "published_at": utc_rfc3339_microseconds | null,
     "segments": [
       {"kind": "object", "source_id": string, "resource": string,
-       "byte_range": {"offset": integer, "size": integer}, "length": integer,
-       "selector": source_selector | null, "validator": source_validator | null,
-       "checksum": checksum | null},
+       "byte_range": {"offset": integer, "size": integer}, "length": integer},
       {"kind": "service", "fetcher_id": string, "operation": string,
        "parameters": json_object, "length": integer,
-       "range_mode": "stable_subranges" | "whole_result",
-       "retry_safety": "never" | "safe",
-       "operation_revision": operation_revision | null,
-       "checksum": checksum | null},
+       "range_mode": "stable_subranges" | "whole_result"},
       {"kind": "inline", "data_base64": string, "length": integer}
     ]
-  }],
-  "batch_digest": sha256_prefixed_lower_hex
+  }]
 }</code></pre>
         <p class="small">
           Optional values are explicit JSON <code>null</code>; arrays retain semantic order. Every batch carries expiration so
-          it can be rejected independently. Across one snapshot, <code>list_id</code>, <code>issued_at</code>,
-          <code>expires_at</code>, and <code>batch_count</code> must match. Golden vectors cover each union arm, multi-batch lists,
+          it can be rejected independently. Across one batch set, <code>list_id</code>, <code>expires_at</code>, and
+          <code>batch_count</code> must match. Golden vectors cover each union arm, multi-batch lists,
           empty objects, Unicode, timestamps, base64, and invalid unknown fields.
         </p>
 
-        <h3>Canonical invariants not expressed by the type declarations</h3>
+        <h3>Invariants not expressed by the type declarations</h3>
         <ul>
           <li>Every <code>AssemblyReference</code> is unique within one complete list snapshot, including across batch boundaries.</li>
           <li>A zero-size object has an empty plan. Otherwise, every segment length is positive and the checked sum of ordered segment lengths equals the descriptor size.</li>
           <li><code>ObjectSegment.byte_range.size == ObjectSegment.length</code>; <code>InlineSegment.length == len(InlineSegment.data)</code>.</li>
-          <li><code>AssemblyDescriptor.etag</code> is an optional identity of the complete assembled byte sequence. It is distinct from a source validator and MSC never synthesizes it from segment identities.</li>
-          <li><code>batch_digest</code> is SHA-256 over the RFC 8785 canonical batch projection excluding <code>batch_digest</code> itself. <code>plan_digest</code> similarly excludes itself and execution-only deadlines.</li>
-          <li>Operation deadlines do not participate in model equality, hashing, digest projections, or cache identity.</li>
-          <li><code>plan_digest</code> and <code>batch_digest</code> protect instructions/artifacts. Neither is an output-byte checksum nor sufficient evidence for <code>SNAPSHOT_PINNED</code>.</li>
+          <li><code>AssemblyDescriptor.etag</code>, when present, is descriptive metadata supplied by the provider; MSC does not derive or enforce it in v1.</li>
+          <li>Operation deadlines are runtime-only values and never appear in the portable artifact.</li>
         </ul>
 
         <h3>Local binding authority and hard inline limits</h3>
@@ -1036,37 +814,30 @@ checksum := {"algorithm": "sha256", "value": lower_hex_64_without_prefix}</code>
           namespace appropriate for every plan they accept. V1 adds no provider-specific narrower-path policy on top of that
           public StorageClient namespace. Rebinding an alias never mutates an existing view. Inline data is decoded
           under two immutable v1 upper ceilings: at most <strong>16 KiB per InlineSegment</strong> and
-          <strong>64 KiB total decoded inline bytes per object/plan</strong>. Client configuration may lower, but never raise,
-          either ceiling. Encoded-size and overall-plan limits apply in
+          <strong>64 KiB total decoded inline bytes per object/plan</strong>. Encoded-size and overall-plan limits apply in
           addition; inline bytes never become a bulk-data escape hatch.
         </p>
 
-        <h3>Expiration and consistency policies</h3>
+        <h3>Expiration and MVP consistency policy</h3>
         <div class="table-wrap">
           <table>
-            <thead><tr><th>Rule</th><th><code>EXPIRATION_ONLY</code> (default)</th><th><code>SNAPSHOT_PINNED</code> (opt-in)</th></tr></thead>
+            <thead><tr><th>Rule</th><th>V1 behavior</th></tr></thead>
             <tbody>
-              <tr><td>Mandatory freshness</td><td colspan="2">Missing, malformed, or expired <code>expires_at</code> raises <code>AssemblyExpiredError</code> before an operation begins.</td></tr>
-              <tr><td>Optional identity/checksum fields</td><td>All may be absent. The initial object binding rejects selectors/enforcing validators but accepts identity-only metadata; service revisions are enforced only when advertised. Identity-only values cannot imply snapshot safety.</td><td>Each object segment needs a verified complete checksum in v1; each service segment needs an advertised enforced revision or verified complete checksum.</td></tr>
-              <tr><td>Same-length mutation</td><td>May be undetectable and is documented as such.</td><td>Must fail closed before publishing bytes.</td></tr>
-              <tr><td>Cross-operation byte cache</td><td colspan="2">Disabled in v1. Consistency computation still determines what the view may claim, but it does not enable a logical-byte cache.</td></tr>
-              <tr><td>Replacement</td><td colspan="2">There is no public refresh operation. Another <code>resolve(reference)</code> obtains and validates a replacement plan/view with its own <code>generation</code> and <code>expires_at</code>; it never extends or mutates the old view.</td></tr>
-              <tr><td>In-flight expiration</td><td colspan="2">An operation admitted while valid may finish. A subsequent operation on the old view is rejected.</td></tr>
+              <tr><td>Mandatory freshness</td><td>Missing, malformed, or expired <code>expires_at</code> raises <code>AssemblyExpiredError</code> before an operation begins.</td></tr>
+              <tr><td>Object identity</td><td>Selectors, validators, and checksums are not part of the v1 model. MSC requires the requested byte count and surfaces StorageClient failures.</td></tr>
+              <tr><td>Service identity</td><td>Operation revisions and checksums are not part of the v1 model. MSC requires the declared result length and validates the fetcher's range protocol.</td></tr>
+              <tr><td>Cross-operation cache</td><td>Disabled in v1. A view retains its own validated plan, but another <code>resolve()</code> calls the provider again and creates a distinct view.</td></tr>
+              <tr><td>Replacement</td><td>There is no public refresh operation. Another <code>resolve(reference)</code> obtains and validates a replacement plan/view with its own <code>generation</code> and <code>expires_at</code>; it never extends or mutates the old view.</td></tr>
+              <tr><td>In-flight expiration</td><td>An operation admitted while valid may finish. A subsequent operation on the old view is rejected.</td></tr>
             </tbody>
           </table>
         </div>
 
         <div class="callout danger">
-          <code>EXPIRATION_ONLY</code> is a truthful weaker guarantee, not a hidden snapshot mode. A
-          <code>HEAD → ordinary GET → HEAD</code> sequence is not an atomic pinned read and cannot satisfy
-          <code>SNAPSHOT_PINNED</code>, even when both metadata calls return the same value.
+          <strong>Assembly does not define dataset snapshot semantics.</strong> A fixed plan does not make an unversioned
+          mutable source immutable. Same-length replacement may be undetectable. The application and plan provider own any
+          dataset- or sample-snapshot contract above this byte-assembly layer.
         </div>
-        <p class="small">
-          A <code>Checksum</code> covers the complete bytes of its segment, not an arbitrary caller-selected subrange.
-          When present it is normative: MSC executes/stages and verifies that complete segment under the configured
-          verification-byte limits before every requested slice, in either consistency mode and regardless of another
-          enforced identity. Successful verification may then contribute snapshot safety.
-        </p>
       </section>
 
       <section id="provider">
@@ -1085,63 +856,23 @@ checksum := {"algorithm": "sha256", "value": lower_hex_64_without_prefix}</code>
     ) -> AssemblyPlan:
         """Return descriptor metadata and every ordered segment."""
 
-    def close(self) -> None:
-        pass
-
-class BrowsableAssemblyPlanProvider(AssemblyPlanProvider):
-    @abstractmethod
-    def list(self, request: ListAssembliesRequest) -> AssemblyPage:
-        """Return stable metadata only; pages are not executable plans."""
-
-class AssemblyListStore(ABC):
-    @property
-    @abstractmethod
-    def snapshot(self) -> AssemblyListSnapshot: ...
-
-    @abstractmethod
-    def get(self, reference: AssemblyReference) -> AssemblyObjectDefinition | None: ...
-
-    @abstractmethod
-    def iter_objects(
-        self,
-        *,
-        namespace: str,
-        prefix: str = "",
-    ) -> Iterator[AssemblyObjectDefinition]: ...
-
-    def close(self) -> None:
-        pass
-
-class StaticAssemblyListProvider(BrowsableAssemblyPlanProvider):
-    def __init__(
-        self,
-        store: AssemblyListStore,
-        *,
-        close_store: bool = False,
-    ) -> None: ...
-
+class StaticAssemblyListProvider(AssemblyPlanProvider):
     @classmethod
     def from_batches(
         cls,
         batches: Iterable[AssemblyListBatch],
-        *,
-        limits: InMemoryAssemblyListLimits | None = None,
-        batch_limits: AssemblyListDecodeLimits | None = None,
     ) -> "StaticAssemblyListProvider": ...</code></pre>
 
         <h3>Contract choices</h3>
         <ul>
-          <li><code>get_plan(request)</code> is the single required provider call. It returns a metadata-only <code>AssemblyDescriptor</code> inside one complete exact-result plan and never returns an executable object or a range-specific fragment. <code>AssemblyClient.resolve</code> validates the response, freezes local bindings, computes capabilities, and returns no <code>AssemblyView</code> until every step succeeds.</li>
-          <li>There is no public provider or client refresh method. Another <code>resolve(reference)</code> repeats the same single-call pipeline and returns a distinct view. Any future automatic re-resolution policy is separately approved and must never start work from a hard-expired plan.</li>
-          <li>No provider binding revision is required or echoed by the descriptor. Core instruction caches are scoped to one <code>AssemblyClient</code> and its concrete provider instance; they are never reused across provider instances.</li>
+          <li><code>get_plan(request)</code> is the single required provider call. It returns a metadata-only <code>AssemblyDescriptor</code> inside one complete exact-result plan and never returns an executable object or a range-specific fragment. <code>AssemblyClient.resolve</code> validates the response, freezes local bindings, and returns no <code>AssemblyView</code> until both steps succeed.</li>
+          <li>There is no public provider or client refresh method and no automatic generation fall-forward in v1. Another <code>resolve(reference)</code> repeats the same single-call pipeline and returns a distinct view. A future automatic policy would be additive and must never start work from a hard-expired plan.</li>
           <li><code>get_plan</code> returns one complete object plan. Backend/list batching is an implementation detail; a partial segment page never enters the validator or executor.</li>
-          <li><code>StaticAssemblyListProvider</code> is the reference concrete-list surface. For each object definition it sets <code>descriptor.generation = snapshot.list_id</code> and <code>descriptor.expires_at = snapshot.expires_at</code>; reference, size, ETag, content type, and publication time come from that object definition. It constructs an exact-result <code>assembly-plan/v1</code> and computes the canonical plan digest locally. The batch-iterator convenience applies default or supplied <code>AssemblyListDecodeLimits</code> structurally even to direct-model batches, then enforces <code>InMemoryAssemblyListLimits</code> over aggregate objects, segments, and canonical bytes before commit. Exact canonical bytes exclude newline framing, but measurement streams into a capped counter/digest sink using the smaller remaining per-batch/aggregate allowance; it aborts at one over and never materializes a full encoding only to measure. Large deployments inject a replayable <code>AssemblyListStore</code>.</li>
-          <li>An <code>AssemblyListStore</code> declares one immutable snapshot, exact lookup, and traversal. Its conformance suite verifies stable results, fully validated batch provenance, close behavior, and the approved cost/memory envelope.</li>
-          <li>Browsing is a separate optional <code>BrowsableAssemblyPlanProvider</code> capability. Its pages and cursors are stable metadata views, not fragments of executable assembly lists.</li>
-          <li><code>get_plan</code> and optional <code>list</code> are unconditionally thread-safe in v1; close begins only after the application stops new operations.</li>
-          <li>The synchronous provider and public façade contracts match the current StorageClient style. Internally, Assembly overlaps independent source/fetcher I/O; the exact async fetcher surface is a separate approval gate and does not imply a Rust implementation.</li>
+          <li><code>StaticAssemblyListProvider.from_batches()</code> is the bounded in-memory reference implementation. For each object definition it sets <code>descriptor.generation = list_id</code> and <code>descriptor.expires_at = expires_at</code>; reference, size, ETag, content type, and publication time come from that object definition. It constructs an exact-result <code>assembly-plan/v1</code>. Private hard limits are applied before committing the in-memory index. Deployments requiring disk-backed or remote lookup implement <code>AssemblyPlanProvider</code> directly.</li>
+          <li>Provider authors are not required to make <code>get_plan</code> thread-safe. AssemblyClient serializes calls to the injected provider.</li>
+          <li>The provider, public façade, and <code>ServiceSegmentFetcher.fetch()</code> contracts are synchronous and match the current StorageClient style. Internally, Assembly overlaps independent source/fetcher I/O through bounded concurrency; v1 adds no public async SPI and implies no Rust implementation.</li>
           <li>Provider retries are internal and bounded. AssemblyClient does not layer general retries around provider calls.</li>
-          <li>Until automatic re-resolution is approved, expiration remains a hard admission check. A caller obtains a replacement through another resolve call; failure leaves the old view unchanged and an expired or closed view remains unusable.</li>
+          <li>Expiration is a hard admission check. A caller obtains a replacement through another resolve call; failure leaves the old view unchanged and an expired or closed view remains unusable.</li>
         </ul>
 
         <h3 id="provider-error-contract">Provider error contract</h3>
@@ -1149,32 +880,31 @@ class StaticAssemblyListProvider(BrowsableAssemblyPlanProvider):
           <table>
             <thead><tr><th>Exception</th><th>Meaning</th><th>AssemblyClient behavior</th></tr></thead>
             <tbody>
-              <tr><td><code>AssemblyNotFoundError</code></td><td>Logical key is unknown.</td><td>Do not call sources; surface a fresh canonical copy.</td></tr>
+              <tr><td><code>AssemblyNotFoundError</code></td><td>Logical key is unknown.</td><td>Do not call sources; surface the typed error.</td></tr>
               <tr><td><code>AssemblyGenerationUnavailableError</code></td><td>The requested generation cannot be served.</td><td>Never fall forward to latest.</td></tr>
               <tr><td><code>AssemblyProviderAuthenticationError</code></td><td>The provider backend rejected credentials after its own safe refresh attempt.</td><td>Do not add an authentication retry.</td></tr>
               <tr><td><code>AssemblyProviderRetryableError</code></td><td>The provider exhausted its bounded retries on a transient failure.</td><td>Do not add an outer retry loop.</td></tr>
               <tr><td><code>InvalidAssemblyPlanError</code></td><td>The provider returned a structurally or semantically invalid plan.</td><td>Fail before source I/O and record a contract violation.</td></tr>
-              <tr><td><code>AssemblyCapabilityError</code></td><td>Browsing or requested consistency is unsupported.</td><td>Fail without fallback or implicit downgrade.</td></tr>
-              <tr><td><code>AssemblyProviderError</code></td><td>An unexpected provider <code>Exception</code>.</td><td>Retain only a safe type token and discard the original object and message.</td></tr>
+              <tr><td><code>AssemblyProviderError</code></td><td>An unexpected provider <code>Exception</code>.</td><td>Expose only a safe cause classification, never the backend message.</td></tr>
             </tbody>
           </table>
         </div>
         <p class="small">
-          Exact allowlisted outcomes are copied into fresh canonical instances using validated safe fields. Subclasses,
-          arbitrary arguments, malformed fields, and incoming cause/context chains never pass through the provider boundary.
+          Provider errors preserve only documented safe fields. Arbitrary backend arguments, messages, and nested causes do
+          not pass through the provider boundary.
         </p>
 
         <h3>MSC-supplied provider conformance suite</h3>
         <p>
           <code>multistorageclient.assembly.testing</code> exposes reusable pytest cases/factories. It proves behavior rather
-          than transport shape: mandatory expiration, stable descriptor generation, complete-object coverage, deterministic exceptions,
-          limits, concurrency claims, and lifecycle. A separate suite covers <code>ServiceSegmentFetcher</code>; neither suite
+          than transport shape: mandatory expiration, stable descriptor generation, complete-object coverage, typed errors,
+          limits, and lifecycle. A separate suite covers <code>ServiceSegmentFetcher</code>; neither suite
           is coupled to HTTP payloads or endpoint names.
         </p>
 
         <div class="callout info">
           Provider implementations own authentication refresh and transport retries. They must not include tokens, full
-          sensitive URLs, or backend response bodies in <code>repr</code>, cache keys, metrics, or public exceptions.
+          sensitive URLs, or backend response bodies in <code>repr</code>, metrics, or public exceptions.
         </div>
       </section>
 
@@ -1182,50 +912,20 @@ class StaticAssemblyListProvider(BrowsableAssemblyPlanProvider):
         <h2>6. Validation and range planning</h2>
         <h3>Configuration validation</h3>
         <p>
-          Every public config/limits dataclass validates in <code>__post_init__</code> and raises <code>AssemblyConfigurationError</code>
-          before dependency/network I/O. Integer fields reject bool/integral float; all byte/count/concurrency/glob/timeout
-          ceilings are positive except <code>plan_cache_entries &gt;= 0</code>, and every integer configuration value is at most
-          <code>2**53 - 1</code>. Every seconds field is finite, within <code>[0, 604800]</code> where zero is allowed or
-          <code>(0, 604800]</code> otherwise. Inline limits may only lower 16/64 KiB and object aggregate is at least segment.
-          The exact byte-limit relationships are <code>materialization_window_bytes &lt;= max_read_bytes</code>;
-          <code>max_object_read_chunk_bytes &lt;= min(max_read_bytes, materialization_window_bytes,
-          max_inflight_object_bytes, max_complete_segment_memory_bytes, max_staging_memory_bytes_per_operation,
-          max_staging_memory_bytes_total)</code>;
-          <code>max_service_chunk_bytes &lt;= min(max_read_bytes, materialization_window_bytes,
-          max_complete_segment_memory_bytes, max_staging_memory_bytes_per_operation,
-          max_staging_memory_bytes_total)</code>; <code>max_complete_segment_memory_bytes &lt;=
-          max_complete_segment_staged_bytes &lt;= max_staging_bytes_per_operation</code>; and
-          <code>max_complete_segment_memory_bytes &lt;= max_staging_memory_bytes_per_operation &lt;=
-          max_staging_bytes_per_operation</code>. The complete-segment thresholds apply equally to WHOLE_RESULT service
-          segments and to checksum-bearing object or service segments that require complete-result staging. Twice each of
-          <code>max_read_bytes</code> and <code>materialization_window_bytes</code> fits
-          <code>max_output_memory_bytes_total</code>. Per-operation staging memory and bytes do not exceed their matching
-          client-wide totals.
-          A staging path must be an existing absolute directory after <code>os.fspath</code>; construction neither
-          creates nor write-probes it. Any future generic HTTP adapter defines and validates its own transport limits in a
-          separately approved contract; those limits are not part of the Assembly core configuration.
-          Every canonical string rejects lone surrogates before cache/digest work. Named namespace/key/resource/operation,
-          cursor, and parameter limits apply first; <code>max_identity_metadata_utf8_bytes</code> is the catch-all for
-          generation/list ID, aliases, ETag/content type, selector/validator/revision kind/value,
-          listing generation, and any other canonical identity/metadata string without a stricter named cap. This semantic
-          validation applies equally to decoded and live/direct provider models.
-          List input requires <code>1 &lt;= page_size &lt;= max_list_page_size</code> and a cursor no larger than
-          <code>max_cursor_utf8_bytes</code>. Provider output must contain at most the requested item count, use a next cursor
-          under the same byte ceiling, and pass normal descriptor validation before caching or glob accumulation.
-          Glob uses the longest literal prefix, requests no page larger than the remaining
-          <code>max_glob_scanned_items</code> budget, and raises <code>AssemblyLimitExceededError</code> without another provider
-          call if a non-null cursor remains after the exact budget. It separately raises before yielding result
-          <code>max_glob_results + 1</code>; earlier iterator yields are not rolled back.
+          <code>AssemblyClient</code> validates <code>max_concurrency</code> as a positive non-bool integer and
+          <code>timeout_seconds</code> as a positive finite number before dependency or network I/O. All remaining limits are
+          private constants validated by module tests. Temporary staging uses a private file in the platform temporary
+          directory; v1 exposes no staging-path or memory-budget configuration surface.
         </p>
         <h3>Validation order</h3>
         <ol>
-          <li>Validate reference, schema/list versions, mandatory <code>expires_at</code>, and configured limits. Require <code>descriptor.reference == request.reference</code> and, when <code>request.generation</code> is non-None, <code>descriptor.generation == request.generation</code>; reject a silent fall-forward before plan/source I/O. Text limits count strict UTF-8 bytes; semantic parameter depth includes the parameter root object, while codec depth includes the complete document root (default 64 versus semantic 32). Recursive item count includes object members/array elements, and parameter bytes use exact RFC 8785 encoding.</li>
-          <li>At plan or view-operation admission, compare one captured UTC clock value with <code>expires_at</code>; equality is expired. Reject a newly returned plan or cached validated plan/view before binding or source/service byte I/O. An explicit later <code>resolve(reference)</code> may call the provider to obtain a replacement generation.</li>
-          <li>Validate that the complete plan echoes the descriptor, then perform cheap structural checks before canonical encoding: exact model types, segment tuple count, discriminator, strict integers, text byte limits, parameter depth/item/canonical-byte limits, inline decoded limits, and checksum/revision grammar. Reject immediately on the first bound violation.</li>
+          <li>Validate reference, schema/list versions, mandatory <code>expires_at</code>, and private hard limits. Require <code>descriptor.reference == request.reference</code> and, when <code>request.generation</code> is non-None, <code>descriptor.generation == request.generation</code>; reject a silent fall-forward before plan/source I/O.</li>
+          <li>At plan or view-operation admission, compare one captured UTC clock value with <code>expires_at</code>; equality is expired. Reject a newly returned plan or existing view before binding or source/service byte I/O. Every explicit later <code>resolve(reference)</code> calls the provider once to obtain a new view, which may represent a replacement generation.</li>
+          <li>Validate that the complete plan echoes the descriptor, then perform cheap structural checks: exact model types, segment count, discriminator, strict integers, text and JSON bounds, and inline decoded limits. Reject immediately on the first violation.</li>
           <li>Tuple order is logical order. Validate every positive length/object range with checked arithmetic; compute the checked sum of every segment length and require it to equal <code>descriptor.size</code>, including for a partial caller read.</li>
-          <li>Stream the exact RFC 8785 digest projection (schema version, result semantics, descriptor, ordered segments; no digest/deadline) into both SHA-256 and a capped byte counter. Do not construct a second complete encoding. Equality with <code>max_plan_bytes</code> is accepted; abort as soon as byte <code>max_plan_bytes + 1</code> would be emitted, then verify <code>plan_digest</code>. The same bounded path handles decoded and direct-model providers.</li>
-          <li>Resolve object aliases to existing StorageClients and service aliases to ServiceSegmentFetchers, then freeze those concrete local objects. Instruction caches remain scoped to this client and frozen registry snapshot; v1 exposes no binding identity for cross-registry reuse.</li>
-          <li>Validate service modes/retry declarations, binding support for optional selectors/validators/operation revisions/checksums, staging feasibility, computed capabilities, and the selected <code>AssemblyConsistency</code> requirements.</li>
+          <li>Estimate the plan's validated encoded size with a capped serializer. Do not construct a second complete encoding; abort when the private plan-byte limit would be exceeded.</li>
+          <li>Resolve object aliases to existing StorageClients and service aliases to ServiceSegmentFetchers, then freeze those concrete local objects in the returned view.</li>
+          <li>Validate each service segment's requested range mode against its selected fetcher's <code>range_modes</code> and ensure any <code>WHOLE_RESULT</code> stage fits the private hard limit.</li>
           <li>Normalize and bounds-check the caller's half-open logical range, intersect it with the already validated full plan, then allocate or stage output and begin I/O.</li>
         </ol>
 
@@ -1244,45 +944,34 @@ class ObjectReadOperation:
     source_id: str
     resource: str
     fetch_range: ByteRange
-    selected_range_in_fetch: ByteRange
-    selector: SourceSelector | None
-    validator: SourceValidator | None
     destination_offset: int
-    checksum: Checksum | None
 
 @dataclass(frozen=True, slots=True)
 class ServiceReadOperation:
     fetcher_id: str
     operation: str
-    parameters: FrozenJsonObject
+    parameters: Mapping[str, JsonValue]
     full_result_length: int
     requested_subrange: ByteRange
     range_mode: ServiceRangeMode
-    retry_safety: RetrySafety
-    operation_revision: OperationRevision | None
-    checksum: Checksum | None
     destination_offset: int</code></pre>
 
         <p class="small">
-          <code>ObjectReadOperation.fetch_range</code> is the absolute object range passed to StorageClient, while
-          <code>selected_range_in_fetch</code> is relative to the returned fetch bytes. For an ordinary object read, MSC fetches
-          only the caller intersection and selects <code>ByteRange(0, fetch_range.size)</code>. For a checksum-bearing object
-          segment, MSC fetches and stages the segment's complete declared object range, verifies it, and only then copies the
-          caller's selected subrange to <code>destination_offset</code>.
+          <code>ObjectReadOperation.fetch_range</code> is the exact absolute object range passed to StorageClient. A service
+          operation carries the logical subrange even when the selected mode requires fetching and locally slicing the full result.
         </p>
 
         <h3>No cross-segment coalescing in v1</h3>
         <p>
           Every intersected object segment remains one independent logical object operation. Within it, MSC issues
-          consecutive public <code>StorageClient.read</code> calls of at most <code>max_object_read_chunk_bytes</code>; a
-          checksum-bearing segment uses its complete source range as <code>fetch_range</code> and records the caller intersection
-          in <code>selected_range_in_fetch</code>, while an ordinary segment fetches only the caller intersection and selects that
+          consecutive public <code>StorageClient.read</code> calls no larger than the private object chunk limit; each segment
+          fetches only the caller intersection and copies that
           complete fetch. V1 never combines adjacent object segments, even when alias/resource/ranges appear compatible,
-          because ObjectSourceBinding exposes no atomic selection, checksum-boundary, or maximum-range coalescing capability. Inline slices copy directly;
-          STABLE_SUBRANGES receives exact intersections; each WHOLE_RESULT segment is keyed by descriptor generation,
-          validated plan digest, and segment ordinal, and is staged once per admitted top-level operation. Repeated intersections with one ordinal
-          reuse that stage, while equal-valued segments at different ordinals never deduplicate. A future additive binding
-          capability may enable coalescing with its own conformance contract.
+          because ObjectSourceBinding exposes no explicit cross-segment coalescing contract. Inline slices copy directly;
+          STABLE_SUBRANGES receives exact intersections; each WHOLE_RESULT segment is identified by its ordinal in the current
+          view and is staged once per admitted operation. Repeated intersections with one ordinal reuse that stage, while
+          equal-valued segments at different ordinals never deduplicate. A future additive binding
+          contract may enable coalescing with its own conformance tests.
         </p>
       </section>
 
@@ -1292,13 +981,11 @@ class ServiceReadOperation:
         <p>
           The complete v1 public object-binding surface is <code>ObjectSourceBinding(client=storage_client)</code>. The binding
           selects an already configured public StorageClient logical namespace; it adds no profile, endpoint, credential,
-          provider, cache-identity, ownership, or provider-specific path-policy controls.
+          provider, ownership, or provider-specific path-policy controls.
         </p>
         <p>
-          For service fulfillment, only <code>range_modes</code> and <code>fetch</code> are abstract. The optional
-          <code>snapshot_revision_kinds</code> and <code>thread_safe</code> capabilities have conservative defaults, and
-          <code>close</code> is an optional lifecycle hook. Every capability property must remain immutable for the lifetime of
-          the injected fetcher; AssemblyClient captures and validates those values before exposing a view.
+          The complete service SPI is <code>range_modes</code> plus <code>fetch</code>. Assembly captures the immutable range-mode
+          set during construction and serializes calls to each fetcher instance. Fetchers and their lifecycle remain application-owned.
         </p>
 
         <pre><code>class CancellationToken(Protocol):
@@ -1330,15 +1017,6 @@ class ServiceSegmentFetcher(ABC):
     @abstractmethod
     def range_modes(self) -> frozenset[ServiceRangeMode]: ...
 
-    @property
-    def snapshot_revision_kinds(self) -> frozenset[str]:
-        """Revision kinds both enforced here and sufficient to pin complete result bytes."""
-        return frozenset()
-
-    @property
-    def thread_safe(self) -> bool:
-        return False
-
     @abstractmethod
     def fetch(
         self,
@@ -1346,10 +1024,7 @@ class ServiceSegmentFetcher(ABC):
         *,
         context: SourceReadContext,
     ) -> ServiceResultStream:
-        """Return a stream for the exact requested subrange or complete result."""
-
-    def close(self) -> None:
-        pass</code></pre>
+        """Return a stream for the exact requested subrange or complete result."""</code></pre>
 
         <div class="callout info">
           The core release expects a user-owned implementation such as <code>MyServiceFetcher</code>. It translates one
@@ -1364,7 +1039,7 @@ class ServiceSegmentFetcher(ABC):
           and assumes no sticky session or hidden ordering state. The client overlaps independent fetches under bounded
           concurrency and relies on the application transport for connection pooling or multiplexing. The service
           <code>operation</code> and <code>parameters</code> are interpreted and confined by the locally selected fetcher;
-          plans never supply credentials. Any future locator requires separate approval and the same local-policy boundary.
+          plans never supply credentials. Any future locator requires a separate versioned design and the same local-policy boundary.
         </div>
 
         <h3>Frozen binding registries</h3>
@@ -1372,16 +1047,14 @@ class ServiceSegmentFetcher(ABC):
           <li>AssemblyClient defensively copies separate <code>object_sources: Mapping[str, ObjectSourceBinding]</code> and <code>service_fetchers: Mapping[str, ServiceSegmentFetcher]</code>; malformed or duplicate aliases fail construction. Either mapping may be empty when the resolved plan uses none of that segment kind.</li>
           <li>Plans select only aliases. They cannot construct a client/fetcher or mutate endpoint, profile, prefix, credentials, or retry policy.</li>
           <li>The complete public object binding is <code>ObjectSourceBinding(client=storage_client)</code>. MSC freezes that concrete association in each view. The plan's <code>resource</code> is a logical path inside that client's already configured public namespace; it cannot reconfigure or expand the client authority. Applications bind a least-privilege namespace suitable for every accepted plan. V1 adds no provider-specific narrower path policy.</li>
-          <li>StorageClients are always borrowed and never closed by AssemblyClient. Calls to each distinct StorageClient object are conservatively serialized across aliases and views.</li>
-          <li><code>snapshot_revision_kinds</code> defaults empty. A kind may be advertised only when the fetcher enforces that revision and it is sufficient, with operation and parameters, to pin the complete result bytes.</li>
-          <li><code>range_modes</code>, <code>snapshot_revision_kinds</code>, and <code>thread_safe</code> are immutable for the injected fetcher's lifetime. AssemblyClient captures exact validated values before view exposure. <code>thread_safe=False</code> serializes calls to the same fetcher across aliases and views; an exact <code>True</code> opts that fetcher into client-wide concurrency.</li>
-          <li>The same client or fetcher may appear under multiple aliases. A transferred service fetcher is closed at most once; a StorageClient remains borrowed under every alias.</li>
-          <li>The same Python object identity cannot occupy different dependency roles (plan provider, service fetcher, StorageClient). A backend serving multiple roles uses distinct adapters; construction rejects cross-role identity reuse so ownership and <code>CloseFailure</code> remain unambiguous.</li>
-          <li>The plan provider and service fetchers are borrowed by default. <code>close_dependencies=True</code> transfers only those dependencies to AssemblyClient; it never transfers a StorageClient.</li>
-          <li>On failure AssemblyClient signals the shared cancellation token, attempts every service-stream close and shared-stage cleanup, and cancels queued work. A user fetcher observes that token through <code>SourceReadContext</code>; custom blocking I/O remains cooperative and must obey the context deadline. Failed stage artifacts follow the retained-reservation/orphan rules below.</li>
-          <li>Every yielded item is non-empty <code>bytes</code> with length ≤ <code>SourceReadContext.max_chunk_bytes</code> (from <code>AssemblyClientConfig.max_service_chunk_bytes</code>). Wrong type, empty, or oversized chunks attempt stream close and raise the primary <code>ServiceProtocolError</code> before copy/staging.</li>
-          <li>Exact allowlisted <code>ServiceSegmentError</code>, <code>AssemblyCancelledError</code>, and <code>AssemblyTimeoutError</code> outcomes are copied into fresh canonical instances using only validated safe fields. Subclasses, malformed typed errors, and any other custom-fetcher <code>Exception</code> become <code>ServiceFetchError(cause_type=safe_type_token(...))</code>. Capture only the safe classification in the catch, discard the caught object, and raise after leaving the handler so neither <code>__cause__</code> nor <code>__context__</code> retains it. Checks outside the catch give cancellation/deadline precedence, and <code>BaseException</code> is never wrapped.</li>
-          <li>Cleanup attempts fetcher-owned result streams first in reverse registration-token order, then MSC-owned stage sink/fd/path resources in reverse registration-token order. A primary execution error takes precedence. With otherwise successful bytes, the first result-stream close failure becomes redacted <code>ServiceFetchError</code> and the current private output is discarded. If private-stage cleanup also fails, <code>ServiceFetchError</code> retains precedence while the artifact/reservation transfers to the orphan registry. A sole MSC-stage cleanup failure is <code>AssemblyStagingError</code>.</li>
+          <li>StorageClients are always borrowed and never closed by AssemblyClient. Independent object reads may overlap under the client-wide concurrency and byte budgets; Assembly adds no per-StorageClient serialization policy.</li>
+          <li><code>range_modes</code> is immutable for the injected fetcher's lifetime. Calls to the same fetcher object are always serialized across aliases and views; different fetchers may overlap under the client-wide concurrency limit.</li>
+          <li>The same client or fetcher may appear under multiple aliases; alias reuse does not change dependency ownership.</li>
+          <li>The plan provider, service fetchers, and StorageClients are borrowed. The application creates, owns, and closes them through their own public APIs.</li>
+          <li>On failure AssemblyClient signals the shared cancellation token, cancels queued work, closes service streams, and attempts cleanup of every MSC-owned private stage. A user fetcher observes that token through <code>SourceReadContext</code>; custom blocking I/O remains cooperative and must obey the context deadline.</li>
+          <li>Every yielded item is non-empty <code>bytes</code> no larger than <code>SourceReadContext.max_chunk_bytes</code>, which comes from a private module constant. Wrong type, empty, or oversized chunks attempt stream close and raise <code>ServiceProtocolError</code> before copy or staging.</li>
+          <li>Documented service-domain errors preserve their stable type and safe fields. Other fetcher exceptions become a redacted <code>ServiceFetchError</code> containing only a validated cause classification; private exception messages and transport details are never exposed.</li>
+          <li>A primary execution error takes precedence over cleanup failures. If execution otherwise succeeds but required stream or stage cleanup fails, discard the private output and raise the appropriate redacted service or staging error.</li>
         </ul>
 
         <h3>Core segment dispatch</h3>
@@ -1389,26 +1062,19 @@ class ServiceSegmentFetcher(ABC):
           <table>
             <thead><tr><th>Segment</th><th>Implementation</th><th>Required behavior</th><th>Primary purpose</th></tr></thead>
             <tbody>
-              <tr><td><code>ObjectSegment</code></td><td>Python dispatcher → existing <code>StorageClient.read</code></td><td>Exact public range read; short reads fail. Initial v1 rejects selectors/enforcing validators; identity-only validators remain weak.</td><td>Bulk bytes travel directly from configured storage to MSC.</td></tr>
-              <tr><td><code>ServiceSegment</code></td><td>User <code>ServiceSegmentFetcher</code></td><td>Advertise supported range modes, enforce exact length, operation-revision/checksum and retry declarations honestly.</td><td>Transport-neutral synthesized bytes.</td></tr>
+              <tr><td><code>ObjectSegment</code></td><td>Python dispatcher → existing <code>StorageClient.read</code></td><td>Exact public range read; short reads fail.</td><td>Bulk bytes travel directly from configured storage to MSC.</td></tr>
+              <tr><td><code>ServiceSegment</code></td><td>User <code>ServiceSegmentFetcher</code></td><td>Advertise supported range modes and return the exact required length.</td><td>Transport-neutral synthesized bytes.</td></tr>
               <tr><td><code>InlineSegment</code></td><td>Python memory copy</td><td>Decode/validate before I/O; enforce 16 KiB segment and 64 KiB object aggregate ceilings.</td><td>Small constants only.</td></tr>
             </tbody>
           </table>
         </div>
 
-        <h3>Object selector and validator semantics</h3>
+        <h3>Object read semantics</h3>
         <p>
-          In default <code>EXPIRATION_ONLY</code> mode, an ObjectSegment without a selector or validator is legal and is read
-          directly through one or more bounded <code>StorageClient.read(resource, Range(offset, size))</code> calls. A <code>SourceSelector</code> always asks
-          the binding to select that exact version. A <code>SourceValidator</code> uses <code>RevisionUse</code> to declare
-          enforcement during the read or identity-only use; identity-only metadata cannot establish stable bytes or satisfy
-          <code>SNAPSHOT_PINNED</code>.
-          Today's public StorageClient cannot generally pass an expected version to provider GET, so the initial v1 binding
-          rejects every selector and every <code>ENFORCE_DURING_READ</code> validator before I/O; an ordinary
-          <code>info → read → info</code> sequence is never promoted to enforced snapshot semantics. In
-          <code>SNAPSHOT_PINNED</code> mode, an object segment therefore needs complete checksum verification in v1; a later
-          additive conditional-read binding may support selectors without changing the list schema. No code touches
-          <code>_storage_provider</code>.
+          Each ObjectSegment is read directly through one or more bounded
+          <code>StorageClient.read(resource, Range(offset, size))</code> calls. MSC requires exactly the requested number of
+          bytes and never touches <code>_storage_provider</code>. V1 does not perform <code>info → read → info</code>, enforce a
+          source version, or verify a checksum; stronger identity belongs inside the application-owned binding.
         </p>
         <p>
           A plan chooses only a local source alias and a logical <code>resource</code> interpreted by that alias's already-bound
@@ -1427,55 +1093,38 @@ class ServiceSegmentFetcher(ABC):
               <tr><td><code>PermissionError</code></td><td><code>SourceAuthorizationError</code></td></tr>
               <tr><td><code>RetryableError</code> after StorageClient exhaustion</td><td><code>SourceRetryableError</code>; no AssemblyClient retry</td></tr>
               <tr><td><code>TimeoutError</code> / <code>ConnectionError</code> while the global deadline remains</td><td><code>SourceTransportError</code></td></tr>
-              <tr><td>Any other <code>Exception</code></td><td><code>SourceReadError(cause_type=safe_type_token(type(exc)))</code></td></tr>
+              <tr><td>Any other <code>Exception</code></td><td><code>SourceReadError</code> with a safe cause classification</td></tr>
               <tr><td>Non-<code>bytes</code> / oversized result</td><td><code>SourceProtocolError</code></td></tr>
               <tr><td>Short result</td><td><code>ShortSourceReadError</code></td></tr>
-              <tr><td>Checksum mismatch</td><td><code>SourceIntegrityError</code></td></tr>
             </tbody>
           </table>
         </div>
         <p>
-          Inside <code>except Exception</code>, record only the safe classification/token; then leave the handler, discard the
-          caught object, construct a fresh canonical assembly error, and raise it from a fresh
-          <code>_SanitizedDependencyCause(safe_type_token)</code>. The original backend exception is absent from both
-          <code>__cause__</code> and <code>__context__</code> and is not otherwise retained. Public exception text is the sealed
-          class name only; <code>SourceReadError</code> exposes only its bounded <code>cause_type</code> field. Bounded alias/range
-          information may appear in redacted telemetry, never in exception text. Catch <code>Exception</code>, not
-          <code>BaseException</code>. Check cancellation and the absolute deadline outside the catch so their stable outcomes
-          are <code>AssemblyCancelledError</code> and <code>AssemblyTimeoutError</code>. Never inspect private providers, SDK
-          causes, status codes, or messages. Unsupported selectors/enforcing validators remain pre-I/O
-          <code>AssemblyCapabilityError</code> because current StorageClient has no typed conditional-read surface.
-          <code>safe_type_token(T)</code> accepts <code>T.__name__</code> only when it matches
-          <code>[A-Za-z_][A-Za-z0-9_]{0,127}</code>; otherwise it returns <code>Exception</code>.
+          Error normalization retains only the documented safe classification and never exposes the original backend
+          message, logical resource, credentials, or nested SDK details. Cancellation and deadline checks keep their stable
+          <code>AssemblyCancelledError</code> and <code>AssemblyTimeoutError</code> outcomes, and <code>BaseException</code> is not wrapped.
         </p>
 
-        <h3>Service range, staging, stability, and retry</h3>
+        <h3>Service range, staging, and stability</h3>
         <ul>
           <li><code>STABLE_SUBRANGES</code> is allowed only when both the segment and fetcher explicitly support it. Every requested subrange must belong to one stable logical byte string for the duration of the operation.</li>
-          <li><code>WHOLE_RESULT</code> is the default. Within one resolved view and top-level operation, MSC submits one logical <code>ServiceFetchRequest</code> through one <code>fetch</code> call for each stage key <code>(generation, plan_digest, segment_ordinal)</code>, where the ordinal is the zero-based position in the validated <code>AssemblyPlan.segments</code> tuple, even when several requested slices touch it. This key is operation-local and does not authorize cross-provider or cross-binding cache reuse. Different ordinals remain distinct even when every segment value is equal. Fetcher-owned SAFE retry may turn that submission into multiple private transport attempts.</li>
-          <li>A checksum may be omitted, but when supplied it is normative in every consistency mode. For a partial STABLE_SUBRANGES access, request/stage the complete segment, verify the digest, and only then slice; never compare the complete checksum with a partial response. Another enforcing revision does not waive this instruction.</li>
-          <li><code>max_complete_segment_memory_bytes</code> is a per-complete-segment memory threshold and <code>max_complete_segment_staged_bytes</code> is the per-complete-segment hard cap. Before launch, reserve declared length against both per-operation and client-wide stage-byte totals. Use memory only when both memory totals also have capacity; otherwise use a unique private file. Multi-budget acquisition is all-or-none; temporary contention waits/serializes until the operation deadline and maps to <code>AssemblyTimeoutError</code>, while a complete segment larger than an applicable per-segment, per-operation, or client-wide hard cap fails before I/O.</li>
-          <li><code>AssemblyClientConfig.staging_directory</code> selects the optional private-file parent for any complete-segment staging, including WHOLE_RESULT service output and checksum verification. A user fetcher may impose a stricter result limit, but it cannot weaken the AssemblyClient staging ceilings.</li>
-          <li>The result is length-checked while staging, optionally digest-checked, then sliced. Before external launch, each stage receives a deterministic registration token in logical scheduling order. Exact-length mismatch raises <code>ServiceLengthMismatchError</code>; complete checksum mismatch raises <code>ServiceIntegrityError</code>. Either failure attempts every MSC-owned stage sink/fd close and private-path unlink in reverse token order before bytes from that stage/current call are published; fetcher-owned result streams follow their separate rule above. Earlier successful reader calls may already be observed. Staged data is never reused across top-level operations in v1.</li>
-          <li>Private-stage allocation/create/write/flush/close/unlink failures use redacted <code>AssemblyStagingError(cause_type=...)</code>; no private path or OS message is public. A cleanup failure never masks or chains onto an already-selected execution error: the primary typed error wins, while the failed artifact stays in a private orphan registry. If the operation would otherwise succeed, cleanup completes before returning bytes or publishing a destination; failure discards private output and raises <code>AssemblyStagingError</code> with the first safe failure type in deterministic cleanup order after every action was attempted. Reader close follows the same selection.</li>
-          <li>A file-backed stage reservation is released only after <em>all</em> owned sinks/file descriptors are closed <em>and</em> every private pathname is unlinked; an in-memory reservation waits for all owned sinks/buffers to release. Allocation/create failure before an artifact exists releases immediately. A partially cleaned artifact remains charged against the matching client-wide memory/disk total and is retried on reader/client close, preventing repeated failures from creating unbounded unaccounted storage. When an operation/reader ends, its per-operation charge ends only after ownership of the continuously held client-wide charge atomically transfers to the orphan ledger. Reader close marks the reader closed and releases its active-operation slot even when cleanup raises. Parent close attempts every retained artifact and adds at most one aggregate <code>CloseFailure(dependency_kind="staging_artifact", aliases=(), ...)</code> for the first safe failure type if any remain.</li>
-          <li>Destination failures use the exact redacted <code>AssemblyMaterializationError(phase=..., cause_type=..., committed=...)</code> contract. Before the atomic commit point <code>committed=False</code> and the prior/concurrently-created destination is preserved; cleanup or directory-fsync failure after publication reports <code>committed=True</code> and never falsely claims rollback.</li>
-          <li><code>RetrySafety.NEVER</code> permits exactly one private attempt once the logical submission starts, regardless of whether that attempt produces any response bytes. <code>RetrySafety.SAFE</code> permits only the fetcher's documented bounded retry under the shared deadline; the assembly execution engine adds no outer retry.</li>
-          <li>Service operation revisions are optional. Identity-only revisions may classify metrics but cannot satisfy <code>SNAPSHOT_PINNED</code>. An enforcing revision qualifies only when its kind appears in <code>snapshot_revision_kinds</code>; a fully verified complete-result checksum qualifies independently.</li>
+          <li><code>WHOLE_RESULT</code> is the default. Within one view operation, MSC makes one core <code>fetch()</code> call for each touched segment ordinal, stages the full declared result, checks its length, and slices locally. Different ordinals remain distinct.</li>
+          <li>A WHOLE_RESULT declaration above the private per-result hard cap fails before I/O. Smaller results stage in bounded memory or a private temporary file and are never reused across view operations.</li>
+          <li>Exact-length mismatch raises <code>ServiceLengthMismatchError</code>. The current call publishes nothing and attempts cleanup of every MSC-owned stage resource.</li>
+          <li>Private-stage allocation, I/O, or cleanup failures use a redacted <code>AssemblyStagingError</code>. A primary execution error takes precedence; if execution otherwise succeeds but required cleanup fails, discard private output and report the staging error. The contract requires complete cleanup attempts but does not expose their internal ordering.</li>
+          <li>Destination failures use the redacted <code>AssemblyMaterializationError(phase=..., cause_type=..., committed=...)</code> contract. Before the atomic commit point <code>committed=False</code> and the prior or concurrently created destination is preserved; cleanup failure after publication reports <code>committed=True</code> and never falsely claims rollback.</li>
+          <li>Assembly adds no outer retry. Any retry hidden inside a user fetcher remains that implementation's responsibility and must stay within the supplied deadline.</li>
         </ul>
       </section>
 
       <section id="executor">
-        <h2>8. Executor, AssemblyView, seekable reader, and materialization</h2>
-        <h3>Client-wide admission and byte reservations</h3>
+        <h2>8. Executor, AssemblyView, forward reader, and materialization</h2>
+        <h3>Client-wide admission</h3>
         <ul>
-          <li>Acquire exactly one <code>max_active_operations</code> slot before provider/source I/O or large allocation for each top-level resolve, info, list page, one-shot read, materialization, or open. A glob iterator holds one from first advancement through exhaustion/close. A successfully opened reader holds its slot until reader/parent close; a passive view holds none.</li>
-          <li>Convenience methods propagate the admitted operation context into a private resolve/plan helper; that helper never reacquires. Glob's private page fetches reuse its iterator slot instead of calling the public admitted list path, and materialization windows/reader calls reuse their operation's existing slot. This rule is required for every convenience at <code>max_active_operations=1</code>.</li>
-          <li>Slot waiters allocate no large buffer, observe the shared deadline/cancellation, and are awakened by parent close. Capture the expiration admission clock only after slot acquisition; timeout maps to <code>AssemblyTimeoutError</code>, cancellation to <code>AssemblyCancelledError</code>, and parent close to <code>AssemblyClosedError</code>.</li>
-          <li><code>AssemblyGlobIterator</code> is a public idempotently closeable context manager. It acquires on first advancement, and exhaustion, explicit close, iterator error, cancellation/deadline, or parent close releases exactly once; close before first advancement acquires nothing. Early-breaking callers use <code>with</code> or <code>close()</code>. Its own close/exhaustion makes later advancement return <code>StopIteration</code>; parent close maps later use to <code>AssemblyClosedError</code>.</li>
-          <li>Before allocating a read result or materialization window, reserve twice its clamped length from client-wide <code>max_output_memory_bytes_total</code>. Reject a single reservation above the total; otherwise wait to the deadline. Release after the immutable bytes cross to caller ownership or the window is written/discarded.</li>
-          <li>Immediately before launching each complete-segment stage, atomically reserve that stage's declared length against both per-operation and client-wide total staging bytes. Do not pre-reserve every stage in the plan. Select memory only if both memory budgets also have space; otherwise select a private file. Acquire all counters under one scheduler or none, never hold one budget while waiting for another. This permits forward readers and materialization to serialize individually feasible stages whose sum exceeds the per-operation cap; retained seekable-reader stages keep their reservations until close.</li>
-          <li>The independent client-wide <code>max_inflight_object_bytes</code> bounds live StorageClient result chunks. Thus client-owned output, stage memory/disk, object chunks, operation count, and active source calls all have non-multiplying global ceilings across callers.</li>
+          <li>One client-wide semaphore with <code>max_concurrency</code> permits bounds active object and service calls across every view and reader.</li>
+          <li>Every top-level operation receives one absolute deadline derived from <code>timeout_seconds</code>; provider and service adapters receive the remaining budget.</li>
+          <li>Calls to the provider and to each individual fetcher instance are serialized internally. Different StorageClients and different fetchers may overlap under the global semaphore.</li>
+          <li>Private hard limits reject an oversized read, plan, inline payload, batch, or WHOLE_RESULT stage before its large allocation or I/O begins.</li>
         </ul>
         <h3>Executor algorithm</h3>
         <ol>
@@ -1484,9 +1133,9 @@ class ServiceSegmentFetcher(ABC):
           <li>Allocate one private pre-sized output buffer after all size/coverage limits pass.</li>
           <li>Intersect the range with the three segment kinds; group object operations by StorageClient binding, service operations by fetcher, and copy inline slices locally.</li>
           <li>Acquire a client-wide concurrency budget shared across concurrent views and reads.</li>
-          <li>For each object operation, split <code>fetch_range</code> into consecutive chunks no larger than <code>max_object_read_chunk_bytes</code>. Before each public <code>StorageClient.read</code>, check the absolute deadline and reserve the declared chunk length from the client-wide <code>max_inflight_object_bytes</code> budget. The call has no deadline parameter and cannot be preempted; after it returns, check the deadline again, discard late bytes, require exact length, and release the reservation. Hold one concurrency permit and any per-client serialization lock across the ordered sequence. An ordinary operation fetches only its intersection. A checksum-bearing operation stages the complete <code>fetch_range</code>, hashes it, then copies <code>selected_range_in_fetch</code>, so temp-file staging never requires a complete StorageClient result in memory. Call range-capable services with exact subranges and key each WHOLE_RESULT stage by descriptor generation, validated plan digest, and segment ordinal.</li>
-          <li>As each chunk or staged slice completes, verify exact length. When a checksum is supplied, first stage and verify the complete segment (never a partial body against a complete digest), then copy the requested slice into the non-overlapping private destination and release it when lifecycle rules permit.</li>
-          <li>On first terminal error, stop scheduling, signal cancellation, attempt every service-stream/stage close and private-file unlink in reverse deterministic registration-token order, and drain cooperative provider/service work only to its required deadline. An already-running synchronous StorageClient call remains non-preemptible until it returns or its configured underlying timeout fires; keep its permit and byte reservation until then and discard any late result. Retain failed artifacts and their reservations for later retry, discard the private output, and preserve the original typed terminal error as the public outcome.</li>
+          <li>Object operations use exact StorageClient ranges and private chunking. Stable-subrange services receive the exact requested subrange; whole-result services stage once for the touched segment ordinal and slice locally.</li>
+          <li>Verify every object result, service stream, and assembled destination slice against its declared length before publication.</li>
+          <li>On first terminal error, stop scheduling, signal cancellation, close open service streams, clean private stages, discard the private output, and preserve the original typed error.</li>
           <li>After every destination slice succeeds, freeze to <code>bytes</code> and return; v1 commits no logical-byte cache entry.</li>
         </ol>
 
@@ -1499,20 +1148,19 @@ class ServiceSegmentFetcher(ABC):
 
         <h3>AssemblyView and reader state</h3>
         <ul>
-          <li>An AssemblyView is the executable handle. It retains one metadata-only <code>AssemblyDescriptor</code>, the complete exact-result validated <code>AssemblyPlan</code>, frozen concrete source/service bindings, mandatory expiration, originally selected <code>required_consistency</code> minimum, computed consistency/capabilities, and lifecycle state. <code>AssemblyView.metadata</code> returns that exact descriptor. None of this executable state is exposed before <code>get_plan(request)</code> returns and complete-plan validation succeeds.</li>
-          <li>It never mutates or replaces its own generation. Another <code>AssemblyClient.resolve(reference)</code> returns a distinct view with its own generation and expiration. Until automatic re-resolution is approved, an expired view rejects new work before I/O.</li>
+          <li>An AssemblyView is the executable handle. It retains one metadata-only <code>AssemblyDescriptor</code>, the complete exact-result validated <code>AssemblyPlan</code>, frozen concrete source/service bindings, mandatory expiration, and lifecycle state. <code>AssemblyView.metadata</code> returns that exact descriptor. None of this executable state is exposed before <code>get_plan(request)</code> returns and complete-plan validation succeeds.</li>
+          <li>It never mutates or replaces its own generation. Another <code>AssemblyClient.resolve(reference)</code> returns a distinct view with its own generation and expiration. V1 performs no automatic re-resolution; an expired view rejects new work before I/O.</li>
           <li>Each public <code>read</code>, <code>materialize</code>, and <code>open</code> admission captures the clock once and rejects an expired view before range planning or source/service work. Once admitted, that operation may finish after expiration.</li>
-          <li>Concurrent <code>view.read</code> calls are supported; an individual seekable reader is not thread-safe.</li>
-          <li>An AssemblyReader is one admitted operation from successful <code>open</code> until <code>close</code>. It owns the pinned descriptor/validated plan, SourceReadContext, operation-local complete-segment stage registry, cursor, and closed state.</li>
+          <li>Concurrent <code>view.read</code> calls are supported; an individual forward reader is not thread-safe.</li>
+          <li>An AssemblyReader is one admitted operation from successful <code>open</code> until <code>close</code>. It owns the fixed descriptor/validated plan, SourceReadContext, operation-local complete-segment stage registry, cursor, and closed state.</li>
           <li>Closing the originating AssemblyView rejects new work through that view but does not cancel an already opened reader. The reader survives independently until its own close or parent-client close.</li>
-          <li>Reader <code>read</code>/<code>seek</code> calls do not recheck descriptor expiration or resolve another generation. A reader opened while valid may continue after expiration; a new <code>open</code> on that view fails.</li>
-          <li>Each reader read intersects its minimal logical range with the same validated complete-object plan. Any complete-segment stage required by a WHOLE_RESULT service or checksum-bearing object/service segment is created at most once per descriptor generation, validated plan digest, and segment ordinal for that reader and retained across seeks until close.</li>
-          <li>Capability computation is total. Validation rejects a WHOLE_RESULT or checksum-bearing full stage when its declared complete length exceeds its applicable per-result hard cap or <code>max_staging_bytes_per_operation</code>. Fetcher-advertised range modes are included in the computation but cannot weaken client limits. Every successfully resolved v1 view therefore has <code>byte_range_read=True</code> and <code>streaming_open=True</code>; a future false flag raises <code>AssemblyCapabilityError</code> before execution I/O.</li>
-          <li>Seek is true only when the checked sum of all distinct potentially retained stages is at most <code>max_staging_bytes_per_operation</code>. Equality is accepted. Seekable readers retain encountered stages; forward-only readers and materialization release a stage immediately after the cursor/last window passes its final logical byte, allowing several individually feasible stages to serialize even when their sum exceeds the cap. V1 never evicts and replays a stage behind a seekable cursor.</li>
+          <li>Reader <code>read</code> calls do not recheck descriptor expiration or resolve another generation. A reader opened while valid may continue after expiration; a new <code>open</code> on that view fails.</li>
+          <li>The reader is always forward-only: <code>seekable()</code> returns <code>False</code>, <code>seek()</code> is unsupported by <code>RawIOBase</code>, and <code>tell()</code> reports only the current forward cursor. Use <code>view.read(range)</code> for random access.</li>
+          <li>A WHOLE_RESULT stage is created at most once while the reader traverses that segment, then released after the cursor passes it. V1 retains no stage for backward replay.</li>
           <li>Using a view or reader after parent close raises <code>AssemblyClosedError</code>.</li>
-          <li>After non-negative/checked validation, explicit ByteRange reads clamp at EOF: zero size or offset at/past EOF returns empty, and a crossing range ends at object size. Negative/overflowing input raises <code>InvalidAssemblyRangeError</code>. Reader seeks beyond EOF are allowed; a target below zero raises that error, and subsequent reads beyond EOF are empty. The clamped output length must not exceed <code>max_read_bytes</code>.</li>
-          <li>Atomicity is per reader call, not the reader lifetime. <code>read/readinto</code> stages the current call privately; terminal execution failure publishes nothing for that call, leaves cursor and destination buffer unchanged, closes/poisons the reader, and raises the typed error. Prior successful calls remain an observable prefix; later read/seek raises <code>AssemblyClosedError</code>. Pre-execution argument errors do not poison it.</li>
-          <li>Override <code>RawIOBase.read(size=-1)</code> and <code>readall()</code>; do not inherit an implementation that loops through committing <code>readinto</code> calls. Compute the full clamped public-call length first (<code>-1</code> means the remainder), reject it above <code>max_read_bytes</code>, stage it privately, and advance the cursor exactly once after complete success.</li>
+          <li>After non-negative checked validation, explicit ByteRange reads clamp at EOF: zero size or offset at/past EOF returns empty, and a crossing range ends at object size. Negative or overflowing input raises <code>InvalidAssemblyRangeError</code>. The clamped output length must not exceed the private read limit.</li>
+          <li>Atomicity is per reader call, not the reader lifetime. <code>read/readinto</code> stages the current call privately; terminal execution failure publishes nothing for that call, leaves cursor and destination buffer unchanged, closes the reader, and raises the typed error. Prior successful calls remain an observable prefix.</li>
+          <li>Override <code>RawIOBase.read(size=-1)</code> and <code>readall()</code>; compute the full clamped public-call length first, reject it above the private read limit, and advance the cursor exactly once after complete success.</li>
         </ul>
 
         <h3>Materialization</h3>
@@ -1520,13 +1168,12 @@ class ServiceSegmentFetcher(ABC):
     destination: str | os.PathLike[str],
     *,
     overwrite: bool = False,
-    fsync: bool = False,
 ) -> None</code></pre>
         <p>
           For a filesystem path, write and close a unique temporary file in the destination directory and validate the entire
           assembled output. Create every private materialization or complete-segment stage file exclusively, use no-follow
           creation where the platform supports it, and use POSIX mode <code>0600</code>. Never reuse or follow an existing path.
-          Publication retains the temporary inode's effective mode. With <code>fsync=True</code>, flush and fsync that file before publication. The commit point is one
+          Publication retains the temporary inode's effective mode. The commit point is one
           atomic filesystem operation: <code>os.replace</code> when <code>overwrite=True</code>; when false, create the destination
           with an atomic same-filesystem no-replace primitive (initially hard-link the closed staging inode, then unlink its
           temporary name). A precheck is only an optimization and never supplies race safety. If no atomic no-replace primitive
@@ -1537,80 +1184,32 @@ class ServiceSegmentFetcher(ABC):
           v1 should therefore keep path materialization as the guaranteed API and direct stream users to <code>open()</code>.
           If materialization began before descriptor expiration it may complete afterward. Before the atomic commit point, any error
           has <code>committed=False</code>, removes the staging name best-effort, and preserves the previous destination. After
-          commit, the new destination is already visible; unlinking the extra staging link and optional parent-directory fsync
-          occur afterward. Their failures use <code>phase="cleanup"</code> or <code>"directory_fsync"</code> with
-          <code>committed=True</code>; MSC must not claim rollback, and durability is indeterminate after directory-fsync
-          failure. Once commit succeeds, the file's retention and deletion are application policy: later descriptor expiration neither deletes nor invalidates completed bytes.
+          commit, the new destination is already visible; any cleanup failure is reported with
+          <code>phase="cleanup"</code> and <code>committed=True</code>, so MSC never falsely claims rollback. Once commit succeeds,
+          the file's retention and deletion are application policy: later descriptor expiration neither deletes nor invalidates completed bytes.
           All windows of one materialization share one operation context and complete-segment stage registry, so a WHOLE_RESULT
-          service or checksum-bearing object/service segment ordinal is not re-executed or refetched. Every operation-local private stage is cleaned successfully before the destination commit;
-          a cleanup failure therefore prevents publication rather than leaving a committed destination with an unreported
-          private orphan. Each logical window is exactly <code>min(materialization_window_bytes, remaining_bytes)</code>;
-          the last may be shorter, and the private assembled-output buffer never exceeds the configured window (separate
-          complete-segment staging reservations still apply).
+          service segment ordinal is not re-executed. Every operation-local private stage is cleaned successfully before the destination commit;
+          a cleanup failure therefore prevents publication. Each logical window is exactly <code>min(MATERIALIZATION_WINDOW_BYTES, remaining_bytes)</code>;
+          the last may be shorter, and the window size is a private module constant.
         </p>
 
         <h3>Memory policy</h3>
         <ul>
-          <li><code>read</code> is bounded by <code>max_read_bytes</code>. The initial Python implementation may hold its mutable private output and immutable returned <code>bytes</code> simultaneously, so the specified peak is at most twice the clamped result length plus bounded in-flight chunks and service stages; a later proven no-copy path may lower but not raise this gate.</li>
+          <li><code>read</code> is bounded by a private hard limit. The initial Python implementation may hold its mutable private output and immutable returned <code>bytes</code> simultaneously.</li>
           <li><code>materialize</code> uses windowed reads and a staging file so object size is not duplicated in memory.</li>
           <li>Complete plans are bounded by segment count and encoded size before range intersection or read scheduling.</li>
-          <li>Complete-segment stages have separate per-result memory, per-result bytes, operation-wide, and client-wide temp-file byte ceilings. These limits cover WHOLE_RESULT services and complete object/service verification required by checksums; each descriptor-generation, plan-digest, and segment-ordinal stage key is materialized once per top-level operation.</li>
-          <li>Inline data has hard decoded upper ceilings of 16 KiB per segment and 64 KiB per complete object; configuration may only lower them.</li>
+          <li>WHOLE_RESULT service stages have a private per-result hard cap and use bounded memory or a private temporary file; each segment ordinal is staged at most once per top-level operation.</li>
+          <li>Inline data has hard decoded upper ceilings of 16 KiB per segment and 64 KiB per complete object.</li>
           <li>Every user-owned service stream is measured against declared length and client staging ceilings; transport metadata is never trusted as a substitute.</li>
         </ul>
       </section>
 
-      <section id="http-adapter">
-        <h2>9. Optional phase-two generic HTTP adapter</h2>
-        <div class="decision">
-          <strong>The Assembly core does not require or ship an HTTP service adapter.</strong>
-          The initial feature is complete when a user-defined <code>ServiceSegmentFetcher</code> can execute service segments
-          through HTTP, gRPC, an SDK, or a local call without any MSC-defined wire protocol. A possible generic
-          <code>HttpServiceSegmentFetcher</code> is a separate phase-two convenience adapter, subject to approval of its own
-          format-neutral contract.
-        </div>
-
-        <h3>Core/non-core boundary</h3>
-        <div class="table-wrap">
-          <table>
-            <thead><tr><th>Concern</th><th>Initial Assembly core</th><th>Optional HTTP adapter</th></tr></thead>
-            <tbody>
-              <tr><td>Service extension contract</td><td><code>ServiceSegmentFetcher</code> and <code>ServiceFetchRequest</code>.</td><td>Implements that same SPI; introduces no second assembly model.</td></tr>
-              <tr><td>External API</td><td>User-owned and transport neutral.</td><td>MSC still defines no server endpoints, payload schema, or authentication API.</td></tr>
-              <tr><td>Protocol translation</td><td>User implementation owns it.</td><td>A user-provided translation hook would map one service request to a bounded HTTP request.</td></tr>
-              <tr><td>Assembly semantics</td><td>Validation, planning, bounds, staging, lifecycle, and errors.</td><td>Must not receive a complete plan or decide segment ordering.</td></tr>
-              <tr><td>Release dependency</td><td>Required.</td><td>Not required for core acceptance, E2E coverage, packaging, or release.</td></tr>
-            </tbody>
-          </table>
-        </div>
-
-        <h3>Approval conditions for a future adapter</h3>
-        <ul>
-          <li>Approve a separately versioned, format-neutral generic HTTP adapter contract. This document intentionally does not freeze its config class, request/response payloads, endpoints, authentication callbacks, status mappings, or retry defaults.</li>
-          <li>Keep origin, credentials, allowed paths, and translation code in trusted local configuration. An assembly plan may select only a locally registered fetcher alias and bounded opaque operation/parameters that the selected fetcher validates.</li>
-          <li>Require the adapter to obey the existing service SPI: one segment request, exact declared bytes, explicit range mode, shared deadline/cancellation, bounded chunks, redacted errors, and no access to the complete plan or segment ordering.</li>
-          <li>Demonstrate that the contract is generic rather than tied to a particular data format or one application's service API.</li>
-        </ul>
-
-        <h3>Open decisions owned by the follow-up</h3>
-        <ul>
-          <li>Whether a built-in adapter is valuable enough to justify a stable public surface.</li>
-          <li>The smallest generic request/response translation hook and how authentication remains application-owned.</li>
-          <li>Origin confinement, TLS, redirects, proxies, retries, response-size limits, streaming, cancellation, and process-lifecycle behavior.</li>
-        </ul>
-
-        <div class="callout info">
-          None of these open decisions blocks the core module. Core E2E tests use an in-process user-defined
-          <code>ServiceSegmentFetcher</code> and pass with no HTTP adapter or network server.
-        </div>
-      </section>
-
       <section id="python-scope">
-        <h2>10. Python-only implementation scope</h2>
+        <h2>9. Python-only implementation scope</h2>
         <div class="decision">
           <strong>All initial Assembly implementation work is in Python.</strong>
-          Public models, the list codec, provider and service SPIs, expiration/consistency semantics, plan validation, range
-          mapping, bounded execution, staging, cache policy, views, readers, and materialization remain in the
+          Public models, the list codec, provider and service SPIs, expiration, exact-length semantics, plan validation, range
+          mapping, bounded execution, staging, views, readers, and materialization remain in the
           <code>multistorageclient.assembly</code> Python package.
         </div>
         <p>
@@ -1620,36 +1219,28 @@ class ServiceSegmentFetcher(ABC):
       </section>
 
       <section id="operations">
-        <h2>11. Cache, retry, lifecycle, telemetry, and security</h2>
+        <h2>10. Retry, lifecycle, telemetry, and security</h2>
 
-        <h3>Cache layers</h3>
-        <div class="table-wrap">
-          <table>
-            <thead><tr><th>Layer</th><th>Key</th><th>Commit rule</th><th>Initial default</th></tr></thead>
-            <tbody>
-              <tr><td>Descriptor</td><td>reference + generation + internal provider-instance scope</td><td>After model/expiration validation; lookup rechecks expiration. The entry never crosses provider instances without a separately approved trustworthy identity.</td><td>Per-client bounded LRU with hard expiry no later than the descriptor's <code>expires_at</code>.</td></tr>
-              <tr><td>Validated complete plan</td><td>descriptor/generation + plan digest + consistency policy + this client's frozen local registry snapshot</td><td>Only after complete-object/global-length/union validation and binding freeze. Entries never cross an AssemblyClient or registry-snapshot boundary.</td><td>Small bounded LRU; hard expiry at the captured descriptor expiration, never sliding.</td></tr>
-              <tr><td>Logical bytes</td><td>Not applicable in v1.</td><td>No logical-byte cache is populated.</td><td>Disabled; v1 exposes no object-binding or fetcher cache identity.</td></tr>
-              <tr><td>Complete-segment staging</td><td>top-level operation + generation + plan digest + segment ordinal</td><td>After exact length and optional digest validation.</td><td>Memory/temp-file staging for WHOLE_RESULT service segments and complete checksum verification is local to the current resolved view and operation. Different ordinals never deduplicate; cleanup failure remains explicitly tracked and charged until retry.</td></tr>
-              <tr><td>Completed materialized file</td><td>Application-selected destination</td><td>Only after the atomic commit operation succeeds.</td><td>Not an assembly cache. Lifetime is application-owned and independent of descriptor expiration.</td></tr>
-            </tbody>
-          </table>
-        </div>
+        <h3>State retention</h3>
+        <ul>
+          <li>V1 has no cross-<code>resolve()</code> descriptor, plan, or logical-byte cache. Every resolve calls the provider once and returns a distinct view.</li>
+          <li>Each view retains only its own validated plan and frozen bindings until the view and its readers are closed.</li>
+          <li>WHOLE_RESULT staging is private to one view operation or reader and is released when that owner closes.</li>
+          <li>A completed materialized file is application-owned and remains independent of descriptor expiration.</li>
+        </ul>
         <h3>Retry ownership</h3>
         <ul>
           <li>Provider adapter retries its own transport without changing the exact request.</li>
           <li>StorageClient retains its documented retry behavior; AssemblyClient adds no outer object-read retry. Because the current read API accepts no deadline, applications configure its underlying transport timeout and retry envelope with the Assembly operation budget in mind.</li>
-          <li>A ServiceSegmentFetcher may create more than one private attempt only when the segment says <code>RetrySafety.SAFE</code>, using its documented bound under the shared deadline. <code>RetrySafety.NEVER</code> permits exactly one private attempt once submission starts, even when that attempt fails before any response byte is observed.</li>
-          <li>The assembly executor never retries an object or service submission. It owns concurrency, internal cancellation, staging cleanup, atomic publication, and hard deadline enforcement for admission and MSC-owned waits; it can only observe the deadline before and after a synchronous StorageClient call.</li>
-          <li>No layer retries invalid/expired plans, binding mismatches, enforced revision mismatches, digest failures, unknown kinds, or protocol violations.</li>
-          <li>Defaults prevent multiplicative retries: every nested operation receives one absolute monotonic deadline and each WHOLE_RESULT stage key has one logical fetch submission. Only its explicit SAFE policy may create multiple private attempts inside that submission; NEVER always remains one attempt.</li>
+          <li>The assembly executor never retries an object or service submission. It owns concurrency, internal cancellation, staging cleanup, atomic publication, and deadline enforcement for admission and MSC-owned waits.</li>
+          <li>A user fetcher may retry internally as an opaque implementation detail, but MSC invokes its core <code>fetch()</code> method once and passes one absolute deadline.</li>
+          <li>No layer retries invalid or expired plans, binding mismatches, unknown kinds, length mismatches, or protocol violations.</li>
           <li><code>AssemblyTimeoutError</code> (also <code>TimeoutError</code>) is the sole public outcome once the shared absolute deadline is observed exhausted at provider, scheduling, object, service, or staging boundaries. The deadline hard-bounds admission, MSC-owned waits, and cooperative provider/service work. An in-progress synchronous StorageClient call cannot be preempted and may return after that instant; MSC checks immediately afterward, discards late bytes/errors, and then raises <code>AssemblyTimeoutError</code>. While budget remains, a provider-local transient timeout maps to <code>AssemblyProviderRetryableError</code>, and object/service local timeouts map to their transport classes. The v1 façade has no caller-cancellation argument: its internal token is signaled by sibling failure or parent close, and cooperative code checks it between attempts or chunks.</li>
         </ul>
 
-        <h3 id="exceptions">Canonical public exception hierarchy and construction</h3>
+        <h3 id="exceptions">Public exception hierarchy</h3>
         <pre><code>AssemblyError
 ├── AssemblyClosedError
-├── AssemblyCloseError
 ├── AssemblyCancelledError
 ├── AssemblyTimeoutError                    # also a TimeoutError
 ├── AssemblyExpiredError
@@ -1657,7 +1248,6 @@ class ServiceSegmentFetcher(ABC):
 ├── AssemblyMaterializationError
 ├── AssemblyNotFoundError                   # also a FileNotFoundError
 ├── AssemblyGenerationUnavailableError
-├── AssemblyCapabilityError
 ├── AssemblyConfigurationError              # also a ValueError
 ├── AssemblyLimitExceededError              # also a ValueError
 ├── InvalidAssemblyRangeError                # also a ValueError
@@ -1673,10 +1263,8 @@ class ServiceSegmentFetcher(ABC):
 │   ├── ServiceAuthenticationError
 │   ├── ServiceAuthorizationError
 │   ├── ServiceNotFoundError
-│   ├── ServiceRevisionMismatchError
 │   ├── ServiceRangeNotSatisfiableError
 │   ├── ServiceLengthMismatchError
-│   ├── ServiceIntegrityError
 │   ├── ServiceProtocolError
 │   └── ServiceTransportError
 └── ObjectSourceError
@@ -1685,40 +1273,13 @@ class ServiceSegmentFetcher(ABC):
     ├── SourceNotFoundError
     ├── SourceRetryableError                # StorageClient exhausted its own retries
     ├── ShortSourceReadError
-    ├── SourceIntegrityError
     ├── SourceProtocolError
     └── SourceTransportError</code></pre>
         <p class="small">
-          Provider and source adapters preserve only a bounded, sanitized cause-type token. They never retain the original
-          backend exception, parse its message, or inspect private provider state.
+          Provider and source adapters expose only a bounded, sanitized cause classification. Public errors never expose
+          backend messages or private provider state.
         </p>
-        <pre><code>class AssemblyError(Exception):
-    def __init__(self, /) -> None:
-        super().__init__()
-
-    def __str__(self) -> str:
-        return type(self).__name__
-
-    def __repr__(self) -> str:
-        return f"{type(self).__name__}()"
-
-@dataclass(frozen=True, slots=True)
-class CloseFailure:
-    dependency_kind: Literal["staging_artifact", "plan_provider", "service_fetcher"]
-    aliases: tuple[str, ...]  # sorted configured aliases; empty for staging and the plan provider
-    error_type: str          # safe_type_token(type(exc)); never its message
-
-class _SanitizedDependencyCause(Exception):
-    cause_type: str
-
-    def __init__(self, cause_type: str) -> None: ...
-
-class AssemblyCloseError(AssemblyError):
-    failures: tuple[CloseFailure, ...]
-
-    def __init__(self, failures: Sequence[CloseFailure]) -> None: ...
-
-class ServiceTransportError(ServiceSegmentError):
+        <pre><code>class ServiceTransportError(ServiceSegmentError):
     retryable: bool          # classification only; not permission for an outer retry
 
     def __init__(self, *, retryable: bool) -> None: ...
@@ -1749,7 +1310,7 @@ class AssemblyStagingError(AssemblyError):
     def __init__(self, *, cause_type: str) -> None: ...
 
 MaterializationPhase: TypeAlias = Literal[
-    "precondition", "create", "write", "file_fsync", "commit", "directory_fsync", "cleanup"
+    "precondition", "create", "write", "commit", "cleanup"
 ]
 
 class AssemblyMaterializationError(AssemblyError):
@@ -1759,55 +1320,41 @@ class AssemblyMaterializationError(AssemblyError):
 
     def __init__(self, *, phase: MaterializationPhase, cause_type: str, committed: bool) -> None: ...</code></pre>
         <p>
-          This hierarchy and these structured constructors are normative. Every fieldless public leaf inherits the no-message
-          constructor. Each structured leaf accepts only its documented bounded keyword fields,
-          calls the no-argument base initializer, and never puts arbitrary caller text in <code>args</code>,
-          <code>str</code>, or <code>repr</code>. At provider, validator, object-client, fetcher, stream-close, and
-          dependency-close boundaries, only exact allowlisted public classes are recognized. MSC copies their validated safe
-          fields into a fresh canonical instance; subclasses or malformed fields normalize to that boundary's generic error.
-          Classification occurs inside <code>except Exception</code>, but the caught object is discarded and the fresh error is
-          raised only after the handler exits. Its only explicit cause may be a newly constructed
-          <code>_SanitizedDependencyCause</code>, whose sole field is <code>safe_type_token</code>. The original object must not
-          be reachable through <code>__cause__</code>, <code>__context__</code>, <code>args</code>, attributes, or formatted
-          traceback. <code>BaseException</code> control-flow signals are not wrapped or logged by this layer.
+          The hierarchy and structured safe fields are normative; the internal exception-copying mechanism is not. Public
+          exceptions never include arbitrary backend messages, logical keys, resources, URLs, parameters, credentials, or
+          response bodies. Unknown provider, StorageClient, or fetcher exceptions map to the generic error for that boundary
+          with only a validated cause-type classification. <code>BaseException</code> control-flow signals are not wrapped.
         </p>
         <p class="small">
-          Structured fields are closed: <code>retryable</code> and <code>committed</code> are exact booleans; limit values are strict non-negative JSON-safe
-          integers; phases and dependency kinds are the documented literals; and input sequences are defensively copied and
-          bounded before assignment. <code>safe_type_token(T)</code> returns <code>T.__name__</code> only when it matches
-          <code>[A-Za-z_][A-Za-z0-9_]{0,127}</code>, otherwise <code>Exception</code>. Close failures use deterministic order:
-          at most one aggregate staging-artifact record, then the plan provider and distinct service fetchers by first alias.
-          Alias tuples are sorted and deduplicated. Public formatting never
-          includes a logical key, resource, URL, parameters, credential, response body, or nested exception message.
-          <code>AssemblyTimeoutError</code> normalizes exhaustion of the shared deadline and remains distinct from MSC's internal
-          sibling-failure/parent-close cancellation; v1 exposes no caller-supplied cancellation input.
+          Structured fields are closed and bounded: booleans are exact booleans, limit values are strict non-negative
+          JSON-safe integers, and phases are documented literals. <code>AssemblyTimeoutError</code> normalizes exhaustion of
+          the shared deadline and remains distinct from MSC's internal sibling-failure or parent-close cancellation; v1
+          exposes no caller-supplied cancellation input.
         </p>
 
         <h3>Lifecycle and ownership</h3>
         <ul>
-          <li>StorageClients are always borrowed because the existing public StorageClient API has no close lifecycle. AssemblyClient never attempts to close one.</li>
-          <li><code>close_dependencies=False</code> also borrows the plan provider and service fetchers.</li>
-          <li>With <code>close_dependencies=True</code>, close the provider and each distinct service fetcher only. A Static provider honors its separate <code>close_store</code> flag.</li>
-          <li>Close sequence: reject new work, cancel queued operations, signal and close active service result streams/internal iterators, drain cooperative work to its deadline, and wait for any already-running synchronous StorageClient call to return under its configured underlying timeout. Then attempt every retained staging artifact, clear caches/views, and optionally close dependencies.</li>
-          <li>Close is state-idempotent: the first call permanently rejects new work. It retries retained artifacts in reverse deterministic registration-token order, then attempts all owned dependencies in deterministic plan-provider then service-fetcher first-alias order. Every artifact/dependency is attempted; at most one leading <code>staging_artifact</code> record captures the first safe cleanup failure type, then each distinct dependency appears once with sorted/deduplicated aliases. If cleanup fails, the client remains closed and raises one redacted <code>AssemblyCloseError</code>. A later <code>close()</code> retries only outstanding orphan artifacts and never re-closes an already attempted dependency; once no artifact remains, subsequent calls are no-ops.</li>
+          <li>AssemblyClient borrows the plan provider, service fetchers, and StorageClients. The application remains responsible for closing those dependencies through their own public APIs.</li>
+          <li>Client close rejects new work, cancels queued operations, signals active cooperative work, closes MSC-owned readers, streams, and private stages, and waits for already-running synchronous StorageClient calls under their configured transport timeouts.</li>
+          <li>Close is idempotent. MSC attempts cleanup of every resource it owns; a cleanup failure uses the relevant redacted service or staging error and does not transfer ownership of application-supplied dependencies.</li>
           <li>Live clients/views/readers are non-pickleable by default; only explicit configuration/factory wrappers may reconstruct them.</li>
-          <li>Expiration does not close an in-flight operation or a successfully materialized file. It rejects subsequent operations and invalidates instruction-derived caches.</li>
+          <li>Expiration does not close an in-flight operation or a successfully materialized file. It rejects subsequent operations on that view.</li>
         </ul>
 
         <h3>Telemetry</h3>
         <ul>
           <li>Spans: <code>assembly.resolve</code>, <code>assembly.plan</code>, <code>assembly.read</code>, <code>assembly.object.read</code>, <code>assembly.service.fetch</code>, and <code>assembly.materialize</code>.</li>
-          <li>Metrics: list batches/objects, plan segments by kind, inline bytes, object/service bytes, core service-fetcher submissions, complete-segment staging bytes/backend, amplification, expiration rejection, cooperative cancellation latency, cache hit/miss, and failure class.</li>
+          <li>Metrics: plan segments by kind, object/service bytes, service-fetcher submissions, WHOLE_RESULT staging bytes, expiration rejection, and failure class.</li>
           <li>Low-cardinality labels only: segment kind, configured alias, range mode, result class, and staging backend.</li>
           <li>Fetcher-internal retries and transport-specific telemetry remain owned by the user implementation because the core SPI does not expose them.</li>
-          <li>No logical keys, resources, credentials, ETags, or auth revisions as metric labels. Trace attributes are redacted and bounded.</li>
+          <li>No logical keys, resources, credentials, or ETags as metric labels. Trace attributes are redacted and bounded.</li>
         </ul>
 
         <h3>Security controls</h3>
         <ul>
           <li>Treat provider output as untrusted and validate before allocation or I/O.</li>
-          <li>Limit list batch/object count, logical object size, one read, segment count, encoded bytes, decoded inline bytes, resource/parameter length, source/service result range, complete-segment staging memory/temp bytes, concurrency, retries, and time.</li>
-          <li>Use separate local object/service aliases and frozen local binding objects; instruction caches never cross an AssemblyClient or frozen registry snapshot, and logical-byte caching is disabled in v1.</li>
+          <li>Limit list batch/object count, logical object size, one read, segment count, encoded bytes, decoded inline bytes, resource/parameter length, WHOLE_RESULT staging bytes, concurrency, and time.</li>
+          <li>Use separate local object/service aliases and frozen local binding objects; cross-operation logical-byte caching is disabled in v1.</li>
           <li>Interpret object resources only through each least-privilege bound StorageClient's public logical namespace. Service fetchers confine operations to their locally configured authority; transport-specific controls belong to that implementation.</li>
           <li>Create every MSC-owned private stage/materialization file exclusively, use no-follow creation where supported, and use POSIX mode <code>0600</code>; publication retains that inode's effective mode.</li>
           <li>Make all errors/reprs safe by construction and test redaction with canary secrets.</li>
@@ -1815,54 +1362,42 @@ class AssemblyMaterializationError(AssemblyError):
       </section>
 
       <section id="files">
-        <h2>12. File-by-file implementation plan</h2>
+        <h2>11. File-by-file implementation plan</h2>
         <h3>Python package</h3>
         <pre><code>multi-storage-client/src/multistorageclient/assembly/
 ├── __init__.py              # intentional public re-exports only
-├── client.py                # AssemblyClient façade, AssemblyGlobIterator, and lifecycle
+├── client.py                # AssemblyClient façade and lifecycle
 ├── view.py                  # immutable generation/expiration-bound AssemblyView
-├── reader.py                # read-only seekable RawIOBase implementation
-├── models.py                # frozen list/plan/segment-union models and policies
+├── reader.py                # read-only forward RawIOBase implementation
+├── models.py                # list/plan/segment-union public models
 ├── provider.py              # AssemblyPlanProvider + StaticAssemblyListProvider
-├── browsing.py              # optional BrowsableAssemblyPlanProvider capability
 ├── service.py               # ServiceSegmentFetcher and requests
 ├── bindings.py              # immutable StorageClient/service alias bindings
-├── config.py                # limits, consistency, retry, staging, ownership, cache policy
+├── limits.py                # internal MVP safety constants
 ├── errors.py                # stable public exception hierarchy
 ├── testing.py               # provider/service-fetcher conformance helpers
 ├── list_codec.py            # public bounded assembly-list/v1 encode/decode/streaming API
-├── list_store.py            # AssemblyListStore + bounded in-memory small-list implementation
-├── _canonical.py            # RFC 8785 plan projection and instruction digest
-├── _validator.py            # expiration, union, global coverage, consistency, limits
-├── _planner.py              # caller-range intersection and operation-local stage reuse
-├── _executor.py             # bounded scheduling and atomic result assembly
-├── _segment_stage.py        # bounded memory/temp-file complete-segment staging
-└── _cache.py                # expiration-bounded descriptor and validated-plan caches</code></pre>
+├── validator.py             # expiration, union, global coverage, aliases, and limits
+├── planner.py               # caller-range intersection and operation-local stage reuse
+├── executor.py              # bounded scheduling and atomic result assembly
+└── staging.py               # bounded memory/temp-file complete-segment staging</code></pre>
 
         <div class="callout info">
-          Only the client/view/reader, stable models/list codec, provider/service contracts, config, and documented errors are public. Leading-
-          underscore planner/executor/cache modules remain implementation details so performance internals can evolve without
-          expanding the compatibility surface.
+          Package files use ordinary submodule names; leading underscores are not used as an architectural boundary. The
+          supported public API is defined by explicit re-exports from <code>multistorageclient.assembly.__init__</code> and by
+          the API documentation. Non-exported implementation submodules may evolve without expanding the compatibility surface.
         </div>
-
-        <h3>Concrete transport-adapter files (not in the core change)</h3>
-        <p>
-          No concrete transport-adapter module is required or changed by the initial core. Any future adapter's public name,
-          files, protocol, and tests belong to its separately approved specification.
-        </p>
 
         <h3>Tests and docs</h3>
         <pre><code>multi-storage-client/tests/test_multistorageclient/unit/assembly/
 ├── conftest.py
 ├── conformance.py
 ├── test_list_codec.py
-├── test_canonical.py
 ├── test_models.py
 ├── test_provider_conformance.py
 ├── test_static_list_provider.py
 ├── test_service_fetcher_conformance.py
 ├── test_expiration.py
-├── test_consistency.py
 ├── test_validation.py
 ├── test_planning.py
 ├── test_planning_properties.py
@@ -1893,11 +1428,11 @@ multi-storage-client-docs/examples/
           <table>
             <thead><tr><th>Concern</th><th>Primary file</th></tr></thead>
             <tbody>
-              <tr><td>Portable codec, canonical models, and limits</td><td><code>test_list_codec.py</code>, <code>test_canonical.py</code>, <code>test_models.py</code>, <code>test_validation.py</code></td></tr>
+              <tr><td>Portable codec, public models, and private hard limits</td><td><code>test_list_codec.py</code>, <code>test_models.py</code>, <code>test_validation.py</code></td></tr>
               <tr><td>Reusable adopter contracts</td><td><code>test_provider_conformance.py</code>, <code>test_service_fetcher_conformance.py</code></td></tr>
               <tr><td>MSC-supplied static provider and bindings</td><td><code>test_static_list_provider.py</code>, <code>test_bindings.py</code>, <code>test_storage_client_object.py</code></td></tr>
               <tr><td>Planning and MSC execution internals</td><td><code>test_planning.py</code>, <code>test_planning_properties.py</code>, <code>test_executor.py</code>, <code>test_service_staging.py</code></td></tr>
-              <tr><td>Public client, view, reader, and lifecycle</td><td><code>test_client.py</code>, <code>test_view.py</code>, <code>test_reader.py</code>, <code>test_expiration.py</code>, <code>test_consistency.py</code></td></tr>
+              <tr><td>Public client, view, reader, and lifecycle</td><td><code>test_client.py</code>, <code>test_view.py</code>, <code>test_reader.py</code>, <code>test_expiration.py</code></td></tr>
               <tr><td>Materialization and in-process acceptance</td><td><code>test_materialize.py</code>, <code>test_acceptance.py</code></td></tr>
             </tbody>
           </table>
@@ -1913,12 +1448,12 @@ multi-storage-client-docs/examples/
       </section>
 
       <section id="test-architecture">
-        <h2>13. Test architecture, fixtures, and quality gates</h2>
+        <h2>12. Test architecture, fixtures, and quality gates</h2>
         <h3>Test pyramid</h3>
         <div class="grid-3">
           <div class="card">
             <h4>Pure unit/property</h4>
-            <p>List codec, segment union, expiration, range intersection, global-length validation, no-cross-segment behavior, error mapping, and instruction-cache scoping. No threads or sockets where unnecessary.</p>
+            <p>List codec, segment union, expiration, range intersection, global-length validation, no-cross-segment behavior, and error mapping. No threads or sockets where unnecessary.</p>
           </div>
           <div class="card">
             <h4>Component/conformance</h4>
@@ -1956,32 +1491,28 @@ multi-storage-client-docs/examples/
 
         <h3>Property-test dependency</h3>
         <p>
-          Add Hypothesis to the Python development dependency group after approval. CI uses <code>max_examples=200</code> and
+          Add Hypothesis to the Python development dependency group through ordinary dependency review. CI uses <code>max_examples=200</code> and
           <code>deadline=None</code>, while preserving minimized failing examples. If the dependency is declined, use seeded
           deterministic generated partitions, but record the reduced malformed-input coverage as a test-plan exception.
         </p>
       </section>
 
       <section id="test-cases">
-        <h2>14. Detailed test cases and assertions</h2>
+        <h2>13. Detailed test cases and assertions</h2>
 
-        <h3>14.1 Language-neutral list codec, models, and expiration</h3>
+        <h3>13.1 Language-neutral list codec, models, and expiration</h3>
         <div class="table-wrap">
           <table>
             <thead><tr><th>Test</th><th>Primary assertion</th></tr></thead>
             <tbody>
-              <tr><td><code>test_decode_minimal_batch_returns_one_complete_object_definition</code></td><td>Independent JSON input produces frozen typed models and one complete <code>AssemblyObjectDefinition</code>; decoding alone does not create an executable <code>AssemblyPlan</code>.</td></tr>
-              <tr><td><code>test_public_batch_encode_decode_round_trip_and_digest_encoding</code></td><td>One canonical document uses the exact <code>sha256:&lt;64 lowercase hex&gt;</code> digest form.</td></tr>
-              <tr><td><code>test_segment_checksum_uses_unprefixed_lower_hex_64</code></td><td>Segment checksum JSON is distinct from prefixed plan/batch digests and rejects uppercase/prefix variants.</td></tr>
+              <tr><td><code>test_decode_minimal_batch_returns_one_complete_object_definition</code></td><td>Independent JSON input produces one complete <code>AssemblyObjectDefinition</code>; decoding alone does not create an executable <code>AssemblyPlan</code>.</td></tr>
+              <tr><td><code>test_public_batch_encode_decode_round_trip</code></td><td>The simplified v1 fields round-trip without producer-specific data.</td></tr>
               <tr><td><code>test_reference_parameters_are_scalar_only</code></td><td>Nested reference values fail while nested service parameters remain injective.</td></tr>
-              <tr><td><code>test_canonical_key_order_uses_rfc8785_utf16_units</code></td><td>BMP/non-BMP golden keys match language-neutral JCS vectors; lone surrogates fail.</td></tr>
-              <tr><td><code>test_frozen_json_scalar_equality_and_hash_are_kind_aware</code></td><td>True/1 and False/0 remain distinct; numerically canonical 1/1.0 and 0/-0.0 normalize equal and digest identically.</td></tr>
-              <tr><td><code>test_schema_integer_fields_reject_bool_and_integral_float</code></td><td>Range, sizes, lengths, indexes, pages, and config counts accept strict int only.</td></tr>
-              <tr><td><code>test_streaming_codec_reads_and_writes_canonical_ndjson_batches</code></td><td>One bounded document per line; iterator never accumulates the snapshot.</td></tr>
-              <tr><td><code>test_streaming_codec_rejects_oversized_line_before_parse_or_large_allocation</code></td><td><code>max_encoded_batch_bytes</code> applies while buffering.</td></tr>
-              <tr><td><code>test_static_from_batches_applies_structural_limits_and_capped_canonical_counter_to_direct_models</code></td><td>An oversized one-shot direct batch aborts at one-over without constructing its complete encoding or committing earlier aggregate counters.</td></tr>
-              <tr><td><code>test_assembly_list_v1_matches_published_language_neutral_golden_vectors</code></td><td>Python encoding and decoding match the shared canonical bytes for all three segment kinds, Unicode, timestamps, and base64; each future consumer language validates the same fixtures in its own suite.</td></tr>
-              <tr><td><code>test_multi_batch_list_requires_shared_metadata_declared_count_and_contiguous_indexes</code></td><td>Mixed list IDs/issuance/expiration/counts, gaps, duplicates, missing batches, indexes outside the declared count, and batch-digest mismatch fail closed.</td></tr>
+              <tr><td><code>test_schema_integer_fields_reject_bool_and_integral_float</code></td><td>Ranges, sizes, lengths, indexes, and constructor concurrency accept strict integers only.</td></tr>
+              <tr><td><code>test_streaming_codec_reads_and_writes_bounded_json_batches</code></td><td>One bounded document per line; the iterator never accumulates the whole batch set.</td></tr>
+              <tr><td><code>test_streaming_codec_rejects_oversized_line_before_parse</code></td><td>The private encoded-batch limit applies while buffering.</td></tr>
+              <tr><td><code>test_assembly_list_v1_matches_published_language_neutral_golden_vectors</code></td><td>Python encoding and decoding match shared JSON values for all segment kinds, Unicode, timestamps, and base64.</td></tr>
+              <tr><td><code>test_multi_batch_list_requires_shared_metadata_count_and_contiguous_indexes</code></td><td>Mixed list IDs, expirations, counts, gaps, duplicates, missing batches, and out-of-range indexes fail closed.</td></tr>
               <tr><td><code>test_multi_batch_list_rejects_duplicate_reference_across_batches</code></td><td>One canonical <code>AssemblyReference</code> identifies at most one complete object definition in the validated snapshot.</td></tr>
               <tr><td><code>test_v1_portable_list_omits_replacement_locator</code></td><td>Replacement transport remains provider-owned and uses another <code>get_plan(request)</code> rather than a dead portable field.</td></tr>
               <tr><td><code>test_batch_never_splits_one_object_definition</code></td><td>A partial/carry-over object is not representable or executable.</td></tr>
@@ -1990,67 +1521,51 @@ multi-storage-client-docs/examples/
               <tr><td><code>test_static_provider_rejects_expired_list_at_admission</code></td><td>Raises <code>AssemblyExpiredError</code> before plan exposure with zero object/service calls.</td></tr>
               <tr><td><code>test_byte_range_is_frozen_hashable_and_bounded</code></td><td>Canonical range cannot mutate and rejects negative/overflow arithmetic.</td></tr>
               <tr><td><code>test_existing_msc_range_is_copied_at_api_boundary</code></td><td>Later mutation of the caller's Range cannot alter view/request identity.</td></tr>
-              <tr><td><code>test_models_are_slotted_hashable_and_immutable</code></td><td>Mutation and unknown attribute assignment fail; identity types are hashable where documented.</td></tr>
-              <tr><td><code>test_reference_parameters_are_defensively_copied_and_canonical</code></td><td>Mutating the caller's mapping cannot change reference or cache identity.</td></tr>
-              <tr><td><code>test_reference_parameters_reject_nonfinite_numbers</code></td><td>NaN and infinities never enter equality, digest, or cache keys.</td></tr>
-              <tr><td><code>test_reference_integer_parameters_require_json_safe_range</code></td><td>Cross-language plan digests cannot silently round large integers.</td></tr>
-              <tr><td><code>test_frozen_json_array_and_object_are_distinct_for_pair_shaped_values</code></td><td><code>[["a", 1]]</code> and <code>{"a": 1}</code> never collapse to the same Python model or digest.</td></tr>
-              <tr><td><code>test_service_parameters_require_frozen_json_object_root</code></td><td>Nested arrays/objects round-trip injectively while the operation parameter root remains an object.</td></tr>
+              <tr><td><code>test_plan_json_inputs_are_defensively_copied_at_resolve</code></td><td>Mutating provider-owned parameter dictionaries cannot change an existing view.</td></tr>
+              <tr><td><code>test_json_parameters_reject_nonfinite_or_non_json_values</code></td><td>NaN, infinities, bytes, and arbitrary Python objects never enter a validated plan.</td></tr>
               <tr><td><code>test_rejects_unknown_list_or_plan_schema_version</code></td><td>Fails closed with <code>UnsupportedAssemblySchemaError</code>.</td></tr>
               <tr><td><code>test_v1_plan_requires_exact_result_semantics</code></td><td>Missing or non-<code>exact</code> semantics fails before binding or byte I/O; informational annotations cannot request projection.</td></tr>
-              <tr><td><code>test_future_projection_plan_requires_new_version_and_capability</code></td><td>A v1 client rejects carrier-plus-projection semantics instead of silently materializing a semantic superset.</td></tr>
+              <tr><td><code>test_future_projection_plan_requires_new_version</code></td><td>A v1 client rejects carrier-plus-projection semantics instead of silently materializing a semantic superset.</td></tr>
               <tr><td><code>test_supporting_future_plan_version_does_not_change_v1_exact_interpretation</code></td><td>The same valid v1 golden vector continues to produce identical final bytes after a newer decoder is introduced.</td></tr>
-              <tr><td><code>test_unknown_required_capability_rejects_before_binding_or_io</code></td><td>A client never ignores a capability that is required to interpret a newer plan safely.</td></tr>
               <tr><td><code>test_v1_provider_and_fetcher_spis_gain_no_required_abstract_members</code></td><td>The minimal v1 adopter implementations remain constructible as the package evolves.</td></tr>
               <tr><td><code>test_additive_public_parameters_are_keyword_only_with_defaults</code></td><td>Existing façade calls retain their behavior when optional parameters are added.</td></tr>
               <tr><td><code>test_rejects_unknown_fields_or_segment_kind</code></td><td>Forward-incompatible input is not silently ignored or reinterpreted.</td></tr>
               <tr><td><code>test_decodes_object_service_and_inline_discriminated_union</code></td><td>Each kind has its exact fields and cannot borrow fields from another kind.</td></tr>
               <tr><td><code>test_rejects_inline_segment_over_16_kib</code>, <code>test_rejects_inline_total_over_64_kib</code></td><td>Decoded-byte hard limits apply before allocation/scheduling, independent of base64 size.</td></tr>
               <tr><td><code>test_zero_length_object_accepts_only_empty_plan</code></td><td>No source call and no non-empty segment.</td></tr>
-              <tr><td><code>test_plan_digest_is_stable_for_canonical_equivalent_input</code></td><td>Map ordering cannot change digest identity.</td></tr>
-              <tr><td><code>test_plan_digest_uses_rfc8785_sha256_and_excludes_self_and_deadlines</code></td><td>It covers descriptor expiration and all segment semantics but remains an instruction digest, not required output digest.</td></tr>
-              <tr><td><code>test_assembly_plan_create_freezes_segments_and_computes_digest</code></td><td>Provider authors can construct a valid plan without implementing canonicalization themselves.</td></tr>
-              <tr><td><code>test_plan_digest_changes_when_semantic_field_changes</code></td><td>Descriptor generation/expiration, union kind, range, alias, parameters, revision, digest, or inline bytes change it.</td></tr>
+              <tr><td><code>test_assembly_plan_create_accepts_direct_public_models</code></td><td>Provider authors do not need portable-list encoding or special JSON wrapper classes.</td></tr>
             </tbody>
           </table>
         </div>
 
-        <h3>14.2 Provider contract, replacement resolution, and static-provider behavior</h3>
+        <h3>13.2 Provider contract, replacement resolution, and static-provider behavior</h3>
         <p>
-          Metadata-bearing complete-plan, deadline, concurrency, and public-error cases form the reusable provider suite.
-          Expiration/replacement/cache cases are MSC client tests, while static-provider and list-store cases target the
-          MSC-supplied implementation.
+          Metadata-bearing complete-plan, deadline, and public-error cases form the reusable provider suite.
+          Expiration and replacement cases are MSC client tests, while static-provider cases target the MSC-supplied implementation.
         </p>
         <div class="table-wrap">
           <table>
             <thead><tr><th>Test</th><th>Primary assertion</th></tr></thead>
             <tbody>
               <tr><td><code>test_provider_get_plan_returns_metadata_and_complete_exact_plan</code></td><td>One call returns an <code>AssemblyPlan</code> with an embedded metadata-only descriptor, mandatory future expiration, exact v1 result semantics, and no executable byte methods.</td></tr>
-              <tr><td><code>test_provider_get_plan_must_echo_exact_reference_and_requested_generation</code></td><td>A substituted reference or silent pinned-generation fall-forward is rejected before source calls; latest is allowed only when generation was None.</td></tr>
+              <tr><td><code>test_provider_get_plan_must_echo_exact_reference_and_requested_generation</code></td><td>A substituted reference or silent requested-generation fall-forward is rejected before source calls; latest is allowed only when generation was None.</td></tr>
               <tr><td><code>test_resolve_invokes_get_plan_once_and_no_descriptor_spi</code></td><td>The public provider contract has one resolution method and never performs a preliminary metadata lookup.</td></tr>
               <tr><td><code>test_provider_plan_is_complete_object_not_transport_page</code></td><td>Segments globally cover <code>[0, descriptor.size)</code> even when caller later reads a small range.</td></tr>
-              <tr><td><code>test_expired_view_does_not_fall_forward_or_auto_resolve</code></td><td>Raises <code>AssemblyExpiredError</code>; under the proposed v1 policy the provider is not asked for latest implicitly.</td></tr>
-              <tr><td><code>test_second_resolve_returns_distinct_view_for_replacement_generation</code></td><td>The returned view has the later plan's generation and expiration; the old view retains its descriptor, validated plan, capabilities, and frozen routing.</td></tr>
+              <tr><td><code>test_expired_view_does_not_fall_forward_or_auto_resolve</code></td><td>Raises <code>AssemblyExpiredError</code>; under the v1 policy the provider is not asked for latest implicitly.</td></tr>
+              <tr><td><code>test_second_resolve_returns_distinct_view_for_replacement_generation</code></td><td>The returned view has the later plan's generation and expiration; the old view retains its descriptor, validated plan, and frozen routing.</td></tr>
               <tr><td><code>test_replacement_resolve_failure_never_mutates_or_revives_old_view</code></td><td>Failure never extends expiration, changes routing, or reopens closed state; an independently still-valid old view remains usable.</td></tr>
-              <tr><td><code>test_public_capabilities_have_no_refresh_member</code></td><td>Provider and client expose no separate refresh method or capability.</td></tr>
-              <tr><td><code>test_provider_instruction_cache_is_scoped_to_concrete_provider_instance</code></td><td>No provider revision is required in metadata and instructions are never reused across provider instances.</td></tr>
-              <tr><td><code>test_provider_supports_concurrent_get_plan</code></td><td>The required provider method is thread-safe without an undeclared capability.</td></tr>
+              <tr><td><code>test_client_serializes_calls_to_provider</code></td><td>Provider authors have no hidden concurrency requirement; concurrent client operations do not overlap calls to one provider instance.</td></tr>
               <tr><td><code>test_provider_honors_expired_monotonic_deadline_without_backend_call</code></td><td>Retries cannot outlive the AssemblyClient operation budget.</td></tr>
-              <tr><td><code>test_provider_exact_public_exception_contract</code></td><td>Not-found, unavailable generation, auth, exhausted retryable backend, malformed output, unsupported capability, unexpected exception, and deadline each map to the frozen hierarchy with no fallback.</td></tr>
-              <tr><td><code>test_provider_unexpected_error_uses_fresh_sanitized_cause_without_original_context</code></td><td>Only the bounded safe type token is reachable; backend text/reference and the original object are absent from cause, context, args, attributes, repr, and traceback.</td></tr>
-              <tr><td><code>test_provider_close_is_idempotent</code></td><td>Second close has no side effect or error.</td></tr>
-              <tr><td><code>test_static_provider_decodes_batches_and_exact_lookup_matches_traversal</code></td><td>Static provider is the concrete-list surface and never executes browse pages.</td></tr>
-              <tr><td><code>test_static_provider_maps_list_id_to_generation_and_preserves_expiration</code></td><td>Every descriptor returned from one static snapshot uses that snapshot's <code>list_id</code> as <code>generation</code> and its exact <code>expires_at</code>; lookup and traversal agree.</td></tr>
-              <tr><td><code>test_static_from_batches_stops_at_aggregate_in_memory_limit</code></td><td>A one-shot iterator cannot accumulate more objects/segments/encoded bytes than configured.</td></tr>
-              <tr><td><code>test_assembly_list_store_get_and_iter_objects_share_one_snapshot</code></td><td>Lookup/traversal are replayable, stable, and return only complete definitions from the declared validated snapshot.</td></tr>
-              <tr><td><code>test_static_provider_revalidates_store_result_before_execution</code></td><td>A faulty store cannot bypass canonical model, expiration, alias, or global-length checks.</td></tr>
-              <tr><td><code>test_static_provider_close_store_flag_controls_store_ownership</code></td><td>Borrowed and owned stores follow the explicit lifecycle contract.</td></tr>
-              <tr><td><code>test_browse_index_cursor_is_stable_and_not_executable</code></td><td>Optional metadata pages do not mix snapshots and cannot be passed as an AssemblyPlan.</td></tr>
+              <tr><td><code>test_provider_exact_public_exception_contract</code></td><td>Not-found, unavailable generation, auth, exhausted retryable backend, malformed output, unexpected exception, and deadline each map to the stable hierarchy with no fallback.</td></tr>
+              <tr><td><code>test_provider_unexpected_error_is_redacted</code></td><td>The public error contains only a safe cause classification and exposes no backend message, reference, or credential.</td></tr>
+              <tr><td><code>test_static_provider_decodes_batches_and_exact_lookup</code></td><td>Static provider resolves exact references from the complete validated batch set.</td></tr>
+              <tr><td><code>test_static_provider_maps_list_id_to_generation_and_preserves_expiration</code></td><td>Every exact lookup from one batch set uses its <code>list_id</code> as <code>generation</code> and its exact <code>expires_at</code>.</td></tr>
+              <tr><td><code>test_static_from_batches_stops_at_private_aggregate_limit</code></td><td>A one-shot iterator cannot exceed private object, segment, or encoded-byte safeguards.</td></tr>
             </tbody>
           </table>
         </div>
 
-        <h3>14.3 Validation and limits</h3>
+        <h3>13.3 Validation and limits</h3>
         <div class="table-wrap">
           <table>
             <thead><tr><th>Tests</th><th>Required assertion</th></tr></thead>
@@ -2063,43 +1578,31 @@ multi-storage-client-docs/examples/
               <tr><td><code>test_rejects_inline_segment_length_data_mismatch</code>, <code>test_nonempty_object_rejects_zero_length_segment</code></td><td>Inline length equals decoded byte length and every segment of a non-empty object is positive; neither invariant can be hidden by a valid global sum.</td></tr>
               <tr><td><code>test_rejects_negative_numbers</code>, <code>test_rejects_json_safe_integer_overflow</code>, <code>test_rejects_object_byte_range_overflow</code></td><td>No cross-language rounding, OverflowError/MemoryError leakage, or allocation before rejection.</td></tr>
               <tr><td><code>test_rejects_descriptor_echo_mismatch</code>, <code>test_rejects_generation_or_expiration_echo_mismatch</code></td><td>Provider contract violation before binding lookup.</td></tr>
-              <tr><td><code>test_rejects_plan_digest_mismatch</code></td><td>Provider-supplied digest is recomputed; no cache entry or source call.</td></tr>
               <tr><td><code>test_rejects_unknown_object_or_service_alias</code>, <code>test_freezes_local_binding_objects_before_io</code></td><td>Plan cannot construct an authority; the view keeps the exact locally supplied objects even if the caller later mutates the input mappings.</td></tr>
-              <tr><td><code>test_expiration_only_accepts_missing_selectors_validators_revisions_and_checksums</code></td><td>Optional identity fields are genuinely optional under the default policy.</td></tr>
-              <tr><td><code>test_identity_only_validator_or_operation_revision_does_not_claim_enforcement</code></td><td>It may identify an operation but cannot enable stable-byte caching or snapshot guarantees.</td></tr>
-              <tr><td><code>test_snapshot_pinned_rejects_unenforceable_object_selector_or_validator</code>, <code>test_snapshot_pinned_rejects_unenforceable_service_revision</code></td><td>Strict opt-in fails before I/O; no HEAD/read/HEAD substitution.</td></tr>
-              <tr><td><code>test_snapshot_pinned_accepts_verified_complete_checksum_for_object</code></td><td>The client-only initial binding accepts snapshot-pinned object bytes only after the complete segment checksum is verified; no unapproved validator or policy hook is required.</td></tr>
-              <tr><td><code>test_any_supplied_checksum_forces_bounded_complete_segment_verification_before_partial_slice</code></td><td>The rule applies in both consistency modes and even alongside an enforcing revision; a complete checksum is never compared to a partial body, and over-limit verification fails before I/O.</td></tr>
-              <tr><td><code>test_rejects_service_range_mode_not_supported_by_fetcher</code></td><td>Support is determined only by the injected fetcher's advertised SPI capability; rejection performs zero service calls.</td></tr>
               <tr><td><code>test_enforces_max_segments</code>, <code>test_enforces_max_plan_bytes</code>, <code>test_enforces_max_logical_size</code>, <code>test_enforces_max_read_bytes</code>, <code>test_enforces_inline_hard_limits</code></td><td>Correct limit name/value and zero downstream calls.</td></tr>
-              <tr><td><code>test_plan_size_streaming_counter_accepts_exact_limit_and_aborts_at_one_over</code>, <code>test_huge_direct_model_fails_cheap_structure_before_full_canonical_encoding</code></td><td>No second complete plan encoding/allocation; direct and decoded paths share exact canonical size semantics.</td></tr>
-              <tr><td><code>test_config_integer_and_timeout_hard_bounds_accept_exact_and_reject_one_over</code></td><td>Strict integers stop at <code>2**53-1</code>, seconds stop at 604800, and invalid values fail before allocation or dependency I/O.</td></tr>
-              <tr><td><code>test_client_wide_budget_relationships_accept_exact_boundaries_and_reject_one_over</code></td><td>Twice the read/window maxima fit output total; per-operation staging memory/disk fit their totals; object chunks fit read/window/in-flight/staging-memory bounds.</td></tr>
+              <tr><td><code>test_plan_size_counter_accepts_exact_private_limit_and_aborts_at_one_over</code></td><td>No second complete plan encoding or large allocation is constructed.</td></tr>
+              <tr><td><code>test_constructor_validates_only_concurrency_and_timeout</code></td><td>Invalid values fail before dependency I/O and no public config or limit object is required.</td></tr>
               <tr><td><code>test_plan_rejects_individually_unstageable_full_result_before_execution</code></td><td>A stage above its per-result or aggregate client cap yields a typed limit error with no service/object call; a user fetcher may enforce an additional private cap.</td></tr>
-              <tr><td><code>test_client_resolve_exposes_no_view_before_complete_plan_validation</code></td><td><code>AssemblyClient.resolve</code> performs one <code>get_plan(request)</code>, exact-generation/global validation, binding freeze, and capability computation before exposing a view; any failure returns no partial view and performs no object or service byte I/O.</td></tr>
-              <tr><td><code>test_plan_validation_failure_performs_no_byte_io</code></td><td>Malformed global length, digest, alias, mode, or consistency fails before any StorageClient or ServiceSegmentFetcher byte call.</td></tr>
-              <tr><td><code>test_valid_v1_view_always_advertises_range_read_and_forward_open</code></td><td>Successfully resolved v1 plans have both flags true; a synthetic future false capability rejects the operation before I/O.</td></tr>
-              <tr><td><code>test_rejects_resource_or_reference_over_length_limit</code></td><td>No unbounded logging/cache key or URL creation.</td></tr>
-              <tr><td><code>test_unassigned_identity_metadata_strings_accept_exact_utf8_cap_and_reject_one_over_or_lone_surrogate</code></td><td>Decoded and direct/live provider models fail before cache, digest, alias lookup, or external I/O for every covered field family.</td></tr>
+              <tr><td><code>test_client_resolve_exposes_no_view_before_complete_plan_validation</code></td><td><code>AssemblyClient.resolve</code> performs one <code>get_plan(request)</code>, exact-generation/global validation, and binding freeze before exposing a view; failure returns no partial view and performs no byte I/O.</td></tr>
+              <tr><td><code>test_plan_validation_failure_performs_no_byte_io</code></td><td>Malformed global length, alias, or range mode fails before any StorageClient or ServiceSegmentFetcher byte call.</td></tr>
+              <tr><td><code>test_rejects_resource_or_reference_over_length_limit</code></td><td>No unbounded logging or downstream request creation.</td></tr>
             </tbody>
           </table>
         </div>
 
-        <h3>14.4 Planner and property tests</h3>
+        <h3>13.4 Planner and property tests</h3>
         <ul>
           <li><code>test_plans_range_inside_one_segment</code></li>
           <li><code>test_plans_range_across_multiple_segments</code></li>
           <li><code>test_maps_first_and_last_partial_segments</code></li>
           <li><code>test_handles_exact_segment_boundaries_last_byte_and_eof</code></li>
           <li><code>test_intersects_object_inline_and_stable_service_segments</code></li>
-          <li><code>test_preserves_destination_offsets_and_optional_selectors_validators_and_revisions</code></li>
-          <li><code>test_checksum_object_operation_uses_complete_fetch_range_and_selected_range_in_fetch</code> — <code>fetch_range</code> is the complete source segment required for digest verification, while <code>selected_range_in_fetch</code> identifies only the caller-requested slice copied from the verified result at the correct destination offset.</li>
-          <li><code>test_unchecked_object_operation_fetches_only_selected_source_intersection</code> — without a checksum, <code>fetch_range</code> is the exact caller intersection and <code>selected_range_in_fetch</code> covers that complete fetched result.</li>
+          <li><code>test_preserves_destination_offsets</code></li>
+          <li><code>test_object_operation_fetches_only_selected_source_intersection</code></li>
           <li><code>test_adjacent_object_segments_remain_distinct_public_reads</code></li>
-          <li><code>test_never_coalesces_across_segment_checksum_or_identity_boundaries</code></li>
           <li><code>test_whole_result_same_ordinal_has_one_logical_submission_per_operation</code></li>
           <li><code>test_two_equal_valued_whole_result_segments_at_distinct_ordinals_are_not_deduplicated</code></li>
-          <li><code>test_same_whole_result_ordinal_reuses_stage_across_reader_seeks_and_materialization_windows</code></li>
+          <li><code>test_same_whole_result_ordinal_reuses_stage_within_materialization</code></li>
           <li><code>test_valid_partition_reconstructs_reference_slice</code> — random payload, valid partition, and read range equal direct slicing.</li>
           <li><code>test_planned_output_is_covered_exactly_once</code> — no destination gap or overlap.</li>
           <li><code>test_split_read_equals_unsplit_read</code> — <code>read(a,n) == read(a,k) + read(a+k,n-k)</code>.</li>
@@ -2108,40 +1611,32 @@ multi-storage-client-docs/examples/
           <li><code>test_malformed_numeric_input_always_raises_domain_error</code>.</li>
         </ul>
 
-        <h3>14.5 Bindings, direct object reads, and the service-fetcher boundary</h3>
+        <h3>13.5 Bindings, direct object reads, and the service-fetcher boundary</h3>
         <p>
-          Binding tests use only the existing public <code>StorageClient</code> contract. StorageClients are always borrowed;
-          optional Assembly ownership applies only to the plan provider and service fetchers.
+          Binding tests use only the existing public <code>StorageClient</code> contract. All injected dependencies are borrowed
+          and remain application-owned.
         </p>
         <ul>
           <li><code>test_binding_registries_copy_mappings_and_reject_late_mutation</code></li>
           <li><code>test_binding_registries_reject_empty_or_malformed_alias_names</code></li>
-          <li><code>test_dependency_object_identity_cannot_be_reused_across_provider_fetcher_or_client_roles</code></li>
           <li><code>test_plan_schema_has_no_unrestricted_endpoint_profile_credentials_or_fetcher_implementation_fields</code></li>
           <li><code>test_object_source_binding_minimum_constructor_requires_only_client</code></li>
-          <li><code>test_default_client_close_borrows_provider_storage_clients_and_fetchers</code></li>
-          <li><code>test_close_dependencies_closes_provider_and_distinct_fetchers_once</code></li>
-          <li><code>test_close_dependencies_never_closes_storage_clients</code></li>
-          <li><code>test_close_attempts_all_owned_provider_and_fetcher_dependencies_then_raises_redacted_assembly_close_error</code></li>
-          <li><code>test_close_failure_records_are_deduplicated_sorted_and_publicly_typed</code></li>
-          <li><code>test_storage_client_calls_are_serialized_across_aliases_and_views</code></li>
-          <li><code>test_non_thread_safe_service_fetcher_serializes_calls_and_opt_in_allows_concurrency</code></li>
+          <li><code>test_client_close_never_closes_injected_provider_fetchers_or_storage_clients</code></li>
+          <li><code>test_independent_storage_client_reads_may_overlap_within_global_budgets</code></li>
+          <li><code>test_service_fetcher_calls_are_always_serialized_per_instance</code></li>
           <li><code>test_object_segment_uses_only_public_storage_client_contract</code></li>
           <li><code>test_client_only_binding_uses_exact_configured_storage_client_authority</code> — a plan selects a local alias and resource only; it cannot replace the bound client, endpoint, profile, credentials, root, or provider.</li>
           <li><code>test_plan_resource_is_sent_only_to_selected_binding</code> — only the client selected by <code>source_id</code> receives the resource and all other clients record zero calls.</li>
           <li><code>test_object_chunks_map_exact_source_offsets_and_sizes_without_gap_or_overlap</code></li>
           <li><code>test_object_interval_below_at_and_above_chunk_limit_uses_exact_consecutive_public_reads</code></li>
-          <li><code>test_checksum_object_partial_access_chunks_and_stages_complete_segment_before_slice</code></li>
           <li><code>test_object_chunks_never_cross_segment_boundaries_and_request_count_matches_formula</code></li>
-          <li><code>test_client_wide_inflight_object_byte_reservations_bound_concurrent_callers_and_release_on_failure</code></li>
-          <li><code>test_object_read_maps_file_not_found_permission_retryable_and_source_errors_with_sanitized_causes</code></li>
-          <li><code>test_object_read_runtime_error_uses_generic_source_read_error_without_message_or_sdk_cause_parsing</code></li>
+          <li><code>test_object_read_maps_typed_storage_failures_to_source_errors</code></li>
+          <li><code>test_object_read_unexpected_error_is_redacted</code></li>
           <li><code>test_object_read_does_not_wrap_base_exception</code></li>
-          <li><code>test_object_read_full_formatted_traceback_redacts_resource_provider_message_and_secret_nested_cause</code></li>
+          <li><code>test_object_read_errors_redact_resource_backend_message_and_secret</code></li>
           <li><code>test_object_read_rejects_non_bytes_short_and_oversized_results_with_exact_classes</code></li>
           <li><code>test_object_read_checks_deadline_and_internal_cancellation_before_and_after_sync_call</code> — Assembly does not claim to preempt a synchronous <code>StorageClient.read</code>; a late result is discarded and the typed deadline/cancellation outcome takes precedence over result validation.</li>
-          <li><code>test_expiration_only_object_read_does_not_require_info_or_revision</code></li>
-          <li><code>test_object_source_binding_does_not_claim_atomic_selector_or_validator_enforcement</code></li>
+          <li><code>test_object_read_does_not_require_metadata_lookup</code></li>
           <li><code>test_private_storage_provider_is_never_accessed</code></li>
         </ul>
 
@@ -2155,86 +1650,68 @@ multi-storage-client-docs/examples/
           <li><code>test_fetcher_confines_operation_and_parameters_under_local_policy</code></li>
           <li><code>test_fetcher_receives_exact_deadline_cancellation_and_chunk_limit_context</code></li>
           <li><code>test_fetcher_range_modes_are_exact_immutable_and_captured_before_view_exposure</code></li>
-          <li><code>test_optional_fetcher_capabilities_are_immutable_for_injected_lifetime</code> — optional revision-kind and thread-safety declarations cannot change after injection.</li>
           <li><code>test_service_fetcher_declared_range_modes_match_observed_behavior</code></li>
           <li><code>test_stable_subranges_returns_exact_first_middle_and_last_ranges</code></li>
           <li><code>test_stable_subranges_denotes_one_stable_logical_string_per_operation</code></li>
           <li><code>test_whole_result_fetcher_receives_no_requested_range</code></li>
           <li><code>test_fetcher_result_must_be_closeable_before_publish</code> — a non-closeable result raises <code>ServiceProtocolError</code> and publishes no bytes.</li>
           <li><code>test_whole_result_length_mismatch_fails_before_slice_publish</code></li>
-          <li><code>test_service_optional_revision_absent_under_expiration_only</code></li>
-          <li><code>test_snapshot_revision_kinds_defaults_empty_and_is_immutable</code></li>
-          <li><code>test_enforced_service_revision_requires_advertised_snapshot_revision_kind</code></li>
-          <li><code>test_verified_complete_service_checksum_qualifies_without_operation_revision</code></li>
-          <li><code>test_service_enforced_revision_or_digest_mismatch_fails_closed</code></li>
-          <li><code>test_service_checksum_mismatch_raises_service_integrity_error_before_publish</code></li>
-          <li><code>test_retry_safety_never_pre_response_reset_is_not_retried_by_core</code> — the fetcher is invoked once and the typed fixture failure is surfaced even before any chunk is yielded.</li>
-          <li><code>test_retry_safety_never_partial_stream_failure_is_not_retried_by_core</code> — the fetcher is invoked once and the current call publishes no bytes.</li>
-          <li><code>test_retry_safety_safe_does_not_add_outer_core_retry</code> — MSC invokes <code>fetch</code> once; the test makes no claim about private work inside the user implementation.</li>
+          <li><code>test_core_invokes_fetch_once_on_pre_response_or_partial_stream_failure</code> — MSC adds no outer retry and publishes no bytes from the failed call.</li>
         </ul>
 
         <p>MSC execution-engine boundary tests, which are not part of the reusable adopter suite, include:</p>
         <ul>
-          <li><code>test_stream_cleanup_attempts_all_in_reverse_order_and_primary_execution_error_wins</code></li>
+          <li><code>test_stream_cleanup_attempts_all_resources_and_primary_execution_error_wins</code></li>
           <li><code>test_sole_stream_close_failure_becomes_sanitized_service_fetch_error_and_discards_output</code></li>
-          <li><code>test_result_stream_and_private_stage_cleanup_failures_select_service_fetch_error_and_retain_stage_orphan</code></li>
+          <li><code>test_stream_and_stage_cleanup_failure_discards_private_output</code></li>
           <li><code>test_custom_stream_rejects_nonbytes_empty_and_over_context_chunk_limit_before_copy_or_stage</code></li>
           <li><code>test_service_errors_and_repr_redact_parameters_and_credentials</code></li>
-          <li><code>test_public_error_constructors_reject_arbitrary_messages_and_keep_args_str_repr_canonical</code></li>
-          <li><code>test_custom_typed_error_is_normalized_and_subclass_or_malformed_fields_cannot_bypass_redaction</code></li>
-          <li><code>test_unexpected_custom_fetcher_exception_maps_to_service_fetch_error_without_original_cause_or_context</code></li>
-          <li><code>test_redaction_walks_cause_context_args_attributes_and_full_formatted_traceback</code></li>
+          <li><code>test_public_errors_expose_only_documented_safe_fields</code></li>
+          <li><code>test_unexpected_custom_fetcher_exception_maps_to_redacted_service_fetch_error</code></li>
           <li><code>test_service_deadline_internal_cancellation_and_base_exception_are_not_wrapped</code></li>
         </ul>
 
-        <h3>14.6 Executor, client, view, and reader</h3>
+        <h3>13.6 Executor, client, view, and reader</h3>
         <div class="table-wrap">
           <table>
             <thead><tr><th>Area</th><th>Tests and key assertions</th></tr></thead>
             <tbody>
               <tr><td>Ordering</td><td><code>test_reassembles_out_of_order_completions_in_logical_order</code>; result equals reference bytes.</td></tr>
-              <tr><td>Concurrency</td><td><code>test_never_exceeds_client_wide_concurrency_across_callers</code>; <code>test_independent_service_fetches_overlap_without_manual_batching</code>; <code>test_streaming_service_result_holds_permit_and_fetcher_lock_until_closed</code>; <code>test_object_chunk_memory_reservation_never_exceeds_client_wide_byte_budget</code>; <code>test_active_operation_slots_bound_one_shots_and_open_readers_and_release_on_all_exit_paths</code>.</td></tr>
-              <tr><td>Admission reentrancy</td><td><code>test_resolve_info_read_open_materialize_and_glob_do_not_reacquire_at_max_active_operations_one</code>; every convenience completes without self-deadlock and performs only one resolution/list-page sequence.</td></tr>
-              <tr><td>Admission wait</td><td><code>test_slot_wait_allocates_no_output_or_stage_and_observes_deadline_cancel_and_parent_close</code>; <code>test_slot_wait_time_is_followed_by_fresh_expiration_admission_check</code>.</td></tr>
-              <tr><td>Global byte budgets</td><td><code>test_output_total_bounds_concurrent_reads_and_materialization_windows_then_releases</code>; <code>test_staging_memory_and_disk_totals_bound_concurrent_callers_and_retained_readers</code>; <code>test_multi_budget_reservation_is_all_or_none_and_cannot_deadlock</code>.</td></tr>
-              <tr><td>Atomicity</td><td><code>test_short_long_digest_or_enforced_revision_failure_returns_no_bytes_from_current_call</code>; <code>test_reader_prefix_may_be_observed_before_later_call_fails_and_poison_closes_reader</code>; <code>test_reader_read_all_late_segment_failure_returns_nothing_and_commits_cursor_once</code>; cursor/readinto buffer is unchanged for the failed public call and its private output is not published.</td></tr>
-              <tr><td>Cancellation</td><td><code>test_first_terminal_error_signals_shared_token_attempts_every_cleanup_and_cancels_queued_reads</code>; successful cleanup removes the stage, injected cleanup failure follows orphan accounting, and cooperative user calls observe the operation deadline.</td></tr>
-              <tr><td>Retry</td><td><code>test_assembly_executor_never_retries_object_or_service_call</code>; both NEVER and SAFE fixtures observe exactly one core <code>fetch</code> invocation. Work internal to the user implementation is out of scope.</td></tr>
+              <tr><td>Concurrency</td><td><code>test_never_exceeds_client_wide_concurrency_across_callers</code>; <code>test_independent_fetchers_may_overlap</code>; <code>test_same_fetcher_instance_is_serialized</code>.</td></tr>
+              <tr><td>Atomicity</td><td><code>test_short_or_long_result_returns_no_bytes_from_current_call</code>; <code>test_reader_read_all_late_segment_failure_returns_nothing_and_commits_cursor_once</code>; cursor/readinto buffer is unchanged for the failed public call.</td></tr>
+              <tr><td>Cancellation</td><td><code>test_first_terminal_error_signals_shared_token_attempts_every_cleanup_and_cancels_queued_reads</code>; private output is discarded and cooperative user calls observe the operation deadline.</td></tr>
+              <tr><td>Retry</td><td><code>test_assembly_executor_never_retries_object_or_service_call</code>; the fetcher observes exactly one core invocation. Work internal to the user implementation is out of scope.</td></tr>
               <tr><td>Composition</td><td><code>test_object_inline_plan_accepts_empty_service_fetcher_registry</code>; <code>test_inline_only_plan_accepts_empty_object_and_service_registries</code>; <code>test_service_only_plan_accepts_empty_object_source_registry</code>; only aliases actually referenced by the complete plan are required.</td></tr>
-              <tr><td>Resolution</td><td><code>test_one_shot_read_calls_get_plan_once</code>; <code>test_info_calls_get_plan_once_without_byte_io</code>; <code>test_view_operations_reuse_frozen_plan_without_provider_calls</code>; <code>test_open_keeps_one_generation_across_seek_and_read</code>. After resolve, view operations never replan under the proposed v1 policy.</td></tr>
+              <tr><td>Resolution</td><td><code>test_resolve_calls_get_plan_once</code>; <code>test_second_resolve_calls_provider_again</code>; <code>test_view_operations_reuse_frozen_plan_without_provider_calls</code>; <code>test_open_keeps_one_generation_across_reads</code>.</td></tr>
               <tr><td>Segment-free I/O</td><td><code>test_inline_segment_emits_exact_bytes_without_object_or_service_io</code>; <code>test_zero_length_read_validates_complete_plan_then_performs_no_segment_io</code>.</td></tr>
-              <tr><td>Reader expiration</td><td><code>test_reader_opened_while_valid_reads_and_seeks_after_expiration_until_close</code>; <code>test_new_open_after_expiration_fails_before_plan_or_service_io</code>.</td></tr>
-              <tr><td>View/reader close</td><td><code>test_reader_survives_originating_view_close_until_reader_or_parent_close</code>; <code>test_reader_close_result_stream_failure_maps_to_service_fetch_error_but_still_releases_slot</code>; reader uses pinned capabilities/state, the view rejects new work, all cleanup is attempted, and parent close cancels both.</td></tr>
-              <tr><td>Reader service stage</td><td><code>test_reader_reuses_one_whole_result_stage_across_reads_and_seeks</code>; <code>test_seek_true_when_retained_stage_sum_equals_cap_and_false_at_cap_plus_one</code>; <code>test_forward_reader_releases_passed_stages_and_does_not_self_deadlock_when_sum_exceeds_cap</code>; <code>test_seekable_reader_retains_stages_without_replay</code>; stage/context close exactly once.</td></tr>
+              <tr><td>Reader expiration</td><td><code>test_reader_opened_while_valid_reads_forward_after_expiration_until_close</code>; <code>test_new_open_after_expiration_fails_before_byte_io</code>.</td></tr>
+              <tr><td>View/reader close</td><td><code>test_reader_survives_originating_view_close_until_reader_or_parent_close</code>; the view rejects new work, cleanup is attempted, and parent close cancels both.</td></tr>
+              <tr><td>Reader service stage</td><td><code>test_forward_reader_reuses_one_whole_result_stage_while_crossing_segment</code>; <code>test_forward_reader_releases_stage_after_segment</code>; stage and context close exactly once.</td></tr>
               <tr><td>Expiration</td><td><code>test_operation_rejects_when_clock_equals_expiration</code>; <code>test_operation_started_valid_may_finish_after_expiration</code>; the next operation fails with <code>AssemblyExpiredError</code>.</td></tr>
               <tr><td>Replacement resolution</td><td><code>test_second_resolve_returns_new_view_and_never_mutates_old_view</code>; <code>test_replacement_plan_has_its_own_generation_and_expiration</code>; <code>test_public_client_and_provider_have_no_refresh_method</code>.</td></tr>
               <tr><td>Reference shorthand</td><td><code>test_string_reference_normalizes_to_empty_namespace_key</code>; parameters remain explicit-only.</td></tr>
-              <tr><td>Browsing</td><td><code>test_list_requires_browse_index</code>, <code>test_cursor_is_bound_to_listing_request</code>, <code>test_browse_page_cannot_execute</code>; <code>test_list_page_size_zero_exact_max_and_one_over</code>; <code>test_list_cursor_utf8_exact_cap_one_over_and_lone_surrogate</code>; <code>test_provider_page_rejects_requested_plus_one_items_or_oversized_next_cursor_before_cache</code>; <code>test_glob_no_match_and_late_match_stop_at_exact_scan_budget_without_extra_provider_call</code>; <code>test_glob_result_budget_raises_before_yielding_one_over</code>; <code>test_glob_close_before_start_acquires_none_and_early_close_error_or_exhaustion_releases_slot_once</code>; <code>test_glob_context_manager_releases_slot_when_loop_breaks</code>.</td></tr>
               <tr><td>Views</td><td><code>test_assembly_view_metadata_returns_exact_resolved_descriptor</code>; <code>test_existing_view_never_switches_generation</code>; <code>test_closing_one_view_rejects_that_view_and_leaves_sibling_view_usable</code>; metadata remains control-plane-only and only a newly resolved view may observe a replacement generation.</td></tr>
               <tr><td>Read-only façade</td><td><code>test_assembly_view_exposes_no_write_delete_copy_sync_or_presign_operations</code>; reader writes and truncate raise <code>UnsupportedOperation</code>.</td></tr>
-              <tr><td>Consistency truthfulness</td><td><code>test_expiration_only_same_length_source_mutation_may_change_bytes_without_snapshot_claim</code>; two admitted operations may differ, the view remains <code>EXPIRATION_ONLY</code>, and stale mutable bytes are not reused.</td></tr>
-              <tr><td>Reader</td><td><code>test_reader_supports_seek_tell_readinto_and_eof</code>; <code>test_range_zero_at_eof_past_eof_crossing_eof_negative_and_overflow_boundaries</code>; <code>test_reader_overrides_read_and_readall_instead_of_rawio_looping_default</code>; seek past EOF is allowed, seek before zero fails, and writes/truncate raise <code>UnsupportedOperation</code>.</td></tr>
-              <tr><td>Lifecycle</td><td><code>test_client_close_is_idempotent_and_rejects_new_work</code>; <code>test_view_close_is_idempotent_and_does_not_close_parent_or_siblings</code>; <code>test_close_attempt_order_and_close_failure_order_are_deterministic</code>; <code>test_parent_close_retries_orphans_and_emits_one_leading_staging_failure_record</code>; <code>test_second_close_retries_only_remaining_orphans_without_reclosing_dependencies</code>.</td></tr>
+              <tr><td>Identity truthfulness</td><td><code>test_unversioned_same_length_source_mutation_may_change_bytes_without_snapshot_claim</code>; two admitted operations may differ, no dataset snapshot is claimed, and stale mutable bytes are not reused.</td></tr>
+              <tr><td>Reader</td><td><code>test_reader_is_forward_only_and_supports_tell_readinto_and_eof</code>; <code>test_reader_seekable_is_false_and_seek_is_unsupported</code>; <code>test_reader_overrides_read_and_readall</code>.</td></tr>
+              <tr><td>Lifecycle</td><td><code>test_client_close_is_idempotent_rejects_new_work_and_cleans_owned_resources</code>; <code>test_client_close_does_not_close_injected_dependencies</code>; <code>test_view_close_is_idempotent_and_does_not_close_parent_or_siblings</code>.</td></tr>
               <tr><td>Timeout</td><td><code>test_global_deadline_normalizes_provider_queue_object_service_and_staging_exhaustion</code>; while the global budget remains, an already typed provider/source/service domain error is preserved and internal cancellation remains distinct. The object-source case verifies pre/post-call checks and late-result discard, but does not assert a hard latency bound for an already-running synchronous <code>StorageClient.read</code>.</td></tr>
-              <tr><td>Complete-segment staging</td><td><code>test_whole_result_one_logical_submission_serves_multiple_intersections</code>; <code>test_checksum_complete_segment_stage_is_reused_across_reader_seeks_and_materialization_windows</code>; <code>test_small_whole_result_stages_in_memory</code>; <code>test_large_whole_result_stages_to_temp_file</code>; <code>test_complete_segment_memory_and_total_temp_limits_fail_closed</code>; <code>test_staging_create_write_flush_failures_map_to_redacted_staging_error</code>; <code>test_stage_close_and_unlink_attempt_all_in_reverse_order</code>; <code>test_primary_execution_error_wins_without_cleanup_chain</code>; <code>test_sole_private_stage_cleanup_failure_discards_success_and_raises_staging_error</code>; <code>test_file_stage_reservation_requires_both_handle_close_and_path_unlink</code>; <code>test_create_failure_before_artifact_releases_reservation_immediately</code>; <code>test_failed_artifact_reservation_remains_charged_until_cleanup_retry</code>; <code>test_reader_close_failure_still_closes_reader_releases_slot_and_transfers_orphan_charge</code>.</td></tr>
-              <tr><td>Cache</td><td><code>test_descriptor_and_plan_cache_hard_expire_with_descriptor</code>; <code>test_cache_ttl_never_extends_descriptor_expiration</code>; <code>test_expiration_only_does_not_cache_mutable_source_bytes</code>; <code>test_failed_or_expired_plan_is_never_reused</code>.</td></tr>
+              <tr><td>Whole-result staging</td><td><code>test_whole_result_one_core_submission_serves_requested_slice</code>; <code>test_small_result_stages_in_memory</code>; <code>test_large_result_stages_to_temp_file</code>; <code>test_private_stage_limit_fails_before_fetch</code>; <code>test_stage_resources_release_on_success_failure_and_close</code>.</td></tr>
             </tbody>
           </table>
         </div>
 
-        <h3>14.7 Materialization</h3>
+        <h3>13.7 Materialization</h3>
         <ul>
-          <li><code>test_materialize_uses_exact_bounded_windows_and_peak_output_buffer_never_exceeds_config</code></li>
+          <li><code>test_materialize_uses_exact_private_bounded_windows</code></li>
           <li><code>test_materialize_atomically_replaces_destination_when_allowed</code></li>
           <li><code>test_materialize_refuses_existing_destination_by_default</code></li>
           <li><code>test_materialize_no_replace_loses_concurrent_destination_race_without_overwriting_winner</code></li>
           <li><code>test_materialize_unsupported_atomic_no_replace_fails_precommit_and_preserves_destination</code></li>
           <li><code>test_materialize_failure_preserves_existing_destination</code></li>
           <li><code>test_materialize_failure_removes_staging_file</code></li>
-          <li><code>test_materialize_fsyncs_file_and_parent_directory_when_enabled</code></li>
           <li><code>test_postcommit_staging_unlink_failure_reports_cleanup_committed_true_and_destination_visible</code></li>
-          <li><code>test_postcommit_directory_fsync_failure_reports_directory_fsync_committed_true_and_indeterminate_durability</code></li>
-          <li><code>test_precommit_create_write_file_fsync_or_commit_failure_reports_committed_false</code></li>
+          <li><code>test_precommit_create_write_or_commit_failure_reports_committed_false</code></li>
           <li><code>test_materialize_private_file_is_exclusive_no_follow_and_mode_0600</code></li>
           <li><code>test_materialize_published_inode_retains_effective_mode_0600</code></li>
           <li><code>test_materialization_started_valid_may_commit_after_descriptor_expiration</code></li>
@@ -2247,7 +1724,7 @@ multi-storage-client-docs/examples/
           with the minimal application-supplied in-process fetcher and contains no tests for hypothetical adapter modules.
         </div>
 
-        <h3>14.8 In-process acceptance and compatibility</h3>
+        <h3>13.8 In-process acceptance and compatibility</h3>
         <p>
           The format-shaped fixtures below are non-blocking examples. The blocking core acceptance gate is the
           format-neutral mixed-union reconstruction and routing behavior; MSC does not parse or interpret those formats.
@@ -2261,7 +1738,6 @@ multi-storage-client-docs/examples/
           <li><code>test_object_service_and_inline_segments_reconstruct_complete_object</code></li>
           <li><code>test_partial_range_touching_all_three_segment_kinds_returns_exact_slice</code></li>
           <li><code>test_range_capable_and_whole_result_services_both_pass_acceptance_flow</code></li>
-          <li><code>test_enforced_service_revision_changes_between_plan_and_read_fail_atomically</code></li>
           <li><code>test_existing_open_handle_stays_on_original_generation_and_continues_after_expiration_until_close</code></li>
           <li><code>test_second_resolve_after_expiration_creates_replacement_generation_and_new_bytes</code></li>
           <li><code>test_plan_cannot_select_fetcher_implementation_endpoint_or_credentials</code></li>
@@ -2278,22 +1754,21 @@ multi-storage-client-docs/examples/
       </section>
 
       <section id="performance">
-        <h2>15. Performance and benchmark plan</h2>
+        <h2>14. Performance and benchmark plan</h2>
         <h3>Scenario matrix</h3>
         <div class="table-wrap">
           <table>
             <thead><tr><th>Dimension</th><th>Values</th></tr></thead>
             <tbody>
-              <tr><td>Objects per list</td><td>1, 1K, 100K, and the approved product maximum</td></tr>
-              <tr><td>Segments / encoded plan</td><td>1, 8, 64, 512, 4,096, 16,384, configured 100K boundary, and the approved product segment/encoded-byte maxima</td></tr>
+              <tr><td>Objects per batch set</td><td>1, 1K, and the private hard boundary</td></tr>
+              <tr><td>Segments / encoded plan</td><td>1, 8, 64, 512, and the private hard boundaries</td></tr>
               <tr><td>Segment kind</td><td>object-only, service-only, inline-heavy at legal limit, mixed union</td></tr>
               <tr><td>Logical read</td><td>4 KiB, 1 MiB, 64 MiB</td></tr>
               <tr><td>Binding</td><td>StorageClient local, stable-subrange service, whole-result service, mixed</td></tr>
-              <tr><td>Service staging</td><td>below/at/above memory threshold; temp-file result at approved maximum; hard-limit rejection</td></tr>
+              <tr><td>Service staging</td><td>small in-memory result, large temp-file result, and hard-limit rejection</td></tr>
               <tr><td>Concurrency</td><td>1, 4, 16, 64 and multiple concurrent callers</td></tr>
-              <tr><td>Segment adjacency / object chunking</td><td>same binding, different binding, checksum/identity boundary, mixed, and intervals below/at/above object chunk size; v1 never crosses a segment boundary</td></tr>
-              <tr><td>List workload</td><td>full traversal, exact-name hit/miss, sequential/random lookup, browse index page</td></tr>
-              <tr><td>Cache state</td><td>cold descriptor/plan, warm plan, just-before/at/after expiration, replacement descriptor generation</td></tr>
+              <tr><td>Segment adjacency / object chunking</td><td>same binding, different binding, mixed, and intervals below/at/above the private object chunk size; v1 never crosses a segment boundary</td></tr>
+              <tr><td>Batch workload</td><td>decode, exact-reference hit/miss, sequential and random lookup</td></tr>
               <tr><td>Service scheduling</td><td>single request and 8, 64, or 512 independently ready segment requests dispatched through the single-request SPI</td></tr>
             </tbody>
           </table>
@@ -2303,95 +1778,82 @@ multi-storage-client-docs/examples/
         <ul>
           <li>Planner median/p95 and microseconds per segment.</li>
           <li>List decode/traversal objects per second, exact-name lookup median/p95, time to first object, encoded bytes, and index build time.</li>
-          <li>Peak RSS for streaming codec traversal, scan-backed store, exact-name store, and browse pages as object count grows.</li>
+          <li>Peak RSS for streaming codec traversal and the bounded static provider as object count grows.</li>
           <li>End-to-end median/p95, throughput, time to first internal chunk, and completion latency.</li>
           <li>Core calls to <code>ServiceSegmentFetcher.fetch</code>, result bytes, and source-byte amplification; fetcher-internal retries and transport metrics are fetcher-owned.</li>
-          <li>Peak RSS, output size, maximum in-flight response bytes, and plan cache footprint.</li>
+          <li>Peak RSS, output size, and maximum in-flight response bytes.</li>
           <li>Complete-segment peak memory/temp-file bytes, stage count, core fetch submissions, and read amplification.</li>
-          <li>High-water marks and wait time for active operations, output memory, stage memory/disk, and in-flight object-byte budgets across concurrent callers and retained readers.</li>
           <li>Cancellation latency and active tasks/connections after failure.</li>
         </ul>
 
-        <h3>Initial performance gates</h3>
+        <h3>Initial performance checks</h3>
         <ul>
-          <li><strong>Blocking product-input gate:</strong> before implementation acceptance, product owners approve the maximum object count, maximum segments or encoded list bytes, exact lookup/traversal mix, and process memory envelope. Gate 0 cannot close with any value marked TBD.</li>
-          <li><code>test_large_list_full_traversal_stays_below_approved_latency_and_rss_limits</code> passes at the approved maximum using numeric Gate 0 thresholds.</li>
-          <li><code>test_large_list_exact_lookup_hit_and_miss_stay_below_approved_latency_limits</code> passes with the selected <code>AssemblyListStore</code> implementation.</li>
-          <li><code>test_large_list_batch_decode_peak_rss_stays_below_approved_bytes</code> proves batches do not accumulate accidentally against a concrete byte limit.</li>
-          <li><code>test_approved_max_segments_and_encoded_plan_bytes_meet_latency_and_memory_envelope</code> passes at both exact approved boundaries and rejects one over before I/O.</li>
-          <li>Gate 0 records the permitted planner time ratio between the approved <code>N</code> and <code>2N</code> segment cases; the benchmark fails when that numeric ratio is exceeded.</li>
+          <li><code>test_large_batch_set_records_decode_latency_and_peak_rss</code> records a reproducible baseline below the private hard boundary.</li>
+          <li><code>test_static_provider_exact_lookup_hit_and_miss_record_latency</code> exercises the bounded in-memory static provider.</li>
+          <li><code>test_private_segment_and_plan_limits_reject_one_over</code> proves internal safeguards fail before I/O.</li>
+          <li>The benchmark records planner growth between representative <code>N</code> and <code>2N</code> segment cases so regressions can be reviewed without a product-level approval threshold.</li>
           <li>Observed concurrent source reads never exceed the configured client-wide ceiling.</li>
-          <li>Observed top-level operations, output-memory reservations, stage-memory/stage-disk reservations, and in-flight object bytes never exceed their client-wide limits under concurrent read/open/materialize/glob workloads; <code>max_active_operations=1</code> conveniences complete without nested-admission deadlock.</li>
-          <li>Object request count equals the sum of <code>ceil(selected_source_bytes / max_object_read_chunk_bytes)</code> per logical object operation: caller-intersection bytes normally, complete segment bytes when a checksum is supplied. V1 performs no cross-segment coalescing.</li>
-          <li>Peak Python read memory is bounded by up to twice the clamped returned length plus configured in-flight object/service chunks and complete-segment staging limits, not all unexecuted bytes.</li>
-          <li>WHOLE_RESULT core submission count is exactly one <code>fetch</code> call per touched operation-local <code>(generation, plan_digest, segment_ordinal)</code> per top-level operation; this key is not reused across providers or bindings. Fetcher-internal SAFE attempts belong to that fetcher's own conformance tests. Successful cleanup removes private files; an injected unlink failure remains charged, is retried, and surfaces through the specified redacted error/close record rather than being reported as success.</li>
+          <li>Object request count matches private chunking of each caller-selected intersection; v1 never coalesces across segment boundaries.</li>
+          <li>Peak Python read memory is bounded by the clamped returned length plus bounded chunks and WHOLE_RESULT staging, not all unexecuted bytes.</li>
+          <li>WHOLE_RESULT core submission count is exactly one <code>fetch</code> call per touched segment ordinal per view operation. Cleanup failures never convert private output into success.</li>
           <li>Failure cancellation closes/drains queued work, internal waits, and cooperative service streams within the remaining operation deadline. A synchronous <code>StorageClient.read</code> already in progress is measured separately and is not claimed to be preemptible by Assembly.</li>
         </ul>
         <p>
           Local benchmark throughput absolute numbers are recorded but do not block early pull requests because shared CI is noisy.
-          After Gate 0 records an approved same-machine regression percentage, nightly measurements beyond that numeric
-          threshold trigger investigation rather than an automatic functional failure.
+          The repository may establish a same-machine regression threshold from repeated baseline runs; nightly measurements
+          beyond that threshold trigger investigation rather than an automatic functional failure.
         </p>
       </section>
 
       <section id="rollout">
-        <h2>16. Incremental delivery plan and approval gates</h2>
+        <h2>15. Incremental delivery plan</h2>
 
         <div class="phase">
-          <div class="phase-name">Gate 0<br><span class="small">Contract</span></div>
-          <div><strong>Approve contracts, limits, and product scale inputs.</strong> Freeze <code>assembly-list/v1</code>, exact-result semantics, expiration/re-resolution/in-flight semantics, union kinds, complete-plan/global-length invariant, both consistency policies, service range/retry rules, 16/64 KiB inline ceilings, complete-segment staging limits, exception taxonomy, and ownership. Record that v1 has internal cancellation only and that the current synchronous StorageClient call is checked before/after—but cannot be preempted by—the Assembly deadline. Keep the v1 object binding client-only, StorageClients always borrowed, and logical-byte caching disabled. Product owners must approve the proposed object-count, list-size/segment, workload, operational defaults, and memory envelope before those defaults become stable. Add golden fixtures; no runtime integration yet.</div>
+          <div class="phase-name">Stage 0<br><span class="small">Contract baseline</span></div>
+          <div><strong>Record the MVP contracts and private safeguards.</strong> Freeze <code>assembly-list/v1</code>, exact-result semantics, expiration/re-resolution behavior, union kinds, complete-plan/global-length invariant, service range rules, 16/64 KiB inline ceilings, WHOLE_RESULT hard limit, exception taxonomy, and borrowed dependency ownership. Record that revision/checksum enforcement, browse, seek, and public limit objects are out of scope. Add golden fixtures; no runtime integration yet.</div>
         </div>
         <div class="phase">
-          <div class="phase-name">Gate 1<br><span class="small">Resolve and view</span></div>
-          <div><strong>Implement the metadata-to-executable pipeline.</strong> List codec/batches, canonical models, the single <code>get_plan(request)</code> provider call, validation, frozen binding registries, capability computation, and <code>AssemblyView.metadata</code>. No view is exposed and no byte I/O occurs before the returned complete plan passes validation.</div>
+          <div class="phase-name">Stage 1<br><span class="small">Resolve and view</span></div>
+          <div><strong>Implement the metadata-to-executable pipeline.</strong> List codec/batches, public models, the single <code>get_plan(request)</code> provider call, validation, frozen binding registries, and <code>AssemblyView.metadata</code>. No view is exposed and no byte I/O occurs before the returned complete plan passes validation.</div>
         </div>
         <div class="phase">
-          <div class="phase-name">Gate 2<br><span class="small">Core execution</span></div>
-          <div><strong>Implement the complete Python execution path.</strong> Direct StorageClient reads, user-defined ServiceSegmentFetcher wiring, inline bytes, bounded staging, range planning, client/view/reader, lifecycle, and atomic materialization. Core E2E must pass without an HTTP adapter or network server.</div>
+          <div class="phase-name">Stage 2<br><span class="small">Core execution</span></div>
+          <div><strong>Implement the complete Python execution path.</strong> Direct StorageClient reads, user-defined ServiceSegmentFetcher wiring, inline bytes, bounded staging, range planning, client/view/reader, lifecycle, and atomic materialization. Core E2E uses only an application-supplied in-process fetcher.</div>
         </div>
         <div class="phase">
-          <div class="phase-name">Gate 3<br><span class="small">Integration</span></div>
+          <div class="phase-name">Stage 3<br><span class="small">Integration</span></div>
           <div><strong>Exercise the complete union and third-party conformance.</strong> Range/whole-result user services, multiple StorageClients, inline limits, expiration/re-resolution, staging, lifecycle, redaction, failure injection, and unchanged existing MSC tests.</div>
         </div>
         <div class="phase">
-          <div class="phase-name">Gate 4<br><span class="small">Release</span></div>
+          <div class="phase-name">Stage 4<br><span class="small">Release</span></div>
           <div><strong>Complete docs, benchmarks, and packaging.</strong> User guide, API reference, quickstart notebook, benchmark baseline, full build, and opt-in release note.</div>
-        </div>
-
-        <div class="callout info">
-          <strong>Post-core follow-up, not Gate 5:</strong> only after a separate generic HTTP-adapter proposal is approved
-          may work begin on that convenience adapter. Core release and stable-v1 evaluation do not wait for it.
         </div>
 
         <h3>Feature rollout</h3>
         <ul>
           <li>Ship only from the explicit <code>multistorageclient.assembly</code> namespace.</li>
-          <li>Keep logical output caching disabled throughout v1; descriptor and plan caches remain hard-bounded by descriptor expiration.</li>
-          <li>Keep <code>EXPIRATION_ONLY</code> as the documented default and require explicit construction for <code>SNAPSHOT_PINNED</code>.</li>
-          <li>Mark the distinct browse index optional/experimental until stable cursor and approved scale-envelope tests pass.</li>
+          <li>Keep cross-operation descriptor, plan, and logical-output caching disabled throughout v1.</li>
+          <li>Document that v1 enforces expiration and lengths, while same-length source mutation may be undetectable.</li>
           <li>Do not automatically expose assembly through FUSE, fsspec, pathlib, CLI, sync, or <code>msc://</code>.</li>
           <li>Collect protocol and performance evidence before considering a stable-v1 designation.</li>
         </ul>
       </section>
 
       <section id="risks">
-        <h2>17. Risk register and definition of done</h2>
+        <h2>16. Risk register and definition of done</h2>
         <div class="table-wrap">
           <table>
             <thead><tr><th>Risk</th><th>Mitigation / gate</th></tr></thead>
             <tbody>
-              <tr><td>Expiration omitted, parsed differently, or extended through cache.</td><td>Mandatory canonical UTC field on batches/descriptors, one admission clock, hard cache expiry, missing/malformed/boundary tests.</td></tr>
-              <tr><td>Default mode is mistaken for snapshot consistency.</td><td>Name it EXPIRATION_ONLY, permit optional selectors/validators/revisions honestly, disable unsafe byte caching, and document same-length mutation risk.</td></tr>
-              <tr><td>Current StorageClient cannot atomically pin a mutable version.</td><td>Default direct read remains allowed; in v1, SNAPSHOT_PINNED requires complete checksum verification for object segments. A later additive conditional-read binding may enforce selectors or validators.</td></tr>
-              <tr><td>Complete service/checksum verification exhausts memory or disk.</td><td>Reserve each complete-segment stage immediately before launch, serialize individually feasible forward stages, enforce memory/result/temp ceilings, and verify length/digest before publication.</td></tr>
-              <tr><td>Unsafe service operation is retried.</td><td>RetrySafety defaults NEVER; NEVER permits one private attempt even if no response bytes arrive, only SAFE permits fetcher-owned bounded retry, and Assembly adds no outer retry.</td></tr>
-              <tr><td>Inline becomes a bulk-data path.</td><td>Hard 16 KiB per-segment and 64 KiB aggregate upper ceilings (configuration may only lower) plus encoded-plan limits.</td></tr>
-              <tr><td>Large lists make lookup/traversal or memory unusable.</td><td>Versioned batches, bounded public codec, AssemblyListStore contract, bounded small-list provider, and blocking product-envelope tests.</td></tr>
-              <tr><td>Provider returns huge or malicious plans.</td><td>Canonical bounded decoder and semantic validation before allocation/I/O.</td></tr>
+              <tr><td>Expiration omitted or parsed differently.</td><td>Mandatory canonical UTC field on batches/descriptors, one admission clock, and missing/malformed/boundary tests.</td></tr>
+              <tr><td>V1 is mistaken for a dataset snapshot guarantee.</td><td>Document that v1 validates expiration and lengths only; same-length mutation may be undetectable and stronger identity remains application-owned.</td></tr>
+              <tr><td>Whole service result exhausts memory or disk.</td><td>Reject declarations above the private hard cap, stage smaller results in bounded memory or a private file, and verify exact length before publication.</td></tr>
+              <tr><td>Inline becomes a bulk-data path.</td><td>Hard 16 KiB per-segment and 64 KiB aggregate upper ceilings plus the encoded-plan limit.</td></tr>
+              <tr><td>Large batch sets make memory unusable.</td><td>Versioned batches, bounded codec, bounded in-memory static provider, and custom <code>AssemblyPlanProvider</code> implementations for larger catalogs.</td></tr>
+              <tr><td>Provider returns huge or malicious plans.</td><td>Bounded decoding and semantic validation before allocation or I/O.</td></tr>
               <tr><td>Remote plans drive authority or credential escape.</td><td>Separate immutable object/service registries, least-privilege bound StorageClient namespaces, no plan-controlled client configuration, and fetcher-owned operation confinement.</td></tr>
-              <tr><td>Nested retries multiply attempts.</td><td>Assembly performs no outer source retry; SAFE service retries remain fetcher-owned and bounded, while NEVER remains exactly one attempt.</td></tr>
+              <tr><td>Nested retries multiply attempts.</td><td>Assembly performs no outer object or service retry; any user-fetcher retry remains opaque and bounded by the supplied deadline.</td></tr>
               <tr><td>Python sync calls cannot be forcibly cancelled.</td><td>The deadline hard-bounds admission, internal waits, and cooperative provider/service work. Current StorageClient reads are checked before/after, use application-configured underlying timeouts, and may outlive the Assembly deadline; MSC makes no preemption claim.</td></tr>
-              <tr><td>Plan cache mixes bindings/provider generations or survives expiration.</td><td>Frozen concrete bindings, per-client registry-snapshot scope, hard expiry, and commit-after-validation; logical-byte caching is disabled in v1.</td></tr>
               <tr><td>Scope expands back into StorageClient/provider hierarchy.</td><td>Import-boundary and private-provider regression tests; no factory/config changes in v1.</td></tr>
             </tbody>
           </table>
@@ -2399,29 +1861,28 @@ multi-storage-client-docs/examples/
 
         <h3>Definition of done</h3>
         <ul class="checklist">
-          <li>High-level API and capability approval gates are signed off.</li>
+          <li>The approved lean MVP API and SPI are represented consistently across all three documents.</li>
           <li>All new public types have complete docstrings and Sphinx reference entries.</li>
           <li>The versioned language-neutral list codec publishes golden vectors for batches and every explicit segment kind.</li>
           <li>Provider and ServiceSegmentFetcher conformance suites are reusable outside the MSC repository.</li>
           <li><code>AssemblyPlanProvider.get_plan(request)</code> returns descriptor metadata and a complete exact-result plan in one call; <code>AssemblyClient.resolve</code> exposes an executable view only after validation and binding freeze.</li>
           <li><code>AssemblyView.metadata</code> returns the exact descriptor used to create that view.</li>
           <li>Validation proves checked global logical length and rejects expired/malformed plans before object/service I/O.</li>
-          <li>A mixed object/service/inline plan passes full, partial, seekable, and materialization E2E cases through a user-defined in-process service fetcher with no HTTP-adapter dependency.</li>
-          <li>Expiration-only and snapshot-pinned guarantees are separately tested and documented; another <code>resolve(reference)</code> creates a distinct replacement view without mutating the expired generation.</li>
-          <li>Range-capable and whole-result services pass stability, retry-safety, bounded complete-segment staging, and cleanup tests. For <code>RetrySafety.NEVER</code>, MSC proves there is no second core <code>fetch()</code> invocation after pre-response or partial-stream failure; fetcher owners separately verify that their opaque implementation performs at most one private attempt.</li>
-          <li>Checksum-bearing object operations carry a complete <code>fetch_range</code> and a distinct <code>selected_range_in_fetch</code>, verify before copying that slice, and ordinary reads fetch only their intersection.</li>
+          <li>A mixed object/service/inline plan passes full, partial-range, forward-reader, and materialization E2E cases through a user-defined in-process service fetcher.</li>
+          <li>Mandatory expiration, exact-length enforcement, same-length mutation risk, and replacement resolution are tested and documented.</li>
+          <li>Stable-subrange and whole-result services pass range stability, one-core-call, bounded staging, and cleanup tests.</li>
           <li>Deadline documentation and tests distinguish hard-bounded MSC/cooperative waits from non-preemptible synchronous StorageClient calls, and v1 makes no public caller-cancellation claim.</li>
           <li>Private stage and materialization files use exclusive no-follow creation where supported and POSIX mode <code>0600</code>; published files retain the effective mode.</li>
-          <li>Every failed one-shot read/current reader call publishes no bytes from that call; a reader may already have returned a successful prefix in earlier calls, and v1 creates no logical-byte cache entry on either path.</li>
+          <li>Every failed view read or current reader call publishes no bytes from that call; a reader may already have returned a successful prefix in earlier calls, and v1 creates no logical-byte cache entry on either path.</li>
           <li>No existing StorageClient/StorageProvider/config behavior changes.</li>
           <li>Go/FUSE remains unchanged in the initial release; any future cross-language runtime consumes the normative list schema.</li>
           <li>Focused Python tests, analyzer, existing unit suites, documentation build, and final repository build pass.</li>
-          <li>Product scale inputs are signed off and large-list traversal/exact-lookup/memory benchmarks are attached.</li>
+          <li>Batch decoding, exact-lookup, and memory benchmarks are attached below the private hard limits.</li>
         </ul>
       </section>
 
       <section id="commands">
-        <h2>18. Verification commands and references</h2>
+        <h2>17. Verification commands and references</h2>
         <h3>Focused development commands</h3>
         <pre><code># Prepare the project environment
 just multi-storage-client/prepare-toolchain
@@ -2430,7 +1891,7 @@ just multi-storage-client/prepare-toolchain
 cd multi-storage-client
 uv run pytest tests/test_multistorageclient/unit/assembly -q
 
-# Reproducible benchmark artifact using the Gate 0 thresholds
+# Reproducible benchmark artifact using the MVP boundaries
 uv run python tests/test_multistorageclient/benchmark/evaluate_assembly.py \
   --output artifacts/assembly-benchmark.json
 
@@ -2453,18 +1914,8 @@ just build</code></pre>
 
         <h3>Core normative reference</h3>
         <ul>
-          <li><a href="https://www.rfc-editor.org/rfc/rfc8785.html">RFC 8785 — JSON Canonicalization Scheme</a></li>
-        </ul>
-
-        <h3>Optional generic HTTP-adapter references</h3>
-        <p class="small">
-          These references inform only the separately approved transport follow-up. They do not define an Assembly core
-          dependency or an MSC-owned external service contract.
-        </p>
-        <ul>
-          <li><a href="https://www.rfc-editor.org/rfc/rfc9110.html">RFC 9110 — HTTP Semantics</a></li>
-          <li><a href="https://www.rfc-editor.org/rfc/rfc9111.html">RFC 9111 — HTTP Caching</a></li>
-          <li><a href="https://www.rfc-editor.org/rfc/rfc8246.html">RFC 8246 — Immutable HTTP Responses</a></li>
+          <li><a href="https://www.rfc-editor.org/rfc/rfc8259.html">RFC 8259 — The JavaScript Object Notation (JSON) Data Interchange Format</a></li>
+          <li><a href="https://www.rfc-editor.org/rfc/rfc3339.html">RFC 3339 — Date and Time on the Internet</a></li>
         </ul>
 
         <p class="small">


### PR DESCRIPTION
## Description

Adds the design package for the proposed `multistorageclient.assembly` module:

- High-Level Design
- Workflow User Guide
- Implementation & Test Plan

The proposal introduces a format-neutral assembly layer above existing StorageClients without changing current StorageClient or StorageProvider APIs.

This PR contains design documentation only—no runtime implementation.

Relates to NGCDP-9356

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive user guide for composing and operating the proposed assembly workflow.
  - Added a high-level design document covering architecture, responsibilities, extension points, validation, expiration, compatibility, and versioning.
  - Included API examples, troubleshooting guidance, adoption steps, diagrams, tables, and responsive light/dark/print-friendly styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->