### PR TITLE
fix(file): emit READ metrics once for PosixFile.readall()

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -15,6 +15,7 @@
 
 ## Bug Fixes
 
+- `PosixFile.readall()` no longer emits READ metrics twice (once for itself and once for the instrumented `read()` it delegated to).
 - Ingest MSFS manifests on writable mounts. Ingest previously ran only for read-only backends, so a writable manifest-backed mount appended delta records that nothing replayed and lost every mutation on remount. Only manifest generation, which lists the entire namespace, still requires a read-only backend.
 - Replay MSFS delta records for directories that have no base manifest part. Ingest walked only enumerated base TSVs, so a directory first written after manifest generation was never visited and its delta records were dropped.
 - Declare the record method explicitly on the cross-process `Counter`/`Gauge` telemetry proxies (derived from each instrument class's public methods). Proxy generation no longer depends on the installed OpenTelemetry's instrument shape, fixing `AttributeError: 'AutoProxy[opentelemetry.metrics.Counter]' object has no attribute 'add'` under OpenTelemetry version skew.

--- a/multi-storage-client/src/multistorageclient/file.py
+++ b/multi-storage-client/src/multistorageclient/file.py
@@ -782,7 +782,9 @@ class PosixFile(IOBase, IO):
 
     @file_metrics(operation=BaseStorageProvider._Operation.READ)
     def readall(self) -> Any:
-        return self.read(-1)
+        """Read and return all remaining data from the file."""
+        # Call the underlying file directly; going through the decorated read() would emit READ metrics twice.
+        return self._file.read(-1)
 
     def close(self) -> None:
         """

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_file.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_file.py
@@ -401,3 +401,24 @@ def test_posix_file_descriptor_telemetry_failures_do_not_affect_file_lifecycle(t
     assert another_file.closed
     assert (tmp_path / "file.txt").read_bytes() == b"content"
     assert (tmp_path / "another-file.txt").read_bytes() == b"other content"
+
+
+def test_posix_file_readall_emits_read_metrics_once(tmp_path):
+    """readall() is instrumented itself and must not also go through the instrumented read()."""
+    config = StorageClientConfig.from_dict(
+        {"profiles": {"data": {"storage_provider": {"type": "file", "options": {"base_path": str(tmp_path)}}}}},
+        profile="data",
+    )
+    storage_client = StorageClient(config)
+    storage_client.write("file.txt", b"content")
+    provider = storage_client._storage_provider
+    assert isinstance(provider, BaseStorageProvider)
+
+    with (
+        patch.object(provider, "_emit_metrics", wraps=provider._emit_metrics) as emit_metrics,
+        storage_client.open("file.txt", "rb") as f,
+    ):
+        assert isinstance(f, PosixFile)
+        emit_metrics.reset_mock()
+        assert f.readall() == b"content"
+        assert emit_metrics.call_count == 1


### PR DESCRIPTION
## Description

`readall` is decorated with `file_metrics` and delegated to the also
decorated `read(-1)`, recording two requests, two latencies and the payload
size twice per call. Read from the underlying file directly.

Release note: `PosixFile.readall()` no longer emits READ metrics twice (once for itself and once for the instrumented `read()` it delegated to).

_Found during a review of the commit history; no tracked issue._

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.

## Testing

Regression tests added/extended:
- `multi-storage-client/tests/test_multistorageclient/unit/test_file.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed POSIX file reads so `readall()` records read metrics only once, preventing duplicate telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->