### PR TITLE
fix(client): report base_path mtime for info("") on POSIX profiles

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -16,5 +16,6 @@
 ## Bug Fixes
 
 - Ingest MSFS manifests on writable mounts. Ingest previously ran only for read-only backends, so a writable manifest-backed mount appended delta records that nothing replayed and lost every mutation on remount. Only manifest generation, which lists the entire namespace, still requires a read-only backend.
+- `info("")` on a POSIX profile now reports the modification time of the profile's `base_path` instead of the process working directory.
 - Replay MSFS delta records for directories that have no base manifest part. Ingest walked only enumerated base TSVs, so a directory first written after manifest generation was never visited and its delta records were dropped.
 - Declare the record method explicitly on the cross-process `Counter`/`Gauge` telemetry proxies (derived from each instrument class's public methods). Proxy generation no longer depends on the installed OpenTelemetry's instrument shape, fixing `AttributeError: 'AutoProxy[opentelemetry.metrics.Counter]' object has no attribute 'add'` under OpenTelemetry version skew.

--- a/multi-storage-client/src/multistorageclient/client/single.py
+++ b/multi-storage-client/src/multistorageclient/client/single.py
@@ -490,7 +490,8 @@ class SingleStorageClient(AbstractStorageClient):
         """
         if not path or path == ".":  # empty path or '.' provided by the user
             if self._is_posix_file_storage_provider():
-                last_modified = datetime.fromtimestamp(os.path.getmtime("."), tz=timezone.utc)
+                root = cast(PosixFileStorageProvider, self._storage_provider)._prepend_base_path("")
+                last_modified = datetime.fromtimestamp(os.path.getmtime(root), tz=timezone.utc)
             else:
                 last_modified = AWARE_DATETIME_MIN
             return ObjectMetadata(key="", type="directory", content_length=0, last_modified=last_modified)

--- a/multi-storage-client/tests/test_multistorageclient/unit/client/test_client.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/client/test_client.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import inspect
+import os
 import pickle
 import threading
 from datetime import datetime, timezone
@@ -1006,3 +1007,24 @@ def test_composite_make_symlink_raises(multi_backend_config):
 
     with pytest.raises(NotImplementedError):
         client.make_symlink("link.txt", "target.txt")
+
+
+def test_single_info_root_reports_base_path_mtime(tmp_path, monkeypatch):
+    """info("") on a POSIX profile must report the base_path mtime, not the process CWD."""
+    base_path = tmp_path / "base"
+    base_path.mkdir()
+    os.utime(base_path, (0, 0))
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+
+    config = StorageClientConfig.from_dict(
+        {"profiles": {"data": {"storage_provider": {"type": "file", "options": {"base_path": str(base_path)}}}}},
+        profile="data",
+    )
+    client = SingleStorageClient(config)
+
+    for path in ("", "."):
+        metadata = client.info(path)
+        assert metadata.type == "directory"
+        assert metadata.last_modified.timestamp() == 0.0


### PR DESCRIPTION
## Description

The root-path branch of `SingleStorageClient.info` used
`os.path.getmtime(".")`, i.e. the interpreter's current working directory,
which is unrelated to the storage profile. Use the provider's base path,
matching the idiom already used by `get_posix_path`.

Release note: `info("")` on a POSIX profile now reports the modification time of the profile's `base_path` instead of the process working directory.

_Found during a review of the commit history; no tracked issue._

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.

## Testing

Regression tests added/extended:
- `multi-storage-client/tests/test_multistorageclient/unit/client/test_client.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected POSIX storage metadata reporting so `info("")` and `info(".")` return the configured base path’s modification time instead of the process working directory’s timestamp.
  - Preserved existing behavior for other storage providers.

- **Tests**
  - Added regression coverage for POSIX base path modification times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->