### PR TITLE
chore: Upgrade AIStore Nix package to 1.4.9.

### DIFF
--- a/nix/overlays/development/multi-storage-client/packages/aistore/package.nix
+++ b/nix/overlays/development/multi-storage-client/packages/aistore/package.nix
@@ -7,20 +7,20 @@
 # https://nixos.org/manual/nixpkgs/unstable#ssec-language-go
 buildGoModule (finalAttrs: {
   pname = "aistore";
-  version = "1.4.8";
+  version = "1.4.9";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "aistore";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-u6MBpOQfQh+EuIYlN0jHMgByHPj1TKn/DTzAb1eRwcc=";
+    hash = "sha256-0EmOEexiDnjed7otPx+XWBcUbbDzvgXMsJ1pNEGco9c=";
   };
 
   vendorHash = "sha256-lWsLLIx4YJcitNpHWl965VBRHJDRxw8EWTGBjiexQBE=";
 
   # Exclude `cmd/cli` and `cmd/ishard` which are separate Go modules.
   #
-  # https://github.com/NVIDIA/aistore/tree/v1.4.8/cmd
+  # https://github.com/NVIDIA/aistore/tree/v1.4.9/cmd
   subPackages = [
     "cmd/aisinit"
     "cmd/aisloader"
@@ -32,7 +32,7 @@ buildGoModule (finalAttrs: {
 
   # Needed for version strings.
   #
-  # https://github.com/NVIDIA/aistore/blob/v1.4.8/Makefile#L86
+  # https://github.com/NVIDIA/aistore/blob/v1.4.9/Makefile#L86
   ldflags = [
     "-X main.build=v${finalAttrs.version}"
     "-X main.buildtime=1970-01-01T00:00:00-00:00"
@@ -41,7 +41,7 @@ buildGoModule (finalAttrs: {
   tags = [
     # Monotonic time.
     #
-    # https://github.com/NVIDIA/aistore/blob/v1.4.8/Makefile#L98
+    # https://github.com/NVIDIA/aistore/blob/v1.4.9/Makefile#L98
     "mono"
   ];
 


### PR DESCRIPTION
## Description

Upgrade AIStore Nix package to 1.4.9.

Closes NGCDP-9531.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AIStore package to version 1.4.9.
  * Refreshed related documentation links and package verification metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->