### PR TITLE
fix(file): honor the requested mode and encoding on cached opens

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -5,3 +5,4 @@
 ## New Features
 
 ## Bug Fixes
+- `open(path, "r", encoding=...)` with caching enabled now honors the requested mode and encoding when the object is served from the cache; the cache-first fast path previously opened the cached file in binary mode (so `read()` returned `bytes`), and cached text opens ignored a non-default `encoding`.

--- a/multi-storage-client/src/multistorageclient/cache.py
+++ b/multi-storage-client/src/multistorageclient/cache.py
@@ -309,14 +309,18 @@ class CacheManager:
         mode: str = "rb",
         source_version: str | None = None,
         check_source_version: SourceVersionCheckMode = SourceVersionCheckMode.INHERIT,
+        encoding: str | None = None,
     ) -> Any | None:
-        """Open a file from the cache and return the file object."""
+        """Open a file from the cache and return the file object.
+
+        :param encoding: Text encoding used for text modes; must be ``None`` for binary modes.
+        """
         try:
             if self.contains(key=key, check_source_version=check_source_version, source_version=source_version):
                 file_path = self._get_cache_file_path(key)
                 # Update access time based on eviction policy
                 self._update_access_time(file_path)
-                return open(file_path, mode)
+                return open(file_path, mode, encoding=encoding)
         except OSError:
             pass
 

--- a/multi-storage-client/src/multistorageclient/file.py
+++ b/multi-storage-client/src/multistorageclient/file.py
@@ -275,7 +275,10 @@ class ObjectFile(IOBase, IO):
                 ):
                     # Cache hit with no version check - open directly from cache
                     cached_file = self._cache_manager.open(
-                        self._remote_path, mode="rb", check_source_version=SourceVersionCheckMode.DISABLE
+                        self._remote_path,
+                        mode=self._mode,
+                        check_source_version=SourceVersionCheckMode.DISABLE,
+                        encoding=self._text_encoding(),
                     )
                     if cached_file is not None:
                         self._file = cached_file
@@ -330,6 +333,10 @@ class ObjectFile(IOBase, IO):
 
         self._open_files.append(self._file)
 
