### PR TITLE
perf(posix): cache realpath of base_path to avoid repeated syscalls per symlink

### DIFF
--- a/multi-storage-client/src/multistorageclient/providers/posix_file.py
+++ b/multi-storage-client/src/multistorageclient/providers/posix_file.py
@@ -120,6 +120,7 @@ class PosixFileStorageProvider(BaseStorageProvider):
             config_dict=config_dict,
             telemetry_provider=telemetry_provider,
         )
+        self._real_base_path = os.path.realpath(base_path)
 
     def _translate_errors(
         self,
@@ -314,12 +315,11 @@ class PosixFileStorageProvider(BaseStorageProvider):
         """
         Return True when ``real_target`` resolves outside ``base_path``.
 
-        Resolve ``base_path`` before comparing so intermediate directory
+        Uses the pre-computed ``_real_base_path`` so intermediate directory
         symlinks do not make an in-tree target look external.
         """
-        real_base_path = os.path.realpath(self._base_path)
         try:
-            return os.path.commonpath((real_base_path, real_target)) != real_base_path
+            return os.path.commonpath((self._real_base_path, real_target)) != self._real_base_path
         except ValueError:
             return True
 


### PR DESCRIPTION
## Description

`_symlink_target_is_external` called `os.path.realpath(self._base_path)` on every invocation. During large directory listings with many symlinks this becomes a per-entry syscall on a value that never changes after construction. Pre-computing it once in `__init__` as `_real_base_path` eliminates the redundancy.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved symlink validation efficiency by reusing the resolved storage location.
  * Preserved existing path comparison behavior and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->