### PR TITLE
feat: add PosixFile descriptor metrics

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -6,6 +6,7 @@
 
 ## New Features
 
+- Add OpenTelemetry metrics for POSIX file descriptor usage: `multistorageclient.file_descriptor.open` tracks file descriptors held by `PosixFile`, and `multistorageclient.file_descriptor.duration` records how long each descriptor remains open.
 - Add an optional `s3_cuobject` provider backed by NVIDIA cuObject for direct S3-over-RDMA buffer transfers to RDMA-capable endpoints.
 - Add MSFS write support for S3 backends. Writable mounts stream large objects through multipart upload and buffer newly created objects locally until `multipart_upload_threshold_bytes`, so small objects commit with a single `PutObject`. `fsync`/`fdatasync` is the durability barrier; `flush_on_close` optionally makes release wait for the backend commit.
 - Commit deferred small MSFS objects through a bounded worker pool, so independent files upload concurrently without holding the global filesystem lock. Tunable via `write_commit_workers`, `write_commit_queue_depth`, and `write_deferral_max_bytes`.

--- a/multi-storage-client-docs/src/user_guide/telemetry.rst
+++ b/multi-storage-client-docs/src/user_guide/telemetry.rst
@@ -217,6 +217,61 @@ Storage Provider
 
         * Operation End
 
+   ``multistorageclient.file_descriptor.duration``
+      The time a :py:class:`multistorageclient.file.PosixFile` held its underlying file descriptor, from a
+      successful open until the descriptor was released by ``close()`` or ``discard()``. The duration excludes
+      the time spent opening the file and work performed after release, such as atomic rename, extended attribute
+      updates, or temporary-file removal.
+
+      * Operations:
+
+        * POSIX file descriptor release
+
+      * Metric data point:
+
+        * Gauge
+
+      * Unit:
+
+        * Seconds
+
+      * Attributes:
+
+        * ``multistorageclient.version``
+        * ``multistorageclient.provider`` (always ``file``)
+        * ``multistorageclient.file.mode`` (e.g. ``rb``, ``wb``)
+        * Configured metric attributes (e.g. node and process)
+
+      * Timestamp:
+
+        * File Descriptor Release
+
+   ``multistorageclient.file_descriptor.open``
+      The number of currently open file descriptors owned by :py:class:`multistorageclient.file.PosixFile`.
+      A synchronous UpDownCounter adds one after the underlying file is opened successfully and subtracts one
+      after it is released by ``close()`` or ``discard()``.
+
+      * Operations:
+
+        * POSIX file descriptor open and release
+
+      * Metric data point:
+
+        * Non-monotonic Sum (UpDownCounter)
+
+      * Unit:
+
+        * File descriptors (``{file_descriptor}``)
+
+      * Attributes:
+
+        * ``multistorageclient.version``
+        * ``multistorageclient.provider`` (always ``file``)
+        * ``multistorageclient.file.mode`` (e.g. ``rb``, ``wb``)
+        * Configured metric attributes (e.g. node and process)
+
+      The increment and decrement for a file descriptor use identical attributes. File paths are not included.
+
    ``multistorageclient.data_size``
       The data (object/file) size for an operation.
 

--- a/multi-storage-client/src/multistorageclient/file.py
+++ b/multi-storage-client/src/multistorageclient/file.py
@@ -21,8 +21,9 @@ import logging
 import os
 import tempfile
 import threading
+import time
 import types
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from io import BytesIO, IOBase, StringIO
 from typing import IO, TYPE_CHECKING, Any, cast
 
@@ -655,7 +656,6 @@ class PosixFile(IOBase, IO):
         atomic: bool = True,
         attributes: dict[str, Any] | None = None,
     ):
-        # Store storage_client for emitting metrics
         self._storage_client = storage_client
 
         # If metadata provider is enabled, resolve the logical path to physical path.
@@ -668,7 +668,8 @@ class PosixFile(IOBase, IO):
             realpath = path
 
         # Required to get the absolute POSIX path.
-        self._real_path = cast(BaseStorageProvider, storage_client._storage_provider)._prepend_base_path(realpath)
+        storage_provider = cast(BaseStorageProvider, storage_client._storage_provider)
+        self._real_path = storage_provider._prepend_base_path(realpath)
 
         self._path = path
         self._mode = mode
