### PR TITLE
fix(azure): percent-encode the blob path in generated SAS URLs

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -23,3 +23,4 @@
 - Declare the record method explicitly on the cross-process `Counter`/`Gauge` telemetry proxies (derived from each instrument class's public methods). Proxy generation no longer depends on the installed OpenTelemetry's instrument shape, fixing `AttributeError: 'AutoProxy[opentelemetry.metrics.Counter]' object has no attribute 'add'` under OpenTelemetry version skew.
 - `MultiStoragePath.read_text()` now honors its `errors` argument (`"ignore"`, `"replace"`, ...) instead of always decoding strictly.
 - `msc ls` now shows the size of files whose provider reports no modification time (for example HuggingFace or AIStore); the size column was previously blanked for every row without a date.
+- Percent-encode the container and blob path in Azure presigned (SAS) URLs; blob names containing spaces, `#`, `+` or `%` previously produced URLs that were truncated or rejected.

--- a/multi-storage-client/src/multistorageclient/providers/azure.py
+++ b/multi-storage-client/src/multistorageclient/providers/azure.py
@@ -19,7 +19,7 @@ import tempfile
 from collections.abc import Callable, Iterator
 from datetime import datetime, timedelta, timezone
 from typing import IO, Any, TypeVar
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 from azure.core import MatchConditions
 from azure.core.exceptions import AzureError, HttpResponseError
@@ -153,7 +153,8 @@ class AzureURLSigner(URLSigner):
             sas_kwargs["user_delegation_key"] = self._user_delegation_key
 
         sas_token = generate_blob_sas(**sas_kwargs)
-        blob_url = f"{self._account_url}/{container_name}/{blob_name}"
+        # Percent-encode the path the same way BlobClient.url does; the SAS itself is signed over the raw names.
+        blob_url = f"{self._account_url}/{quote(container_name)}/{quote(blob_name, safe='~/')}"
         return f"{blob_url}?{sas_token}"
 
 

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_presigned_url.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_presigned_url.py
@@ -435,6 +435,21 @@ class TestAzureURLSigner:
         assert perm.write is False
         assert perm.delete is False
 
+    @patch("multistorageclient.providers.azure.generate_blob_sas", return_value="sv=2021&sig=abc")
+    def test_url_path_is_percent_encoded(self, mock_sas):
+        signer = AzureURLSigner(
+            account_name="myaccount",
+            account_url="https://myaccount.blob.core.windows.net",
+            account_key="mykey==",
+        )
+        url = signer.generate_presigned_url("mycontainer/reports/2024 q1#final+v%2.csv", method="GET")
+
+        assert url == (
+            "https://myaccount.blob.core.windows.net/mycontainer/reports/2024%20q1%23final%2Bv%252.csv?sv=2021&sig=abc"
+        )
+        # The SAS is signed over the raw (unencoded) names.
+        assert mock_sas.call_args.kwargs["blob_name"] == "reports/2024 q1#final+v%2.csv"
+
     @patch("multistorageclient.providers.azure.generate_blob_sas", return_value="sv=2021&sig=xyz")
     def test_put_url(self, mock_sas):
         signer = AzureURLSigner(


### PR DESCRIPTION
## Description

`AzureURLSigner.generate_presigned_url` interpolated the raw container and
blob names into the URL. `generate_blob_sas` correctly signs the raw
canonical resource, but the URL path itself must be percent-encoded (the
SDK's `BlobClient.url` does `quote(container)/quote(blob, safe="~/")`).
A blob such as `reports/2024 q1#final.csv` yielded a URL whose `#` started
a fragment, so the request addressed the wrong blob or returned 400.

Release note: Percent-encode the container and blob path in Azure presigned (SAS) URLs; blob names containing spaces, `#`, `+` or `%` previously produced URLs that were truncated or rejected.

_Found during a review of the commit history; no tracked issue._

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.

## Testing

Regression tests added/extended:
- `multi-storage-client/tests/test_multistorageclient/unit/test_presigned_url.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Azure presigned SAS URLs so container and blob paths correctly percent-encode spaces, `#`, `+`, and `%`.
  - Preserved `~` and `/` characters in blob names while ensuring the original blob name is used for SAS generation.
  - Corrected Azure batch-delete error formatting for clearer error details.
  - Improved handling of UTF-8 text in downloaded temporary files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->