### PR TITLE
fix(test): replace vacuous memmap assertion with real array comparison

### DIFF
--- a/multi-storage-client/tests/test_multistorageclient/unit/test_shortcuts.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_shortcuts.py
@@ -414,11 +414,15 @@ def verify_shortcuts(profile: str, prefix: str):
     # numpy
     arr = np.array([1, 2, 3, 4, 5], dtype=np.int32)
     msc.numpy.save(f"msc://{profile}/{prefix}/folder/arr-01.npy", arr)
+    # save raw bytes (no .npy header) for memmap — np.memmap maps raw bytes from offset 0
+    with msc.open(f"msc://{profile}/{prefix}/folder/arr-01.bin", "wb") as fp:
+        fp.write(arr.tobytes())
     msc.commit_metadata(f"msc://{profile}")
 
-    assert msc.numpy.load(f"msc://{profile}/{prefix}/folder/arr-01.npy").all() == arr.all()
-    assert (
-        msc.numpy.memmap(f"msc://{profile}/{prefix}/folder/arr-01.npy", dtype=np.int32, shape=(5,)).all() == arr.all()
+    assert np.array_equal(msc.numpy.load(f"msc://{profile}/{prefix}/folder/arr-01.npy"), arr)
+    assert np.array_equal(
+        msc.numpy.memmap(f"msc://{profile}/{prefix}/folder/arr-01.bin", dtype=np.int32, shape=(5,)),
+        arr,
     )
 
     # mmap


### PR DESCRIPTION
## Description

msc.numpy.memmap maps raw bytes from offset 0, so pointing it at a .npy file returns header bytes reinterpreted as int32, not the array. The old assertion used .all() on both sides, which reduced to True == True since all values happened to be non-zero — hiding the mismatch entirely.

Fix: write raw bytes (arr.tobytes()) to a .bin file and memmap that, then compare with np.array_equal. Also tighten the numpy.load assertion from the same vacuous .all() pattern to np.array_equal.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.