@@ -686,6 +687,13 @@ class PosixFile(IOBase, IO):
             self._file = open(self._temp_path, mode=mode, buffering=buffering, encoding=encoding)  # noqa: SIM115
         else:
             self._file = open(self._real_path, mode=mode, buffering=buffering, encoding=encoding)  # noqa: SIM115
+
+        self._file_descriptor_open_time = time.perf_counter()
+        self._file_descriptor_close_callback: Callable[[float], None] | None = None
+        try:
+            self._file_descriptor_close_callback = storage_provider._record_file_descriptor_open(mode=self._mode)
+        except Exception as error:
+            logger.warning("Failed to initialize file descriptor metrics: %s", error, exc_info=True)
 
         self._attributes = attributes
 
@@ -784,7 +792,11 @@ class PosixFile(IOBase, IO):
         if self.closed:
             return
 
-        self._file.close()
+        try:
+            self._file.close()
+        finally:
+            if self._file.closed:
+                self._record_file_descriptor_release()
 
         if self._atomic and "w" in self._mode:
             # Rename the temporary file to the target file
@@ -813,5 +825,19 @@ class PosixFile(IOBase, IO):
             return
 
         if self._atomic and "w" in self._mode:
-            self._file.close()
+            try:
+                self._file.close()
+            finally:
+                if self._file.closed:
+                    self._record_file_descriptor_release()
             os.unlink(self._temp_path)
+
+    def _record_file_descriptor_release(self) -> None:
+        if self._file_descriptor_close_callback is None:
+            return
+
+        duration = time.perf_counter() - self._file_descriptor_open_time
+        try:
+            self._file_descriptor_close_callback(duration)
+        except Exception as error:
+            logger.warning("Failed to finalize file descriptor metrics: %s", error, exc_info=True)

--- a/multi-storage-client/src/multistorageclient/providers/base.py
+++ b/multi-storage-client/src/multistorageclient/providers/base.py
@@ -26,6 +26,7 @@ from abc import abstractmethod
 from collections.abc import Callable, Iterator, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from enum import Enum
+from functools import partial
 from typing import IO, Any, ClassVar, NamedTuple, TypeVar, cast
 
 import opentelemetry.metrics as api_metrics
@@ -182,6 +183,7 @@ class BaseStorageProvider(StorageProvider):
         PROVIDER = "multistorageclient.provider"
         OPERATION = "multistorageclient.operation"
         STATUS = "multistorageclient.status"
+        FILE_MODE = "multistorageclient.file.mode"
 
     class _Operation(Enum):
         READ = "read"
@@ -212,6 +214,7 @@ class BaseStorageProvider(StorageProvider):
     _metric_init_event: threading.Event
     _metric_gauges: dict[Telemetry.GaugeName, api_metrics._Gauge | None]
     _metric_counters: dict[Telemetry.CounterName, api_metrics.Counter | None]
+    _metric_up_down_counters: dict[Telemetry.UpDownCounterName, api_metrics.UpDownCounter | None]
     _metric_attributes_providers: Sequence[AttributesProvider]
     _metric_init_lock: threading.Lock
 
@@ -232,6 +235,7 @@ class BaseStorageProvider(StorageProvider):
         self._metric_init_event = threading.Event()
         self._metric_gauges = {}
         self._metric_counters = {}
+        self._metric_up_down_counters = {}
         self._metric_attributes_providers = ()
         self._metric_init_lock = threading.Lock()
 
@@ -279,6 +283,10 @@ class BaseStorageProvider(StorageProvider):
                                     self._metric_gauges[name] = telemetry.gauge(config=metrics_config, name=name)
                                 for name in Telemetry.CounterName:
                                     self._metric_counters[name] = telemetry.counter(config=metrics_config, name=name)
+                                for name in Telemetry.UpDownCounterName:
+                                    self._metric_up_down_counters[name] = telemetry.up_down_counter(
+                                        config=metrics_config, name=name
+                                    )
 
                                 attributes_provider_configs: list[dict[str, Any]] | None = metrics_config.get(
                                     "attributes"
@@ -406,6 +414,55 @@ class BaseStorageProvider(StorageProvider):
             BaseStorageProvider._AttributeName.PROVIDER.value: self._provider_name,
             BaseStorageProvider._AttributeName.OPERATION.value: operation.value,
         }
