### PR TITLE
refactor(mcp): remove brittle hasattr guard in register_handlers

### DIFF
--- a/multi-storage-client/src/multistorageclient/mcp/server.py
+++ b/multi-storage-client/src/multistorageclient/mcp/server.py
@@ -71,11 +71,7 @@ mcp = mcp_wrapper.server
 
 def register_handlers():
     """Register all MCP handlers after import to avoid circular dependencies."""
-    from . import prompts, tools
-
-    # Ensure modules are loaded for their side effects of tool registration
-    if not hasattr(prompts, "msc_help") or not hasattr(tools, "msc_list"):
-        raise RuntimeError("MCP handler modules (prompts, tools) failed to load")
+    from . import prompts, tools  # noqa: F401
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Description

The guard checked for specific function names (msc_help, msc_list) to verify that the handler modules loaded. This created fragile coupling: renaming either function would raise a misleading RuntimeError even though the import itself succeeded. The import already registers handlers via side effects; if it fails Python raises ImportError, which is the correct signal. Remove the guard entirely.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server startup by allowing prompt and tool integrations to load without unnecessary validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->