+    def _text_encoding(self) -> str | None:
+        # open() rejects a non-None encoding for binary modes.
+        return self._encoding if "b" not in self._mode else None
+
     def _download_file(self) -> None:
         """
         Download the file to the cache directory.
@@ -363,7 +370,11 @@ class ObjectFile(IOBase, IO):
             ):
                 # Read from cache
                 file_object = self._cache_manager.open(
-                    self._remote_path, self._mode, source_version, self._check_source_version
+                    self._remote_path,
+                    self._mode,
+                    source_version,
+                    self._check_source_version,
+                    encoding=self._text_encoding(),
                 )
             else:
                 # Download file and put it into the cache
@@ -380,7 +391,11 @@ class ObjectFile(IOBase, IO):
                         self._cache_manager.set(self._remote_path, temp_file_path, source_version)
 
                 file_object = self._cache_manager.open(
-                    self._remote_path, self._mode, source_version, self._check_source_version
+                    self._remote_path,
+                    self._mode,
+                    source_version,
+                    self._check_source_version,
+                    encoding=self._text_encoding(),
                 )
             if file_object is None:
                 raise FileNotFoundError(f"Unexpected error, file not found at {self._remote_path}")

--- a/multi-storage-client/src/multistorageclient/file.py
+++ b/multi-storage-client/src/multistorageclient/file.py
@@ -334,7 +334,12 @@ class ObjectFile(IOBase, IO):
         self._open_files.append(self._file)
 
     def _text_encoding(self) -> str | None:
-        # open() rejects a non-None encoding for binary modes.
+        """
+        Return the encoding to pass to the builtin ``open`` for the file's mode.
+
+        :return: The configured encoding for text modes, or ``None`` for binary modes
+            (``open`` rejects a non-``None`` encoding for binary modes).
+        """
         return self._encoding if "b" not in self._mode else None
 
     def _download_file(self) -> None:

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_cache.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_cache.py
@@ -31,6 +31,7 @@ from multistorageclient.caching.cache_config import (
     CacheConfig,
     EvictionPolicyConfig,
 )
+from multistorageclient.client.single import SingleStorageClient
 from multistorageclient.config import StorageClientConfig
 from multistorageclient.types import Range, SourceVersionCheckMode
 from test_multistorageclient.unit.utils import tempdatastore
@@ -1404,3 +1405,59 @@ def test_cache_first_no_head_request_on_hit(temp_data_store_type, tmpdir):
         assert head_call_count == 1, (
             f"No additional HEAD requests should be made for cache-first reads; expected 1 total, got {head_call_count}"
         )
+
+
+def test_cache_first_open_honors_text_mode(tmpdir):
+    """Opening a cached object in text mode must return str on a cache hit, not bytes."""
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
+        profile = "data"
+        config_dict = {
+            "profiles": {profile: temp_data_store.profile_config_dict() | {"caching_enabled": True}},
+            "cache": {
+                "size": "10M",
+                "cache_line_size": "1M",
+                "location": str(tmpdir),
+                "check_source_version": False,
+            },
+        }
+        storage_client = SingleStorageClient(config=StorageClientConfig.from_dict(config_dict, profile=profile))
+        storage_client.write("text.txt", b"hello\nworld\n")
+        # Exercise the ObjectFile cache path rather than the POSIX passthrough.
+        storage_client._is_posix_file_storage_provider = lambda: False  # type: ignore
+
+        # First open populates the cache, the second one takes the cache-first fast path.
+        for _ in range(2):
+            with storage_client.open("text.txt", mode="r") as f:
+                content = f.read()
+                assert isinstance(content, str)
+                assert content == "hello\nworld\n"
+            with storage_client.open("text.txt", mode="rb") as f:
+                assert f.read() == b"hello\nworld\n"
+
+        assert storage_client._cache_manager is not None
+        assert storage_client._cache_manager.contains("text.txt", check_source_version=SourceVersionCheckMode.DISABLE)
+
+
+def test_cached_text_open_honors_encoding(tmpdir):
+    """Cached opens in text mode must decode with the requested encoding on both cache miss and cache hit."""
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
+        profile = "data"
+        config_dict = {
+            "profiles": {profile: temp_data_store.profile_config_dict() | {"caching_enabled": True}},
+            "cache": {
+                "size": "10M",
+                "cache_line_size": "1M",
+                "location": str(tmpdir),
+                "check_source_version": False,
+            },
+        }
+        storage_client = SingleStorageClient(config=StorageClientConfig.from_dict(config_dict, profile=profile))
+        text = "h\u00e9llo w\u00f6rld\n"
+        storage_client.write("latin1.txt", text.encode("latin-1"))
+        # Exercise the ObjectFile cache path rather than the POSIX passthrough.
+        storage_client._is_posix_file_storage_provider = lambda: False  # type: ignore
+
+        # First open is a cache miss, the second one takes the cache-first fast path.
+        for _ in range(2):
+            with storage_client.open("latin1.txt", mode="r", encoding="latin-1") as f:
+                assert f.read() == text


### PR DESCRIPTION
## Description

The cache-hit branch of `ObjectFile.__init__` hard-coded `mode="rb"`, so
with `check_source_version` disabled the first `open(path, "r")` (cache
miss) yielded `str` while every subsequent open of the same object yielded
`bytes`. Pass the requested mode, as the cache-miss path already does.

In addition, `CacheManager.open` always opened cached text files with the
locale default encoding, so a non-default `encoding=` passed to
`ObjectFile` was ignored whenever the content came from the cache (both
on the fast path and after a download). Thread the encoding through.

Release note: `open(path, "r", encoding=...)` with caching enabled now honors the requested mode and encoding when the object is served from the cache; the cache-first fast path previously opened the cached file in binary mode (so `read()` returned `bytes`), and cached text opens ignored a non-default `encoding`.

_Found during a review of the commit history; no tracked issue._

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.

## Testing

Regression tests added/extended:
- `multi-storage-client/tests/test_multistorageclient/unit/test_cache.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cached file reads to preserve text or binary mode correctly.
  * Ensured requested text encodings are respected when opening cached files.
  * Improved handling of cache misses and download errors during file reads.
  * Prevented failures when an incomplete download does not produce a usable file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->