+
+    def _record_file_descriptor_open(self, mode: str) -> Callable[[float], None]:
+        """Record a successfully opened POSIX file descriptor without affecting file operations."""
+        attributes: api_types.Attributes = {
+            BaseStorageProvider._AttributeName.VERSION.value: self._VERSION,
+            BaseStorageProvider._AttributeName.PROVIDER.value: self._provider_name,
+            BaseStorageProvider._AttributeName.FILE_MODE.value: mode,
+        }
+        open_counter: api_metrics.UpDownCounter | None = None
+        try:
+            if not self._metric_init_event.is_set():
+                self._init_metrics()
+
+            attributes = {
+                **(collect_attributes(attributes_providers=self._metric_attributes_providers) or {}),
+                **attributes,
+            }
+            metric = self._metric_up_down_counters.get(Telemetry.UpDownCounterName.FILE_DESCRIPTOR_OPEN)
+            if metric is not None:
+                metric.add(1, attributes=attributes)
+                open_counter = metric
+        except Exception as error:
+            logger.warning("Failed to record open file descriptor metric: %s", error, exc_info=True)
+
+        return partial(
+            self._record_file_descriptor_close,
+            attributes=attributes,
+            open_counter=open_counter,
+        )
+
+    def _record_file_descriptor_close(
+        self,
+        duration: float,
+        attributes: api_types.Attributes,
+        open_counter: api_metrics.UpDownCounter | None,
+    ) -> None:
+        """Record a released POSIX file descriptor without affecting file operations."""
+        if open_counter is not None:
+            try:
+                open_counter.add(-1, attributes=attributes)
+            except Exception as error:
+                logger.warning("Failed to record closed file descriptor metric: %s", error, exc_info=True)
+
+        try:
+            metric_duration = self._metric_gauges.get(Telemetry.GaugeName.FILE_DESCRIPTOR_DURATION)
+            if metric_duration is not None:
+                metric_duration.set(duration, attributes=attributes)
+        except Exception as error:
+            logger.warning("Failed to record file descriptor duration metric: %s", error, exc_info=True)
 
     def _build_status_attributes(
         self, base_attributes: api_types.Attributes, error_type: str | None

--- a/multi-storage-client/src/multistorageclient/telemetry/__init__.py
+++ b/multi-storage-client/src/multistorageclient/telemetry/__init__.py
@@ -86,6 +86,7 @@ class Telemetry:
         LATENCY = "multistorageclient.latency"
         DATA_SIZE = "multistorageclient.data_size"
         DATA_RATE = "multistorageclient.data_rate"
+        FILE_DESCRIPTOR_DURATION = "multistorageclient.file_descriptor.duration"
 
     # https://opentelemetry.io/docs/specs/semconv/general/metrics#units
     _GAUGE_UNIT_MAPPING: ClassVar[dict[GaugeName, str]] = {
@@ -95,6 +96,8 @@ class Telemetry:
         GaugeName.DATA_SIZE: "By",
         # Bytes/second.
         GaugeName.DATA_RATE: "By/s",
+        # Seconds.
+        GaugeName.FILE_DESCRIPTOR_DURATION: "s",
     }
 
     # https://opentelemetry.io/docs/specs/semconv/general/naming#metrics
@@ -113,6 +116,15 @@ class Telemetry:
         CounterName.DATA_SIZE_SUM: "By",
     }
 
+    # https://opentelemetry.io/docs/specs/semconv/general/naming#metrics
+    class UpDownCounterName(enum.Enum):
+        FILE_DESCRIPTOR_OPEN = "multistorageclient.file_descriptor.open"
+
+    # https://opentelemetry.io/docs/specs/semconv/general/metrics#units
+    _UP_DOWN_COUNTER_UNIT_MAPPING: ClassVar[dict[UpDownCounterName, str]] = {
+        UpDownCounterName.FILE_DESCRIPTOR_OPEN: "{file_descriptor}",
+    }
+
     # Map of config as a sorted JSON string (since dictionaries can't be hashed) to meter provider.
     _meter_provider_cache: dict[str, api_metrics.MeterProvider]
     _meter_provider_cache_lock: threading.Lock
@@ -125,6 +137,9 @@ class Telemetry:
     # Map of config as a sorted JSON string (since dictionaries can't be hashed) to counter name to counter.
     _counter_cache: dict[str, dict[CounterName, api_metrics.Counter]]
     _counter_cache_lock: threading.Lock
