### PR TITLE
fix(rust): map list_recursive task join errors to StorageError

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -23,3 +23,4 @@
 - Declare the record method explicitly on the cross-process `Counter`/`Gauge` telemetry proxies (derived from each instrument class's public methods). Proxy generation no longer depends on the installed OpenTelemetry's instrument shape, fixing `AttributeError: 'AutoProxy[opentelemetry.metrics.Counter]' object has no attribute 'add'` under OpenTelemetry version skew.
 - `MultiStoragePath.read_text()` now honors its `errors` argument (`"ignore"`, `"replace"`, ...) instead of always decoding strictly.
 - `msc ls` now shows the size of files whose provider reports no modification time (for example HuggingFace or AIStore); the size column was previously blanked for every row without a date.
+- Rust recursive listing now reports a failed listing task as a regular storage error instead of a Rust panic that bypasses MSC's exception translation.

--- a/multi-storage-client/rust/src/lib.rs
+++ b/multi-storage-client/rust/src/lib.rs
@@ -1002,8 +1002,11 @@ impl RustClient {
 
             while !dirs_to_visit.is_empty() || !join_set.is_empty() {
                 if !join_set.is_empty() {
-                    let result: Result<(Vec<ObjectMeta>, Vec<Path>, usize), StorageError> =
-                        join_set.join_next().await.unwrap().unwrap();
+                    let result: Result<(Vec<ObjectMeta>, Vec<Path>, usize), StorageError> = join_set
+                        .join_next()
+                        .await
+                        .unwrap()
+                        .map_err(|e| StorageError::ObjectStoreError(format!("Failed to join list task: {:?}", e)))?;
                     let (objects, directories, depth) = result?;
 
                     for directory in &directories {


### PR DESCRIPTION
## Description

`join_set.join_next().await.unwrap().unwrap()` re-panicked inside the
Python-facing future when a spawned listing task panicked or was
cancelled. pyo3-async-runtimes turns that into a `PanicException`
(`BaseException`), which skips the providers' `except Exception`
translation and retry handling. Map the `JoinError` into
`StorageError::ObjectStoreError`, as `download_multipart_to_bytes`
already does for its tasks.

Release note: Rust recursive listing now reports a failed listing task as a regular storage error instead of a Rust panic that bypasses MSC's exception translation.

_Found during a review of the commit history; no tracked issue._

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.

## Testing

Compile-checked with `cargo check`; behaviour is exercised by the existing Rust client tests (simulator-backed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Recursive storage listings now return standard storage errors when a directory-listing task fails, instead of causing an application panic.
  - Errors are translated consistently for callers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->