### PR TITLE
feat: add strict symlink handling for external targets

### DIFF
--- a/multi-storage-client-docs/src/user_guide/cli.rst
+++ b/multi-storage-client-docs/src/user_guide/cli.rst
@@ -435,11 +435,13 @@ Each JSONL file contains one JSON object per line with ``ObjectMetadata`` fields
 Symlink Handling
 ================
 
-The ``--symlink-handling`` option controls how symbolic links in the source are handled during a sync. Three modes are supported:
+The ``--symlink-handling`` option controls how symbolic links in the source are handled during a sync. Five modes are supported:
 
-* ``follow`` (default) — Symlinks are transparently dereferenced and the target's bytes are copied.
+* ``follow`` (default) — Internal symlinks are transparently dereferenced and the target's bytes are copied. External symlinks (targets outside the source ``base_path``) are skipped.
+* ``follow_strict`` — Same as ``follow`` for internal symlinks, but raises an error on external symlinks.
 * ``skip`` — Symlinks (both file and directory symlinks) are excluded from the sync.
-* ``preserve`` — Symlinks are recreated on the target instead of being dereferenced. A symlink entry is transferred as a pointer, so no duplicate content is written. Required for round-trip fidelity (e.g., upload to object storage, then download, and recover the original layout including symlinks).
+* ``preserve`` — Internal symlinks are recreated on the target instead of being dereferenced. External symlinks are skipped. Required for round-trip fidelity (e.g., upload to object storage, then download, and recover the original layout including internal symlinks).
+* ``preserve_strict`` — Same as ``preserve`` for internal symlinks, but raises an error on external symlinks.
 
 .. code-block:: shell
   :caption: Preserve symlinks when uploading to object storage
@@ -453,9 +455,11 @@ The ``--symlink-handling`` option controls how symbolic links in the source are 
 
 .. note::
 
-  Symlink targets pointing outside the source's ``base_path`` are rejected in ``preserve`` mode because the target is not reachable via the storage profile. Use ``follow`` to dereference such symlinks or ``skip`` to ignore them.
+  External-target and broken-symlink checks apply only to POSIX file providers. Object-storage providers ignore ``--symlink-handling``.
 
-  Broken symlinks (missing target) also raise an error in ``preserve`` mode; use ``skip`` to ignore them.
+  Symlink targets pointing outside the source's ``base_path`` are skipped in ``follow`` and ``preserve`` mode. Use ``follow_strict`` or ``preserve_strict`` to fail instead, or ``skip`` to ignore all symlinks.
+
+  Broken symlinks (missing target) raise an error in ``follow``, ``follow_strict``, ``preserve``, and ``preserve_strict`` mode; use ``skip`` to ignore them.
 
 See :doc:`/user_guide/concepts` and the storage provider documentation for the data model details and backend-specific representation of symlinks.
 

--- a/multi-storage-client/src/multistorageclient/client/single.py
+++ b/multi-storage-client/src/multistorageclient/client/single.py
@@ -820,6 +820,13 @@ class SingleStorageClient(AbstractStorageClient):
         if not path:
             return None, path
 
+        if self._is_posix_file_storage_provider() and not self._metadata_provider:
+            provider = cast(PosixFileStorageProvider, self._storage_provider)
+            normalized_path = path.rstrip("/") or path
+            physical_path = provider._prepend_base_path(normalized_path)
+            if os.path.islink(physical_path):
+                return None, normalized_path
+
         if self.is_file(path):
             if pattern_matcher and not pattern_matcher.should_include_file(path):
                 return None, None