+    # Map of config as a sorted JSON string (since dictionaries can't be hashed) to up-down counter name to counter.
+    _up_down_counter_cache: dict[str, dict[UpDownCounterName, api_metrics.UpDownCounter]]
+    _up_down_counter_cache_lock: threading.Lock
     # Map of config as a sorted JSON string (since dictionaries can't be hashed) to tracer provider.
     _tracer_provider_cache: dict[str, api_trace.TracerProvider]
     _tracer_provider_cache_lock: threading.Lock
@@ -141,6 +156,8 @@ class Telemetry:
         self._gauge_cache_lock = threading.Lock()
         self._counter_cache = {}
         self._counter_cache_lock = threading.Lock()
+        self._up_down_counter_cache = {}
+        self._up_down_counter_cache_lock = threading.Lock()
         self._tracer_provider_cache = {}
         self._tracer_provider_cache_lock = threading.Lock()
         self._tracer_cache = {}
@@ -157,6 +174,7 @@ class Telemetry:
         self._meter_cache_lock = threading.Lock()
         self._gauge_cache_lock = threading.Lock()
         self._counter_cache_lock = threading.Lock()
+        self._up_down_counter_cache_lock = threading.Lock()
         self._tracer_provider_cache_lock = threading.Lock()
         self._tracer_cache_lock = threading.Lock()
 
@@ -263,6 +281,31 @@ class Telemetry:
                         name,
                         meter.create_counter(name=name.value, unit=Telemetry._COUNTER_UNIT_MAPPING.get(name, "")),
                     )
