### PR TITLE
fix(azure): include the response body in batch-delete errors

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -17,4 +17,5 @@
 
 - Ingest MSFS manifests on writable mounts. Ingest previously ran only for read-only backends, so a writable manifest-backed mount appended delta records that nothing replayed and lost every mutation on remount. Only manifest generation, which lists the entire namespace, still requires a read-only backend.
 - Replay MSFS delta records for directories that have no base manifest part. Ingest walked only enumerated base TSVs, so a directory first written after manifest generation was never visited and its delta records were dropped.
+- Azure batch-delete failures now include the response body in the raised error instead of a bound-method repr.
 - Declare the record method explicitly on the cross-process `Counter`/`Gauge` telemetry proxies (derived from each instrument class's public methods). Proxy generation no longer depends on the installed OpenTelemetry's instrument shape, fixing `AttributeError: 'AutoProxy[opentelemetry.metrics.Counter]' object has no attribute 'add'` under OpenTelemetry version skew.

--- a/multi-storage-client/src/multistorageclient/providers/azure.py
+++ b/multi-storage-client/src/multistorageclient/providers/azure.py
@@ -497,7 +497,7 @@ class AzureBlobStorageProvider(BaseStorageProvider):
                         if 200 <= status_code < 300 or status_code == 404:
                             continue
                         raise RuntimeError(
-                            f"Azure batch delete failed with status_code: {status_code}, response: {response.text}"
+                            f"Azure batch delete failed with status_code: {status_code}, response: {response.text()}"
                         )
 
         container_desc = "(" + "|".join(by_container) + ")"

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_azure_batch_delete.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_azure_batch_delete.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from multistorageclient.providers.azure import AzureBlobStorageProvider
+
+
+@pytest.fixture
+def azure_provider():
+    with patch.object(AzureBlobStorageProvider, "_create_blob_service_client", return_value=MagicMock()):
+        yield AzureBlobStorageProvider(endpoint_url="https://account.blob.core.windows.net", base_path="container")
+
+
+def test_batch_delete_error_includes_response_body(azure_provider):
+    """Batch sub-responses expose text() as a method; the error must carry the body, not a bound-method repr."""
+    container_client = azure_provider._blob_service_client.get_container_client.return_value
+    # Use a plain object rather than a Mock so that a bare attribute access cannot mask the bug.
+    container_client.delete_blobs.return_value = [
+        SimpleNamespace(status_code=202, text=lambda: ""),
+        SimpleNamespace(status_code=500, text=lambda: "internal server error body"),
+    ]
+
+    with pytest.raises(RuntimeError, match="status_code: 500, response: internal server error body"):
+        azure_provider._delete_objects(["container/a.txt", "container/b.txt"])
+
+    container_client.delete_blobs.assert_called_once_with("a.txt", "b.txt", raise_on_any_failure=False)
+
+
+def test_batch_delete_treats_missing_blobs_as_success(azure_provider):
+    container_client = azure_provider._blob_service_client.get_container_client.return_value
+    container_client.delete_blobs.return_value = [
+        SimpleNamespace(status_code=202, text=lambda: ""),
+        SimpleNamespace(status_code=404, text=lambda: "not found"),
+    ]
+
+    azure_provider._delete_objects(["container/a.txt", "container/missing.txt"])


### PR DESCRIPTION
## Description

`ContainerClient.delete_blobs` yields `azure.core` HTTP responses whose
`text` is a method, not a property (unlike `requests.Response` used by the
GCS batch path). The error message therefore read
`response: <bound method HttpResponse.text of ...>` and the real error body
was lost. Call `text()`.

Release note: Azure batch-delete failures now include the response body in the raised error instead of a bound-method repr.

_Found during a review of the commit history; no tracked issue._

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.

## Testing

Regression tests added/extended:
- `multi-storage-client/tests/test_multistorageclient/unit/providers/test_azure_batch_delete.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Azure batch-delete errors now display the response body, making failures easier to understand.
  - Attempts to delete blobs that are already missing are now treated as successful deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->