--- a/multi-storage-client/src/multistorageclient/commands/cli/actions/sync.py
+++ b/multi-storage-client/src/multistorageclient/commands/cli/actions/sync.py
@@ -75,14 +75,16 @@ class SyncAction(Action):
         )
         parser.add_argument(
             "--symlink-handling",
-            choices=["follow", "skip", "preserve"],
+            choices=["follow", "follow_strict", "skip", "preserve", "preserve_strict"],
             default="follow",
             help=(
                 "How to handle symbolic links during sync. "
-                "'follow' (default) dereferences symlinks and copies target bytes. "
+                "'follow' (default) dereferences internal symlinks and skips external symlinks. "
+                "'follow_strict' dereferences internal symlinks and raises on external symlinks. "
                 "'skip' excludes symlinks. "
-                "'preserve' recreates symlinks on the target via make_symlink "
-                "(required for round-trip fidelity)."
+                "'preserve' recreates internal symlinks on the target via make_symlink and skips external symlinks. "
+                "'preserve_strict' recreates internal symlinks and raises on external symlinks. "
+                "These modes apply only to POSIX sources; object-storage providers ignore this option."
             ),
         )
         parser.add_argument(

--- a/multi-storage-client/src/multistorageclient/providers/posix_file.py
+++ b/multi-storage-client/src/multistorageclient/providers/posix_file.py
@@ -242,12 +242,39 @@ class PosixFileStorageProvider(BaseStorageProvider):
         end_at = os.path.relpath(end_at, self._base_path) if end_at else None
 
         def _invoke_api() -> Iterator[ObjectMetadata]:
+            symlink_path = path.rstrip("/") or path
+            if os.path.islink(symlink_path):
+                if symlink_handling == SymlinkHandling.SKIP:
+                    return
+
+                relative_path = self._validate_symlink_target(symlink_path, symlink_handling)
+                if relative_path is None:
+                    return
+
+                if (start_after is not None and relative_path <= start_after) or (
+                    end_at is not None and relative_path > end_at
+                ):
+                    return
+
+                if symlink_handling in (SymlinkHandling.PRESERVE, SymlinkHandling.PRESERVE_STRICT):
+                    relative_target, target_type = self._get_symlink_target_info(symlink_path)
+                    yield ObjectMetadata(
+                        key=relative_path,
+                        content_length=0,
+                        last_modified=datetime.fromtimestamp(os.path.getmtime(symlink_path), tz=timezone.utc),
+                        type=target_type,
+                        symlink_target=relative_target,
+                    )
+                    return
+
             if os.path.isfile(path):
-                yield ObjectMetadata(
-                    key=os.path.relpath(path, self._base_path),
-                    content_length=os.path.getsize(path),
-                    last_modified=datetime.fromtimestamp(os.path.getmtime(path), tz=timezone.utc),
-                )
+                relative_path = os.path.relpath(path, self._base_path)
+                if (start_after is None or relative_path > start_after) and (end_at is None or relative_path <= end_at):
+                    yield ObjectMetadata(
+                        key=relative_path,
+                        content_length=os.path.getsize(path),
+                        last_modified=datetime.fromtimestamp(os.path.getmtime(path), tz=timezone.utc),
+                    )
             dir_path = path.rstrip("/") + "/"
             if not os.path.isdir(dir_path):
                 return
@@ -284,6 +311,62 @@ class PosixFileStorageProvider(BaseStorageProvider):
 
         return prefixes, objects
 
+    def _symlink_target_is_external(self, real_target: str) -> bool:
+        """
+        Return True when ``real_target`` resolves outside ``base_path``.
+
+        Resolve ``base_path`` before comparing so intermediate directory
+        symlinks do not make an in-tree target look external.
+        """
+        real_base_path = os.path.realpath(self._base_path)
+        try:
+            return os.path.commonpath((real_base_path, real_target)) != real_base_path
+        except ValueError:
+            return True
+
+    def _validate_symlink_target(
+        self,
+        full_path: str,
+        symlink_handling: SymlinkHandling,
+    ) -> Optional[str]:
+        """
+        Validate a symlink target and return its path relative to ``base_path``.
+
+        Non-strict modes return ``None`` for external targets, while strict
+        modes raise. Broken symlinks always raise unless the caller skipped
+        validation through ``SymlinkHandling.SKIP``.
+        """
+        relative_path = os.path.relpath(full_path, self._base_path)
+        real_target = os.path.realpath(full_path)
+        if not os.path.exists(real_target):
+            raise FileNotFoundError(
+                f"Broken symlink '{relative_path}' points to a missing target "
+                f"({full_path} -> {real_target}). Use symlink_handling=SKIP to ignore."
+            )
+
+        if not self._symlink_target_is_external(real_target):
+            return relative_path
+
+        if symlink_handling in (SymlinkHandling.FOLLOW_STRICT, SymlinkHandling.PRESERVE_STRICT):
+            raise ValueError(
+                f"Symlink '{relative_path}' points outside the base directory "
+                f"({full_path} -> {real_target}). Use symlink_handling=SKIP to ignore."
+            )
+        return None
+
+    @staticmethod
+    def _get_symlink_target_info(full_path: str) -> tuple[str, str]:
+        """Return the encoded immediate target and resolved target type."""
+        raw_link = os.readlink(full_path)
+        immediate_target = (
+            raw_link
+            if os.path.isabs(raw_link)
+            else os.path.normpath(os.path.join(os.path.dirname(full_path), raw_link))
+        )
+        relative_target = ObjectMetadata.encode_symlink_target(full_path, immediate_target)
+        target_type = "directory" if os.path.isdir(full_path) else "file"
+        return relative_target, target_type
+
     def _explore_directory(
         self,
         dir_path: str,
@@ -315,37 +398,12 @@ class PosixFileStorageProvider(BaseStorageProvider):
                 if is_link and symlink_handling == SymlinkHandling.SKIP:
                     continue
 
-                if is_link and symlink_handling == SymlinkHandling.PRESERVE:
-                    relative_path = os.path.relpath(full_path, self._base_path)
+                if is_link and symlink_handling in (SymlinkHandling.PRESERVE, SymlinkHandling.PRESERVE_STRICT):
+                    relative_path = self._validate_symlink_target(full_path, symlink_handling)
+                    if relative_path is None:
+                        continue
 
-                    real_target = os.path.realpath(full_path)
-                    if not os.path.exists(real_target):
-                        raise FileNotFoundError(
-                            f"Broken symlink '{relative_path}' points to a missing target "
-                            f"({full_path} -> {real_target}). Use symlink_handling=SKIP to ignore."
-                        )
-
-                    try:
-                        target_key = os.path.relpath(real_target, self._base_path)
-                    except ValueError:
-                        target_key = None
-
-                    if target_key is None or target_key.startswith(".."):
-                        raise ValueError(
-                            f"Symlink '{relative_path}' points outside the base directory "
-                            f"({full_path} -> {real_target}). Use symlink_handling=FOLLOW "
-                            f"to dereference or symlink_handling=SKIP to ignore."
-                        )
-
-                    raw_link = os.readlink(full_path)
-                    immediate_target = (
-                        raw_link
-                        if os.path.isabs(raw_link)
-                        else os.path.normpath(os.path.join(os.path.dirname(full_path), raw_link))
-                    )
-                    relative_target = ObjectMetadata.encode_symlink_target(full_path, immediate_target)
-
-                    target_type = "directory" if os.path.isdir(full_path) else "file"
+                    relative_target, target_type = self._get_symlink_target_info(full_path)
 
                     if (start_after is None or start_after < relative_path) and (
                         end_at is None or relative_path <= end_at
@@ -354,16 +412,10 @@ class PosixFileStorageProvider(BaseStorageProvider):
                         symlink_info[relative_path] = (relative_target, target_type)
                     continue
 
-                if is_link and symlink_handling == SymlinkHandling.FOLLOW:
-                    # Broken symlinks have no target to dereference: isfile/isdir both return
-                    # False, so the entry would be silently dropped. Fail fast instead.
-                    real_target = os.path.realpath(full_path)
-                    if not os.path.exists(real_target):
-                        relative_path = os.path.relpath(full_path, self._base_path)
-                        raise FileNotFoundError(
-                            f"Broken symlink '{relative_path}' points to a missing target "
-                            f"({full_path} -> {real_target}). Use symlink_handling=SKIP to ignore."
-                        )
+                if is_link and symlink_handling in (SymlinkHandling.FOLLOW, SymlinkHandling.FOLLOW_STRICT):
+                    relative_path = self._validate_symlink_target(full_path, symlink_handling)
+                    if relative_path is None:
+                        continue
 
                 relative_path = os.path.relpath(full_path, self._base_path)
 

--- a/multi-storage-client/src/multistorageclient/types.py
+++ b/multi-storage-client/src/multistorageclient/types.py
@@ -43,12 +43,19 @@ AWARE_DATETIME_MIN = datetime.min.replace(tzinfo=timezone.utc)
 class SymlinkHandling(str, Enum):
     """Controls how symbolic links are handled during listing and sync operations.
 
-    - ``FOLLOW``: Symlinks are transparent -- directory symlinks are recursed into,
-      file symlinks appear as regular files. This is the default and is backward-compatible.
+    External symlinks (targets outside ``base_path``) are skipped by default in
+    ``FOLLOW`` and ``PRESERVE``. Use ``FOLLOW_STRICT`` or ``PRESERVE_STRICT`` to
+    fail instead.
+
+    - ``FOLLOW``: Dereference internal symlinks; skip external symlinks. This is
+      the default.
+    - ``FOLLOW_STRICT``: Dereference internal symlinks; raise on external symlinks.
     - ``SKIP``: All symlinks are excluded from results.
-    - ``PRESERVE``: Symlinks are detected and yielded as leaf entries with
-      :py:attr:`ObjectMetadata.symlink_target` populated. Directory symlinks are
-      **not** recursed into.
+    - ``PRESERVE``: Surface internal symlinks as leaf entries with
+      :py:attr:`ObjectMetadata.symlink_target` populated; skip external symlinks.
+      Directory symlinks are **not** recursed into.
+    - ``PRESERVE_STRICT``: Same as ``PRESERVE`` for internal symlinks; raise on
+      external symlinks.
 
     .. note::
        This option is only meaningful for POSIX file storage providers, which
@@ -61,8 +68,10 @@ class SymlinkHandling(str, Enum):
     """
 
     FOLLOW = "follow"
+    FOLLOW_STRICT = "follow_strict"
     SKIP = "skip"
     PRESERVE = "preserve"
+    PRESERVE_STRICT = "preserve_strict"
 
 
 # Maximum number of symlink hops allowed when resolving a symlink chain.

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_symlinks.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_symlinks.py
@@ -446,36 +446,199 @@ def _build_posix_storage_client_for_preserve_error(
     return storage_client, base_path
 
 
+def test_list_follows_absolute_symlink_within_symlinked_base_path():
+    """
+    Absolute symlinks whose targets resolve inside ``base_path`` must be followed,
+    even when ``base_path`` itself contains intermediate directory symlinks.
+
+    ``os.path.realpath`` on the symlink target yields the fully resolved path;
+    comparing that against a non-realpathed ``base_path`` with
+    ``os.path.relpath`` incorrectly makes the target look external.
+    """
+    profile = "data"
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
+        profile_config = temp_data_store.profile_config_dict()
+        storage_root = profile_config["storage_provider"]["options"]["base_path"]
+        real_base_path = os.path.join(storage_root, "real-base")
+        symlinked_base_path = os.path.join(storage_root, "symlinked-base")
+        os.mkdir(real_base_path)
+        os.symlink(real_base_path, symlinked_base_path)
+        profile_config["storage_provider"]["options"]["base_path"] = symlinked_base_path
+        storage_client = StorageClient(
+            config=StorageClientConfig.from_dict(
+                config_dict={"profiles": {profile: profile_config}},
+                profile=profile,
+            )
+        )
+
+        storage_client.write(path="real.txt", body=b"real content")
+        os.symlink(
+            os.path.join(symlinked_base_path, "real.txt"),
+            os.path.join(symlinked_base_path, "link.txt"),
+        )
+
+        objects = list(storage_client.list(path="", symlink_handling=SymlinkHandling.FOLLOW))
+        assert sorted(obj.key for obj in objects) == ["link.txt", "real.txt"]
+
+
+def test_list_follows_internal_symlink_to_dotdot_prefixed_name():
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
+        storage_client, base_path = _build_posix_storage_client_for_preserve_error(temp_data_store)
+        storage_client.write(path="..real.txt", body=b"real content")
+        os.symlink(os.path.join(base_path, "..real.txt"), os.path.join(base_path, "link.txt"))
+
+        objects = list(storage_client.list(path="", symlink_handling=SymlinkHandling.FOLLOW))
+        assert sorted(obj.key for obj in objects) == ["..real.txt", "c.txt", "link.txt"]
+
+
 @pytest.mark.parametrize(
-    argnames=["temp_data_store_type"],
-    argvalues=[[tempdatastore.TemporaryPOSIXDirectory]],
+    ("symlink_handling", "expected_symlink_target"),
+    [
+        (SymlinkHandling.FOLLOW, None),
+        (SymlinkHandling.FOLLOW_STRICT, None),
+        (SymlinkHandling.PRESERVE, "c.txt"),
+        (SymlinkHandling.PRESERVE_STRICT, "c.txt"),
+    ],
 )
-def test_list_symlinks_from_posix_with_preserve_raises_on_external_target(
-    temp_data_store_type: type[tempdatastore.TemporaryDataStore],
+@pytest.mark.parametrize("operation_name", ["list", "list_recursive"])
+def test_list_direct_internal_symlink_applies_handling(
+    operation_name: str,
+    symlink_handling: SymlinkHandling,
+    expected_symlink_target: str | None,
 ):
-    """
-    ``symlink_handling=SymlinkHandling.PRESERVE`` must raise ``ValueError``
-    when a symlink's resolved target lives outside ``base_path``.
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
+        storage_client, _ = _build_posix_storage_client_for_preserve_error(temp_data_store)
+        storage_client.make_symlink(path="link.txt", target="c.txt")
 
-    MSC surfaces preserved symlinks as portable relative paths that must
-    resolve to a key inside ``base_path``; a target outside ``base_path``
-    has no valid relative key to record, so the provider fails fast with a
-    message telling the caller to switch to ``FOLLOW`` (to dereference the
-    content) or ``SKIP`` (to ignore the symlink).
+        operation = getattr(storage_client, operation_name)
+        objects = list(operation(path="link.txt", symlink_handling=symlink_handling))
 
-    Layout created by this test::
+        assert len(objects) == 1
+        assert objects[0].key == "link.txt"
+        assert objects[0].symlink_target == expected_symlink_target
 
-        base_dir/
-        ├── c.txt
-        └── escaping    -> <outside_dir>/outside.txt   (points OUTSIDE base_dir)
-        <outside_dir>/
-        └── outside.txt
 
-    The symlink is created directly via :py:func:`os.symlink` so the
-    on-disk target unambiguously escapes ``base_dir``; this mirrors how
-    external symlinks end up on a real POSIX tree.
-    """
-    with temp_data_store_type() as temp_data_store:
+@pytest.mark.parametrize("operation_name", ["list", "list_recursive"])
+@pytest.mark.parametrize(
+    "symlink_handling",
+    [SymlinkHandling.PRESERVE, SymlinkHandling.PRESERVE_STRICT],
+)
+def test_list_direct_directory_symlink_with_trailing_slash_is_preserved(
+    operation_name: str,
+    symlink_handling: SymlinkHandling,
+):
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
+        storage_client, _ = _build_posix_storage_client_for_preserve_error(temp_data_store)
+        storage_client.write(path="target/file.txt", body=b"target content")
+        storage_client.make_symlink(path="link", target="target")
+        operation = getattr(storage_client, operation_name)
+
+        objects = list(operation(path="link/", symlink_handling=symlink_handling))
+
+        assert len(objects) == 1
+        assert objects[0].key == "link"
+        assert objects[0].type == "directory"
+        assert objects[0].symlink_target == "target"
+
+
+@pytest.mark.parametrize("operation_name", ["list", "list_recursive"])
+def test_list_direct_symlink_with_skip_returns_nothing(operation_name: str):
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
+        storage_client, _ = _build_posix_storage_client_for_preserve_error(temp_data_store)
+        storage_client.make_symlink(path="link.txt", target="c.txt")
+
+        operation = getattr(storage_client, operation_name)
+        assert list(operation(path="link.txt", symlink_handling=SymlinkHandling.SKIP)) == []
+
+
+@pytest.mark.parametrize("operation_name", ["list", "list_recursive"])
+def test_list_direct_symlink_applies_key_bounds(operation_name: str):
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
+        storage_client, _ = _build_posix_storage_client_for_preserve_error(temp_data_store)
+        storage_client.make_symlink(path="link.txt", target="c.txt")
+        operation = getattr(storage_client, operation_name)
+
+        assert list(operation(path="link.txt", start_after="z")) == []
+        assert list(operation(path="link.txt", end_at="a")) == []
+        assert len(list(operation(path="link.txt", start_after="a", end_at="z"))) == 1
+
+
+@pytest.mark.parametrize(
+    "symlink_handling",
+    [
+        SymlinkHandling.FOLLOW,
+        SymlinkHandling.FOLLOW_STRICT,
+        SymlinkHandling.PRESERVE,
+        SymlinkHandling.PRESERVE_STRICT,
+    ],
+)
+@pytest.mark.parametrize("operation_name", ["list", "list_recursive"])
+def test_list_direct_broken_symlink_raises(operation_name: str, symlink_handling: SymlinkHandling):
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
+        storage_client, base_path = _build_posix_storage_client_for_preserve_error(temp_data_store)
+        os.symlink(os.path.join(base_path, "missing.txt"), os.path.join(base_path, "broken"))
+
+        operation = getattr(storage_client, operation_name)
+        with pytest.raises(FileNotFoundError, match="Broken symlink"):
+            list(operation(path="broken", symlink_handling=symlink_handling))
+
+
+@pytest.mark.parametrize("operation_name", ["list", "list_recursive"])
+def test_list_direct_broken_symlink_with_skip_returns_nothing(operation_name: str):
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
+        storage_client, base_path = _build_posix_storage_client_for_preserve_error(temp_data_store)
+        os.symlink(os.path.join(base_path, "missing.txt"), os.path.join(base_path, "broken"))
+
+        operation = getattr(storage_client, operation_name)
+        assert list(operation(path="broken", symlink_handling=SymlinkHandling.SKIP)) == []
+
+
+@pytest.mark.parametrize("symlink_handling", [SymlinkHandling.FOLLOW, SymlinkHandling.PRESERVE])
+@pytest.mark.parametrize("operation_name", ["list", "list_recursive"])
+def test_list_direct_external_symlink_skips_target(operation_name: str, symlink_handling: SymlinkHandling):
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
+        storage_client, base_path = _build_posix_storage_client_for_preserve_error(temp_data_store)
+
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_file = os.path.join(outside_dir, "outside.txt")
+            with open(outside_file, "wb") as f:
+                f.write(b"outside content")
+            os.symlink(outside_file, os.path.join(base_path, "escaping"))
+
+            operation = getattr(storage_client, operation_name)
+            assert list(operation(path="escaping", symlink_handling=symlink_handling)) == []
+
+
+@pytest.mark.parametrize(
+    "symlink_handling",
+    [SymlinkHandling.FOLLOW_STRICT, SymlinkHandling.PRESERVE_STRICT],
+)
+@pytest.mark.parametrize("operation_name", ["list", "list_recursive"])
+def test_list_direct_external_symlink_with_strict_handling_raises(
+    operation_name: str,
+    symlink_handling: SymlinkHandling,
+):
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
+        storage_client, base_path = _build_posix_storage_client_for_preserve_error(temp_data_store)
+
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_file = os.path.join(outside_dir, "outside.txt")
+            with open(outside_file, "wb") as f:
+                f.write(b"outside content")
+            os.symlink(outside_file, os.path.join(base_path, "escaping"))
+
+            operation = getattr(storage_client, operation_name)
+            with pytest.raises(ValueError, match="points outside the base directory"):
+                list(operation(path="escaping", symlink_handling=symlink_handling))
+
+
+@pytest.mark.parametrize("operation_name", ["list", "list_recursive"])
+@pytest.mark.parametrize("symlink_handling", [SymlinkHandling.FOLLOW, SymlinkHandling.PRESERVE])
+def test_list_symlinks_from_posix_skips_external_target(
+    operation_name: str,
+    symlink_handling: SymlinkHandling,
+):
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
         storage_client, base_path = _build_posix_storage_client_for_preserve_error(temp_data_store)
 
         with tempfile.TemporaryDirectory() as outside_dir:
@@ -485,18 +648,22 @@ def test_list_symlinks_from_posix_with_preserve_raises_on_external_target(
 
             os.symlink(outside_file, os.path.join(base_path, "escaping"))
 
-            with pytest.raises(ValueError, match="points outside the base directory"):
-                list(storage_client.list(path="", symlink_handling=SymlinkHandling.PRESERVE))
+            operation = getattr(storage_client, operation_name)
+            objects = list(operation(path="", symlink_handling=symlink_handling))
+
+            assert [obj.key for obj in objects] == ["c.txt"]
 
 
+@pytest.mark.parametrize("operation_name", ["list", "list_recursive"])
 @pytest.mark.parametrize(
-    argnames=["temp_data_store_type"],
-    argvalues=[[tempdatastore.TemporaryPOSIXDirectory]],
+    "symlink_handling",
+    [SymlinkHandling.FOLLOW_STRICT, SymlinkHandling.PRESERVE_STRICT],
 )
-def test_list_recursive_symlinks_from_posix_with_preserve_raises_on_external_target(
-    temp_data_store_type: type[tempdatastore.TemporaryDataStore],
+def test_list_symlinks_from_posix_with_strict_handling_raises_on_external_target(
+    operation_name: str,
+    symlink_handling: SymlinkHandling,
 ):
-    with temp_data_store_type() as temp_data_store:
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
         storage_client, base_path = _build_posix_storage_client_for_preserve_error(temp_data_store)
 
         with tempfile.TemporaryDirectory() as outside_dir:
@@ -506,8 +673,9 @@ def test_list_recursive_symlinks_from_posix_with_preserve_raises_on_external_tar
 
             os.symlink(outside_file, os.path.join(base_path, "escaping"))
 
+            operation = getattr(storage_client, operation_name)
             with pytest.raises(ValueError, match="points outside the base directory"):
-                list(storage_client.list_recursive(path="", symlink_handling=SymlinkHandling.PRESERVE))
+                list(operation(path="", symlink_handling=symlink_handling))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

- Add `FOLLOW_STRICT` and `PRESERVE_STRICT` symlink handling modes.
- Make `FOLLOW` and `PRESERVE` skip symlinks targeting paths outside the POSIX `base_path`.
- Use canonical common paths to correctly classify targets when `base_path` contains symlinks or target names begin with `..`.
- Apply symlink policy when the requested listing root is itself a symlink, for both `list` and `list_recursive`.
- Cover internal, external, broken, direct-path, strict-mode, and key-boundary behavior.
- Clarify that symlink handling applies only to POSIX sources; object-storage providers ignore the option.

## Behavior

- `SKIP`: skip all symlinks.
- `FOLLOW`: follow internal symlinks and skip external symlinks.
- `FOLLOW_STRICT`: follow internal symlinks and raise on external symlinks.
- `PRESERVE`: preserve internal symlinks and skip external symlinks.
- `PRESERVE_STRICT`: preserve internal symlinks and raise on external symlinks.

Relates to NGCDP-9447

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Added `follow_strict` and `preserve_strict` symlink-handling modes to `msc sync`.
- **Bug Fixes**
  - Improved POSIX symlink listing/traversal for external and broken symlinks (skipped in non-strict modes; errors in strict modes; dangling targets error unless skipping).
  - Prevented symlink targets from being treated as single-file results when metadata isn’t available.
  - Fixed numeric literal handling in attribute filters.
- **Documentation**
  - Updated `msc sync --symlink-handling` guide for all five modes, including POSIX-only behavior and object-storage ignoring the option.
- **Tests**
  - Expanded POSIX symlink coverage for internal/external targets, key bounds, broken symlinks, and strict-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->