+
+    def up_down_counter(self, config: dict[str, Any], name: UpDownCounterName) -> api_metrics.UpDownCounter | None:
+        """
+        Create or return an existing :py:class:`api_metrics.UpDownCounter` for a config and counter name.
+
+        :param config: ``.opentelemetry.metrics`` config dict.
+        :param name: Up-down counter name.
+        :return: A :py:class:`api_metrics.UpDownCounter` or ``None`` if no valid exporter is configured.
+        """
+        config_json = json.dumps(config, sort_keys=True)
+        with self._up_down_counter_cache_lock:
+            if config_json in self._up_down_counter_cache and name in self._up_down_counter_cache[config_json]:
+                return self._up_down_counter_cache[config_json][name]
+
+            meter = self.meter(config=config)
+            if meter is None:
+                return None
+
+            return self._up_down_counter_cache.setdefault(config_json, {}).setdefault(
+                name,
+                meter.create_up_down_counter(
+                    name=name.value,
+                    unit=Telemetry._UP_DOWN_COUNTER_UNIT_MAPPING.get(name, ""),
+                ),
+            )
 
     def tracer_provider(self, config: dict[str, Any]) -> api_trace.TracerProvider | None:
         """
@@ -448,10 +491,19 @@ TelemetryManager.register(
     ],
 )
 TelemetryManager.register(
+    typeid=_fully_qualified_name(api_metrics.UpDownCounter),
+    exposed=[
+        name
+        for name, _ in inspect.getmembers(api_metrics.UpDownCounter, predicate=inspect.isfunction)
+        if not name.startswith("_")
+    ],
+)
+TelemetryManager.register(
     typeid=_fully_qualified_name(api_metrics.Meter),
     method_to_typeid={
         api_metrics.Meter.create_gauge.__name__: _fully_qualified_name(api_metrics._Gauge),
         api_metrics.Meter.create_counter.__name__: _fully_qualified_name(api_metrics.Counter),
+        api_metrics.Meter.create_up_down_counter.__name__: _fully_qualified_name(api_metrics.UpDownCounter),
     },
 )
 TelemetryManager.register(
@@ -497,6 +549,7 @@ TelemetryManager.register(
         Telemetry.meter.__name__: _fully_qualified_name(api_metrics.Meter),
         Telemetry.gauge.__name__: _fully_qualified_name(api_metrics._Gauge),
         Telemetry.counter.__name__: _fully_qualified_name(api_metrics.Counter),
+        Telemetry.up_down_counter.__name__: _fully_qualified_name(api_metrics.UpDownCounter),
         Telemetry.tracer_provider.__name__: _fully_qualified_name(api_trace.TracerProvider),
         Telemetry.tracer.__name__: _fully_qualified_name(api_trace.Tracer),
     },

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_file.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_file.py
@@ -16,13 +16,45 @@
 import functools
 import mmap
 import os
+from unittest.mock import Mock, patch
 
 import pytest
 
 from multistorageclient import StorageClient, StorageClientConfig, telemetry
-from multistorageclient.file import PosixFile
+from multistorageclient.file import ObjectFile, PosixFile, RemoteFileReader
+from multistorageclient.providers.base import BaseStorageProvider
 from test_multistorageclient.unit.utils import tempdatastore
 from test_multistorageclient.unit.utils.telemetry.metrics.export import InMemoryMetricExporter
+
+
+def _posix_client_with_file_descriptor_metrics(tmp_path):
+    duration_gauge = Mock()
+    open_counter = Mock()
+    telemetry_provider = Mock(spec=telemetry.Telemetry)
+    telemetry_provider.gauge.side_effect = lambda config, name: (
+        duration_gauge if name is telemetry.Telemetry.GaugeName.FILE_DESCRIPTOR_DURATION else Mock()
+    )
+    telemetry_provider.counter.return_value = Mock()
+    telemetry_provider.up_down_counter.return_value = open_counter
+
+    profile = "data"
+    config = StorageClientConfig.from_dict(
+        config_dict={
+            "profiles": {profile: {"storage_provider": {"type": "file", "options": {"base_path": str(tmp_path)}}}},
+            "opentelemetry": {
+                "metrics": {
+                    "attributes": [
+                        {"type": "host", "options": {"attributes": {"node": "name"}}},
+                        {"type": "process", "options": {"attributes": {"process": "pid"}}},
+                    ],
+                    "exporter": {"type": "console"},
+                }
+            },
+        },
+        profile=profile,
+        telemetry_provider=lambda: telemetry_provider,
+    )
+    return StorageClient(config=config), duration_gauge, open_counter
 
 
 @pytest.mark.parametrize(
@@ -239,3 +271,133 @@ def test_file_read_does_not_create_parent_dirs(temp_data_store_type: type[tempda
             f.read()
 
         assert not os.path.exists(full_dir_path)
+
+
+def test_posix_file_descriptor_metrics_context_manager_and_attributes(tmp_path):
+    storage_client, duration_gauge, open_counter = _posix_client_with_file_descriptor_metrics(tmp_path)
+
+    with storage_client.open("file.txt", "wb") as file:
+        assert isinstance(file, PosixFile)
+        assert [metric_call.args[0] for metric_call in open_counter.add.call_args_list] == [1]
+
+    assert [metric_call.args[0] for metric_call in open_counter.add.call_args_list] == [1, -1]
+    assert sum(metric_call.args[0] for metric_call in open_counter.add.call_args_list) == 0
+    assert duration_gauge.set.call_count == 1
+
+    opened_attributes = open_counter.add.call_args_list[0].kwargs["attributes"]
+    closed_attributes = open_counter.add.call_args_list[1].kwargs["attributes"]
+    duration_attributes = duration_gauge.set.call_args.kwargs["attributes"]
+    assert opened_attributes is closed_attributes
+    assert opened_attributes is duration_attributes
+    assert opened_attributes["multistorageclient.provider"] == "file"
+    assert opened_attributes["multistorageclient.file.mode"] == "wb"
+    assert "multistorageclient.version" in opened_attributes
+    assert "node" in opened_attributes
+    assert "process" in opened_attributes
+    assert all("path" not in key for key in opened_attributes)
+
+
+def test_posix_file_descriptor_metrics_explicit_close_only_records_once(tmp_path):
+    storage_client, duration_gauge, open_counter = _posix_client_with_file_descriptor_metrics(tmp_path)
+
+    file = storage_client.open("file.txt", "wb")
+    file.close()
+    file.close()
+    file.discard()
+
+    assert [metric_call.args[0] for metric_call in open_counter.add.call_args_list] == [1, -1]
+    assert duration_gauge.set.call_count == 1
+
+
+def test_posix_file_descriptor_metrics_discard_only_records_once(tmp_path):
+    storage_client, duration_gauge, open_counter = _posix_client_with_file_descriptor_metrics(tmp_path)
+
+    file = storage_client.open("file.txt", "wb")
+    file.write(b"discarded")
+    file.discard()
+    file.discard()
+    file.close()
+
+    assert [metric_call.args[0] for metric_call in open_counter.add.call_args_list] == [1, -1]
+    assert duration_gauge.set.call_count == 1
+    assert not (tmp_path / "file.txt").exists()
+
+
+def test_posix_file_descriptor_metrics_open_failure_does_not_increment_counter(tmp_path):
+    storage_client, duration_gauge, open_counter = _posix_client_with_file_descriptor_metrics(tmp_path)
+
+    with pytest.raises(FileNotFoundError):
+        storage_client.open("missing.txt", "rb")
+
+    open_counter.add.assert_not_called()
+    duration_gauge.set.assert_not_called()
+
+
+def test_posix_file_descriptor_counter_increment_failure_does_not_decrement(tmp_path):
+    storage_client, duration_gauge, open_counter = _posix_client_with_file_descriptor_metrics(tmp_path)
+    open_counter.add.side_effect = RuntimeError("counter unavailable")
+
+    with storage_client.open("file.txt", "wb") as file:
+        file.write(b"content")
+
+    assert file.closed
+    assert [metric_call.args[0] for metric_call in open_counter.add.call_args_list] == [1]
+    assert duration_gauge.set.call_count == 1
+
+
+def test_posix_file_descriptor_duration_excludes_atomic_rename(tmp_path):
+    storage_client, duration_gauge, _ = _posix_client_with_file_descriptor_metrics(tmp_path)
+    clock = [10.0]
+    real_rename = os.rename
+
+    def delayed_rename(source, destination):
+        clock[0] = 100.0
+        real_rename(source, destination)
+
+    with (
+        patch("multistorageclient.file.time.perf_counter", side_effect=lambda: clock[0]),
+        patch("multistorageclient.file.os.rename", side_effect=delayed_rename),
+    ):
+        file = storage_client.open("file.txt", "wb")
+        clock[0] = 14.0
+        file.close()
+
+    assert duration_gauge.set.call_args.args[0] == 4.0
+    assert clock[0] == 100.0
+
+
+def test_non_posix_files_do_not_record_file_descriptor_metrics():
+    provider = Mock(spec=BaseStorageProvider)
+    storage_client = Mock()
+    storage_client._storage_provider = provider
+    storage_client._cache_manager = None
+
+    object_file = ObjectFile(storage_client=storage_client, remote_path="object", mode="wb")
+    object_file.close()
+
+    remote_file = RemoteFileReader(remote_path="remote", file_size=0, storage_client=storage_client)
+    remote_file.fileno()
+    remote_file.close()
+
+    provider._record_file_descriptor_open.assert_not_called()
+    provider._record_file_descriptor_close.assert_not_called()
+
+
+def test_posix_file_descriptor_telemetry_failures_do_not_affect_file_lifecycle(tmp_path):
+    storage_client, _, _ = _posix_client_with_file_descriptor_metrics(tmp_path)
+    provider = storage_client._storage_provider
+
+    with patch.object(provider, "_record_file_descriptor_open", side_effect=RuntimeError("open telemetry failed")):
+        file = storage_client.open("file.txt", "wb")
+        file.write(b"content")
+        file.close()
+
+    with patch.object(provider, "_record_file_descriptor_close", side_effect=RuntimeError("close telemetry failed")):
+        another_file = storage_client.open("another-file.txt", "wb")
+        another_file.write(b"other content")
+        another_file.close()
+
+    assert file.closed
+    assert another_file.closed
+    assert (tmp_path / "file.txt").read_bytes() == b"content"
+    assert (tmp_path / "another-file.txt").read_bytes() == b"other content"

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_telemetry.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_telemetry.py
@@ -21,7 +21,7 @@ from typing import Any
 import psutil
 import pytest
 from opentelemetry.context import get_current
-from opentelemetry.metrics import Counter, Meter, MeterProvider, _Gauge
+from opentelemetry.metrics import Counter, Meter, MeterProvider, UpDownCounter, _Gauge
 from opentelemetry.trace import Span, Tracer, TracerProvider, use_span
 
 from multistorageclient import telemetry
@@ -41,6 +41,7 @@ def test_telemetry_init_local() -> None:
     meter_str: str | None = None
     gauge_str: str | None = None
     counter_str: str | None = None
+    up_down_counter_str: str | None = None
     tracer_provider_str: str | None = None
     tracer_str: str | None = None
 
@@ -98,6 +99,21 @@ def test_telemetry_init_local() -> None:
             assert counter_str == str(counter)
 
         counter.add(1)
+
+        up_down_counter: UpDownCounter | None = telemetry_resources.up_down_counter(
+            config=opentelemetry_config["metrics"],
+            name=telemetry.Telemetry.UpDownCounterName.FILE_DESCRIPTOR_OPEN,
+        )
+        assert up_down_counter is not None
+        assert not isinstance(up_down_counter, BaseProxy)
+
+        if up_down_counter_str is None:
+            up_down_counter_str = str(up_down_counter)
+        else:
+            assert up_down_counter_str == str(up_down_counter)
+
+        up_down_counter.add(1)
+        up_down_counter.add(-1)
 
         tracer_provider: TracerProvider | None = telemetry_resources.tracer_provider(opentelemetry_config["traces"])
         assert tracer_provider is not None
@@ -321,14 +337,42 @@ def test_metric_instrument_proxies_expose_mutating_methods() -> None:
     registry = telemetry.TelemetryManager._registry  # pyright: ignore [reportAttributeAccessIssue]
     counter_exposed = registry[telemetry._fully_qualified_name(Counter)][1]
     gauge_exposed = registry[telemetry._fully_qualified_name(_Gauge)][1]
+    up_down_counter_exposed = registry[telemetry._fully_qualified_name(UpDownCounter)][1]
 
     assert counter_exposed is not None and "add" in counter_exposed
     assert gauge_exposed is not None and "set" in gauge_exposed
+    assert up_down_counter_exposed is not None and "add" in up_down_counter_exposed
 
     # The constructor must stay unexposed: an exposed ``__init__`` would override
     # ``BaseProxy.__init__`` and break proxy construction.
     assert "__init__" not in counter_exposed
     assert "__init__" not in gauge_exposed
+    assert "__init__" not in up_down_counter_exposed
+
+
+def test_file_descriptor_metric_names_and_units() -> None:
+    duration_name = telemetry.Telemetry.GaugeName.FILE_DESCRIPTOR_DURATION
+    open_name = telemetry.Telemetry.UpDownCounterName.FILE_DESCRIPTOR_OPEN
+
+    assert duration_name.value == "multistorageclient.file_descriptor.duration"
+    assert telemetry.Telemetry._GAUGE_UNIT_MAPPING[duration_name] == "s"
+    assert open_name.value == "multistorageclient.file_descriptor.open"
+    assert telemetry.Telemetry._UP_DOWN_COUNTER_UNIT_MAPPING[open_name] == "{file_descriptor}"
+
+
+def test_up_down_counter_manager_proxy() -> None:
+    opentelemetry_config = {"metrics": {"exporter": {"type": telemetry._fully_qualified_name(InMemoryMetricExporter)}}}
+    telemetry_resources = telemetry.init(mode=telemetry.TelemetryMode.SERVER)
+
+    up_down_counter = telemetry_resources.up_down_counter(
+        config=opentelemetry_config["metrics"],
+        name=telemetry.Telemetry.UpDownCounterName.FILE_DESCRIPTOR_OPEN,
+    )
+
+    assert up_down_counter is not None
+    assert isinstance(up_down_counter, BaseProxy)
+    up_down_counter.add(1)
+    up_down_counter.add(-1)
 
 
 def _test_telemetry_init_automatic() -> None:


### PR DESCRIPTION
## Description

Add OpenTelemetry metrics for tracking file descriptor usage by `PosixFile`:

- `multistorageclient.file_descriptor.duration`
  - Records how long the underlying file descriptor remains open.
  - Emitted when `close()` or `discard()` releases the descriptor.
  - Excludes `open()` latency and post-close operations such as rename, xattr updates, and unlink.
- `multistorageclient.file_descriptor.open`
  - Uses a synchronous UpDownCounter to track currently open descriptors.
  - Increments after a successful open and decrements after release.

Both metrics use the same low-cardinality attributes, including provider, file mode, version, and configured node/process attributes. File paths are intentionally excluded.

Telemetry initialization and recording failures are isolated from normal file operations. `ObjectFile` and `RemoteFileReader` do not emit these metrics.

Unit tests cover context managers, explicit close, discard, duplicate close/discard calls, open failures, counter balancing, duration boundaries, attribute consistency, telemetry failures, and non-POSIX file types.

Closes NGCDP-9797

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added telemetry for POSIX file descriptors, tracking currently open descriptors and descriptor lifetime.
  * Metrics include operation context, units, timestamps, and file mode attributes.
  * Descriptor metrics remain accurate across close, discard, failed opens, and atomic rename operations.

* **Documentation**
  * Documented the new file-descriptor telemetry metrics and recording behavior.

* **Bug Fixes**
  * Telemetry errors no longer interrupt normal file operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->