### PR TITLE
chore: Upgrade nix-direnv to 3.2.0 + AIStore Nix package to 1.5.0.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -10,8 +10,8 @@ watch_dir nix
 # Use nix-direnv instead of the built-in support.
 #
 # https://github.com/direnv/direnv/wiki/Nix
-if ! has nix_direnv_version || ! nix_direnv_version 3.1.1; then
-    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.1/direnvrc" "sha256-p+fzQdrms/hDa7g+soShAybJNo4bN4SIAeSfqNKgD5I="
+if ! has nix_direnv_version || ! nix_direnv_version 3.2.0; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.2.0/direnvrc" "sha256-hW6NC1JHue3IjZN3uDM6l6I2PMaauqd2D7hXYJ1Zfr4="
 fi
 
 # Use a Nix environment.

--- a/multi-storage-client/.aistore/README.md
+++ b/multi-storage-client/.aistore/README.md
@@ -4,7 +4,7 @@ Self-contained setup for running a local 2-node AIStore cluster (1 proxy + 1 tar
 
 ## Files
 
-- `prepare_sandbox.sh` - Generates AIStore configuration files (adapted from [AIStore's script](https://github.com/NVIDIA/aistore/blob/v1.4.3/deploy/dev/local/aisnode_config.sh))
+- `prepare_sandbox.sh` - Generates AIStore configuration files (adapted from [AIStore's script](https://github.com/NVIDIA/aistore/blob/v1.5.0/deploy/dev/local/aisnode_config.sh))
 - `sandbox/` - Runtime directory (logs, configs, data)
 
 ## Key Differences from Upstream

--- a/multi-storage-client/.aistore/prepare_sandbox.sh
+++ b/multi-storage-client/.aistore/prepare_sandbox.sh
@@ -25,41 +25,9 @@ generate_ais_config() {
     cat > $AIS_CONF_FILE <<EOL
 {
     "backend": {},
-    "mirror": {
-        "copies":       2,
-        "burst_buffer": 128,
-        "enabled":      false
-    },
-    "ec": {
-        "objsize_limit":    262144,
-        "compression":      "never",
-        "bundle_multiplier":    2,
-        "data_slices":      1,
-        "parity_slices":    1,
-        "enabled":      false,
-        "disk_only":        false
-    },
-        "chunks": {
-                "objsize_limit":    "0",
-                "chunk_size":       "1GiB",
-                "checkpoint_every": 0,
-                "flags":            0
-        },
-    "log": {
-        "level":      "3",
-        "max_size":   "10mb",
-        "max_total":  "256mb",
-        "flush_time": "60s",
-        "stats_time": "60s"
-    },
-    "periodic": {
-        "stats_time":        "10s",
-        "notif_time":        "30s",
-        "retry_sync_time":   "2s"
-    },
     "timeout": {
         "cplane_operation":     "2s",
-        "max_keepalive":        "4s",
+        "max_keepalive":        "5s",
         "cold_get_conflict":    "5s",
         "max_host_busy":        "20s",
         "startup_time":         "1m",
@@ -67,11 +35,6 @@ generate_ais_config() {
         "send_file_time":       "5m",
         "ec_streams_time":  "10m",
         "object_md":            "2h"
-    },
-    "client": {
-        "client_timeout":      "10s",
-        "client_long_timeout": "10m",
-        "list_timeout":        "1m"
     },
     "proxy": {
         "primary_url":   "${AIS_PRIMARY_URL}",
@@ -87,43 +50,8 @@ generate_ais_config() {
         "batch_size":        32768,
         "dont_cleanup_time": "120m"
     },
-    "lru": {
-        "dont_evict_time":   "120m",
-        "capacity_upd_time": "10m",
-        "batch_size":        32768,
-        "enabled":           true
-    },
-    "disk":{
-        "iostat_time_long":   "2s",
-        "iostat_time_short":  "100ms",
-        "iostat_time_smooth": "8s",
-        "disk_util_low_wm":   20,
-        "disk_util_high_wm":  80,
-        "disk_util_max_wm":   95
-    },
-    "rebalance": {
-        "dest_retry_time":  "2m",
-        "compression":      "never",
-        "bundle_multiplier":    2,
-        "enabled":          true
-    },
     "resilver": {
         "enabled": true
-    },
-    "checksum": {
-        "type":         "xxhash2",
-        "validate_cold_get":    false,
-        "validate_warm_get":    false,
-        "validate_obj_move":    false,
-        "enable_read_range":    false
-    },
-    "transport": {
-        "max_header":       4096,
-        "burst_buffer":     512,
-        "idle_teardown":    "4s",
-        "quiescent":        "10s",
-        "lz4_block":        "256kb",
-        "lz4_frame_checksum":   false
     },
     "memsys": {
         "min_free":     "2gb",
@@ -143,20 +71,21 @@ generate_ais_config() {
             "sndrcv_buf_size":    131072
         },
         "http": {
-            "use_https":          false,
-            "server_crt":         "server.crt",
-            "server_key":         "server.key",
-            "domain_tls":         "",
-            "client_ca_tls":      "",
-            "client_auth_tls":    0,
-            "idle_conn_time":     "6s",
-            "idle_conns_per_host":32,
-            "idle_conns":         256,
-            "write_buffer_size":  0,
-            "read_buffer_size":   0,
-            "chunked_transfer":   true,
-            "skip_verify":        false
-        }
+            "use_https":           false,
+            "server_crt":          "server.crt",
+            "server_key":          "server.key",
+            "domain_tls":          "",
+            "client_ca_tls":       "",
+            "client_auth_tls":     0,
+            "idle_conn_time":      "6s",
+            "idle_conns_per_host": 32,
+            "idle_conns":          256,
+            "write_buffer_size":   0,
+            "read_buffer_size":    0,
+            "chunked_transfer":    true,
+            "skip_verify":         false
+        },
+        "use_ipv6": false
     },
     "fshc": {
         "test_files":     4,
@@ -165,26 +94,7 @@ generate_ais_config() {
         "io_err_time":    "10s",
         "enabled":        true
     },
-    "auth": {
-        "enabled":     false
-    },
-    "keepalivetracker": {
-        "proxy": {
-            "interval": "10s",
-            "name":     "heartbeat",
-            "factor":   3
-        },
-        "target": {
-            "interval": "10s",
-            "name":     "heartbeat",
-            "factor":   3
-        },
-        "num_retries":    3,
-        "retry_factor":   4
-    },
-    "downloader": {
-        "timeout": "1h"
-    },
+    "auth": {},
     "distributed_sort": {
         "duplicated_records":    "ignore",
         "missing_shards":        "ignore",
@@ -195,40 +105,7 @@ generate_ais_config() {
         "dsorter_mem_threshold": "100GB",
         "compression":           "never",
         "bundle_multiplier":     4
-    },
-    "tcb": {
-        "compression":      "never",
-        "bundle_multiplier":    2
-    },
-    "tco": {
-        "compression":      "never",
-        "bundle_multiplier":    2
-    },
-    "arch": {
-        "compression":      "never",
-        "bundle_multiplier":    2
-    },
-    "write_policy": {
-        "data": "",
-        "md": ""
-    },
-    "rate_limit": {
-        "backend": {
-            "num_retries":       3,
-            "interval":          "1m",
-            "per_op_max_tokens": "",
-            "max_tokens":        1000,
-            "enabled":           false
-        },
-        "frontend": {
-            "burst_size":        375,
-            "interval":          "1m",
-            "per_op_max_tokens": "",
-            "max_tokens":        1000,
-            "enabled":           false
-        }
-    },
-    "features": "0"
+    }
 }
 EOL
 

--- a/nix/overlays/development/multi-storage-client/packages/aistore/package.nix
+++ b/nix/overlays/development/multi-storage-client/packages/aistore/package.nix
@@ -7,20 +7,20 @@
 # https://nixos.org/manual/nixpkgs/unstable#ssec-language-go
 buildGoModule (finalAttrs: {
   pname = "aistore";
-  version = "1.4.9";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "aistore";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0EmOEexiDnjed7otPx+XWBcUbbDzvgXMsJ1pNEGco9c=";
+    hash = "sha256-u2hJr+Y5Dd7MRxJVGd4kz8BgfSQmhyyi4lCUZhNTuC4=";
   };
 
-  vendorHash = "sha256-lWsLLIx4YJcitNpHWl965VBRHJDRxw8EWTGBjiexQBE=";
+  vendorHash = "sha256-jKqrmXSGblzWZUZT9olHkZSSVU6aydxFu3JtYfiSbYY=";
 
   # Exclude `cmd/cli` and `cmd/ishard` which are separate Go modules.
   #
-  # https://github.com/NVIDIA/aistore/tree/v1.4.9/cmd
+  # https://github.com/NVIDIA/aistore/tree/v1.5.0/cmd
   subPackages = [
     "cmd/aisinit"
     "cmd/aisloader"
@@ -32,7 +32,7 @@ buildGoModule (finalAttrs: {
 
   # Needed for version strings.
   #
-  # https://github.com/NVIDIA/aistore/blob/v1.4.9/Makefile#L86
+  # https://github.com/NVIDIA/aistore/blob/v1.5.0/Makefile#L87
   ldflags = [
     "-X main.build=v${finalAttrs.version}"
     "-X main.buildtime=1970-01-01T00:00:00-00:00"
@@ -41,9 +41,11 @@ buildGoModule (finalAttrs: {
   tags = [
     # Monotonic time.
     #
-    # https://github.com/NVIDIA/aistore/blob/v1.4.9/Makefile#L98
+    # https://github.com/NVIDIA/aistore/blob/v1.5.0/Makefile#L99
     "mono"
   ];
+
+  __darwinAllowLocalNetworking = true;
 
   doInstallCheck = true;
 


### PR DESCRIPTION
## Description

Upgrade nix-direnv to 3.2.0 + AIStore Nix package to 1.5.0.

Closes NGCDP-9761.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated AIStore to version 1.5.0.
  - Refreshed the sandbox setup and related documentation for the newer AIStore release.
  - Improved default storage configuration, including IPv4-only networking, streamlined authentication, and a five-second keepalive interval.
  - Updated the development environment bootstrap tooling to version 3.2.0.
  - Added required local-network access support for installation checks on macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->