### PR TITLE
fix(azure): decode chunked StringIO downloads as UTF-8

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -23,3 +23,4 @@
 - Declare the record method explicitly on the cross-process `Counter`/`Gauge` telemetry proxies (derived from each instrument class's public methods). Proxy generation no longer depends on the installed OpenTelemetry's instrument shape, fixing `AttributeError: 'AutoProxy[opentelemetry.metrics.Counter]' object has no attribute 'add'` under OpenTelemetry version skew.
 - `MultiStoragePath.read_text()` now honors its `errors` argument (`"ignore"`, `"replace"`, ...) instead of always decoding strictly.
 - `msc ls` now shows the size of files whose provider reports no modification time (for example HuggingFace or AIStore); the size column was previously blanked for every row without a date.
+- Azure downloads of large objects into a `StringIO` now decode the staged content as UTF-8 regardless of the host locale, matching the small-object path and the upload encoding.

--- a/multi-storage-client/src/multistorageclient/providers/azure.py
+++ b/multi-storage-client/src/multistorageclient/providers/azure.py
@@ -880,7 +880,7 @@ class AzureBlobStorageProvider(BaseStorageProvider):
                         with tempfile.NamedTemporaryFile(mode="wb", delete=False, prefix=".") as tmp:
                             temp_file_path = tmp.name
                             stream.readinto(tmp)
-                        with open(temp_file_path, "r") as tmp_read:
+                        with open(temp_file_path, "r", encoding="utf-8") as tmp_read:
                             f.write(tmp_read.read())
                     finally:
                         if temp_file_path and os.path.exists(temp_file_path):

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_azure_download_text.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_azure_download_text.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import builtins
+import io
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from multistorageclient.providers.azure import AzureBlobStorageProvider
+from multistorageclient.types import ObjectMetadata
+
+TEXT = "h\u00e9llo w\u00f6rld \u2014 \u65e5\u672c\u8a9e\n"
+
+
+@pytest.fixture
+def azure_provider():
+    with patch.object(AzureBlobStorageProvider, "_create_blob_service_client", return_value=MagicMock()):
+        yield AzureBlobStorageProvider(endpoint_url="https://account.blob.core.windows.net", base_path="container")
+
+
+def test_large_stringio_download_decodes_as_utf8(azure_provider):
+    """The chunked StringIO download path must decode the staging file as UTF-8, like the small-object path."""
+    payload = TEXT.encode("utf-8")
+    azure_provider._multipart_threshold = 0  # force the chunked download path
+    stream = azure_provider._blob_service_client.get_blob_client.return_value.download_blob.return_value
+    stream.readinto.side_effect = lambda fp: fp.write(payload)
+    metadata = ObjectMetadata(
+        key="container/text.txt", content_length=len(payload), last_modified=datetime(2025, 1, 1, tzinfo=timezone.utc)
+    )
+
+    text_encodings: list[str | None] = []
+    real_open = builtins.open
+
+    def recording_open(file, mode="r", *args, **kwargs):
+        if "b" not in mode and "r" in mode:
+            text_encodings.append(kwargs.get("encoding"))
+        return real_open(file, mode, *args, **kwargs)
+
+    f = io.StringIO()
+    with patch("multistorageclient.providers.azure.open", recording_open, create=True):
+        assert azure_provider._download_file("container/text.txt", f, metadata) == len(payload)
+
+    assert f.getvalue() == TEXT
+    assert text_encodings == ["utf-8"]


### PR DESCRIPTION
## Description

The small-object branch decodes with `.decode("utf-8")` and uploads encode
with UTF-8, but the chunked (`> multipart_threshold`) StringIO branch
opened the staging file with the locale default encoding, so non-ASCII
text mis-decoded or raised `UnicodeDecodeError` on non-UTF-8 locales.

Release note: Azure downloads of large objects into a `StringIO` now decode the staged content as UTF-8 regardless of the host locale, matching the small-object path and the upload encoding.

_Found during a review of the commit history; no tracked issue._

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.

## Testing

Regression tests added/extended:
- `multi-storage-client/tests/test_multistorageclient/unit/providers/test_azure_download_text.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed large Azure downloads to decode text as UTF-8 consistently, regardless of the host system’s locale.
  - Improved reliability when downloading larger text files.
  - Improved Azure batch-delete error reporting by displaying the response body correctly.

- **Documentation**
  - Clarified that unsupported credential types for presigned URLs raise a `TypeError`.

- **Tests**
  - Added coverage verifying UTF-8 decoding and content integrity for chunked Azure downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->