### PR TITLE
docs: align docstrings with raised exception types and current defaults

### DIFF
--- a/multi-storage-client/src/multistorageclient/providers/ais.py
+++ b/multi-storage-client/src/multistorageclient/providers/ais.py
@@ -123,7 +123,7 @@ class AIStoreStorageProvider(BaseStorageProvider):
         :param ca_cert: Path to a CA certificate file for SSL verification.
         :param timeout: Request timeout in seconds; a single float
             for both connect/read timeouts (e.g., ``5.0``), a tuple for separate connect/read
-            timeouts (e.g., ``(3.0, 10.0)``), or ``None`` to disable timeout.
+            timeouts (e.g., ``(3.0, 10.0)``), or ``None`` (default) to use ``DEFAULT_READ_TIMEOUT`` (60 seconds).
         :param retry: ``urllib3.util.Retry`` parameters. Applied as the ``http_retry`` of the client's
             ``aistore.sdk.RetryConfig`` (the network-level retry defaults are preserved).
         :param base_path: The root prefix path within the bucket where all operations will be scoped.

--- a/multi-storage-client/src/multistorageclient/providers/azure.py
+++ b/multi-storage-client/src/multistorageclient/providers/azure.py
@@ -669,8 +669,8 @@ class AzureBlobStorageProvider(BaseStorageProvider):
         :param signer_type: Must be ``None`` or :py:attr:`SignerType.AZURE`.
         :param signer_options: Optional dict; supports ``expires_in`` (int, seconds).
         :return: A fully-qualified SAS URL.
-        :raises ValueError: If *signer_type* is not ``None`` / ``SignerType.AZURE``, or if the
-            configured credential type does not support SAS generation.
+        :raises ValueError: If *signer_type* is not ``None`` / ``SignerType.AZURE``.
+        :raises TypeError: If the configured credential type does not support SAS generation.
         """
         if signer_type is not None and signer_type != SignerType.AZURE:
             raise ValueError(f"Unsupported signer type for Azure provider: {signer_type!r}")

--- a/multi-storage-client/src/multistorageclient/providers/file_credentials.py
+++ b/multi-storage-client/src/multistorageclient/providers/file_credentials.py
@@ -62,7 +62,9 @@ class FileBasedCredentialsProvider(CredentialsProvider):
 
         :param credential_file_path: The path to the JSON file containing credentials.
         :raises FileNotFoundError: If the credential file does not exist.
-        :raises ValueError: If the file is not valid JSON or does not match the expected schema.
+        :raises ValueError: If the file is not valid JSON, is missing a required field, or has an unsupported version.
+        :raises TypeError: If the file's top-level value is not a JSON object, or if ``AccessKeyId``, ``SecretAccessKey``,
+            ``SessionToken`` or ``Expiration`` has the wrong type.
         """
         self._credential_file_path = Path(credential_file_path)
         self._cached_credentials = None
@@ -77,7 +79,9 @@ class FileBasedCredentialsProvider(CredentialsProvider):
         Validates that the credential file exists and contains valid JSON with the expected schema.
 
         :raises FileNotFoundError: If the credential file does not exist.
-        :raises ValueError: If the file is not valid JSON or does not match the expected schema.
+        :raises ValueError: If the file is not valid JSON, is missing a required field, or has an unsupported version.
+        :raises TypeError: If the file's top-level value is not a JSON object, or if ``AccessKeyId``, ``SecretAccessKey``,
+            ``SessionToken`` or ``Expiration`` has the wrong type.
         """
         if not self._credential_file_path.exists():
             raise FileNotFoundError(f"Credential file not found: {self._credential_file_path}")
@@ -98,7 +102,9 @@ class FileBasedCredentialsProvider(CredentialsProvider):
         Validates that the credential data matches the expected AWS external process schema.
 
         :param data: The parsed JSON data from the credential file.
-        :raises ValueError: If the schema is invalid.
+        :raises ValueError: If a required field is missing or the version is unsupported.
+        :raises TypeError: If ``data`` is not a JSON object, or if ``AccessKeyId``, ``SecretAccessKey``, ``SessionToken``
+            or ``Expiration`` has the wrong type.
         """
         if not isinstance(data, dict):
             raise TypeError("Credential file must contain a JSON object")
@@ -133,7 +139,9 @@ class FileBasedCredentialsProvider(CredentialsProvider):
 
         :return: The credentials loaded from the file.
         :raises FileNotFoundError: If the credential file does not exist.
-        :raises ValueError: If the file is not valid JSON or does not match the expected schema.
+        :raises ValueError: If the file is not valid JSON, is missing a required field, or has an unsupported version.
+        :raises TypeError: If the file's top-level value is not a JSON object, or if ``AccessKeyId``, ``SecretAccessKey``,
+            ``SessionToken`` or ``Expiration`` has the wrong type.
         """
         try:
             # Ensure file modification time is at least 1 second ago

--- a/multi-storage-client/src/multistorageclient/sync/manager.py
+++ b/multi-storage-client/src/multistorageclient/sync/manager.py
@@ -127,7 +127,7 @@ class SyncManager:
         :param commit_metadata: When True (default), calls :py:meth:`StorageClient.commit_metadata` after sync completes.
             Set to False to skip the commit, allowing batching of multiple sync operations before committing manually.
         :param batch_size: Maximum number of operations to batch together before enqueueing. Must be between ``MIN_BATCH_SIZE`` (10)
-            and ``MAX_BATCH_SIZE`` (500). Default is 100. Actual batch sizes may be smaller when the operation type changes
+            and ``MAX_BATCH_SIZE`` (1000). Default is ``DEFAULT_SYNC_BATCH_SIZE`` (32). Actual batch sizes may be smaller when the operation type changes
             (ADD to DELETE or vice versa), when file size buckets change (to group similar-sized files), or when the producer
             completes iteration. Batching reduces queue overhead, improves load balancing, and enables future bulk transfer
             optimizations.


### PR DESCRIPTION
## Description

- `FileBasedCredentialsProvider` and `AzureBlobStorageProvider.generate_presigned_url`
  document `ValueError` where the code (after the ruff TRY004 pass in 712d11f)
  raises `TypeError` for type mismatches.
- `SyncManager.sync_from` documented `batch_size` bounds of 10..500 with default
  100; the constants are 10..1000 with default 32.
- `AIStoreStorageProvider` said `timeout=None` disables the timeout, but since
  ba0d0b3 `None` selects the 60 s default.



_Found during a review of the commit history; no tracked issue._

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added. (docstring-only change, no release note needed)

## Testing

No behaviour change; existing tests cover the touched code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified timeout behavior for the AIStore provider, including the default 60-second read timeout.
  - Documented distinct error conditions for Azure signed URL generation.
  - Clarified credential validation errors, including invalid formats, missing fields, versions, and data types.
  - Updated synchronization guidance to reflect the supported batch size range of 10–1000 and the default size of 32.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->