### PR TITLE
fix(file): reuse the temporary descriptor returned by ObjectFile.fileno()

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -22,4 +22,5 @@
 - Azure batch-delete failures now include the response body in the raised error instead of a bound-method repr.
 - Declare the record method explicitly on the cross-process `Counter`/`Gauge` telemetry proxies (derived from each instrument class's public methods). Proxy generation no longer depends on the installed OpenTelemetry's instrument shape, fixing `AttributeError: 'AutoProxy[opentelemetry.metrics.Counter]' object has no attribute 'add'` under OpenTelemetry version skew.
 - `MultiStoragePath.read_text()` now honors its `errors` argument (`"ignore"`, `"replace"`, ...) instead of always decoding strictly.
+- `ObjectFile.fileno()` on in-memory files now returns one stable temporary descriptor instead of allocating a new one on every call (which leaked a descriptor per call until `close()`), and `close()` releases tracked descriptors and the append-mode staging file even when the upload fails.
 - `msc ls` now shows the size of files whose provider reports no modification time (for example HuggingFace or AIStore); the size column was previously blanked for every row without a date.

--- a/multi-storage-client/src/multistorageclient/file.py
+++ b/multi-storage-client/src/multistorageclient/file.py
@@ -514,15 +514,22 @@ class ObjectFile(IOBase, IO):
         return self._file.isatty()
 
     def fileno(self) -> int:
+        """
+        Return a file descriptor for the underlying file.
+
+        In-memory files (``StringIO``/``BytesIO``) have no descriptor, so a single temporary file is created on
+        first use and its descriptor is returned on every call; it is released by :py:meth:`close`.
+        """
         if self.readable():
             self._download_complete.wait()
 
         if isinstance(self._file, (StringIO, BytesIO)):
             # In-memory file objects (StringIO/BytesIO) don't have real file descriptors.
-            # Create a temporary file and return its file descriptor when needed for operations that require one.
-            fd_holder = tempfile.TemporaryFile()  # noqa: SIM115
-            self._open_files.append(fd_holder)
-            return fd_holder.fileno()
+            # Create a temporary file once and return its file descriptor when needed for operations that require one.
+            if not hasattr(self, "_temp_fd_holder"):
+                self._temp_fd_holder = tempfile.TemporaryFile()  # noqa: SIM115
+                self._open_files.append(self._temp_fd_holder)
+            return self._temp_fd_holder.fileno()
 
         return self._file.fileno()
 
@@ -549,19 +556,27 @@ class ObjectFile(IOBase, IO):
         return self.read(-1)
 
     def close(self) -> None:
+        """
+        Close the file, uploading its content first in write or append mode.
+
+        Local temporary files, including the descriptor placeholder created by :py:meth:`fileno`, are released
+        even if the upload raises.
+        """
         # If the file is already closed, return immediately.
         if self.closed:
             return
 
-        if self.readable():
-            # Ensure the download thread finishes (if it exists)
-            if hasattr(self, "_download_thread") and self._download_thread.is_alive():
-                self._download_thread.join()
-        else:
-            self._upload_file()
-
-        for fp in self._open_files:
-            fp.close()
+        try:
+            if self.readable():
+                # Ensure the download thread finishes (if it exists)
+                if hasattr(self, "_download_thread") and self._download_thread.is_alive():
+                    self._download_thread.join()
+            else:
+                self._upload_file()
+        finally:
+            # Release local files and the fileno() placeholder even when the upload fails.
+            for fp in self._open_files:
+                fp.close()
 
     def _upload_file(self) -> None:
         """
@@ -574,26 +589,30 @@ class ObjectFile(IOBase, IO):
             # The append mode downloads the file first (if applicable), then upload it again with the appended content.
             temp_file_path = self._generate_temp_file_path()
             try:
-                self._storage_client.download_file(self._remote_path, temp_file_path)
-                if os.path.getsize(temp_file_path) > self._memory_load_limit:
-                    logger.warning(
-                        "The append mode ('a' or 'ab') is not suitable for appending to large files. "
-                        "The file at '%s' exceeds the recommended size threshold "
-                        "(%d bytes). This operation will result in poor performance "
-                        "due to the need to download and re-upload the entire file.",
-                        self._remote_path,
-                        self._memory_load_limit,
-                    )
-            except FileNotFoundError:
-                pass
+                try:
+                    self._storage_client.download_file(self._remote_path, temp_file_path)
+                    if os.path.getsize(temp_file_path) > self._memory_load_limit:
+                        logger.warning(
+                            "The append mode ('a' or 'ab') is not suitable for appending to large files. "
+                            "The file at '%s' exceeds the recommended size threshold "
+                            "(%d bytes). This operation will result in poor performance "
+                            "due to the need to download and re-upload the entire file.",
+                            self._remote_path,
+                            self._memory_load_limit,
+                        )
+                except FileNotFoundError:
+                    pass
 
-            # Append the content to the downloaded file
-            with open(temp_file_path, self._mode, encoding=self._encoding) as fp:
-                self._file.seek(0)
-                fp.write(self._file.read())
+                # Append the content to the downloaded file
+                with open(temp_file_path, self._mode, encoding=self._encoding) as fp:
+                    self._file.seek(0)
+                    fp.write(self._file.read())
 
-            self._storage_client.upload_file(self._remote_path, temp_file_path, attributes=self._attributes)
-            os.unlink(temp_file_path)
+                self._storage_client.upload_file(self._remote_path, temp_file_path, attributes=self._attributes)
+            finally:
+                # Remove the staging file even if the download, append or upload failed.
+                if os.path.exists(temp_file_path):
+                    os.unlink(temp_file_path)
 
     def resolve_filesystem_path(self) -> str:
         """

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_file.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_file.py
@@ -366,6 +366,61 @@ def test_posix_file_descriptor_duration_excludes_atomic_rename(tmp_path):
     assert clock[0] == 100.0
 
 
+def test_object_file_fileno_is_stable_for_in_memory_files():
+    """fileno() on an in-memory ObjectFile must reuse one temporary descriptor instead of leaking one per call."""
+    storage_client = Mock()
+    storage_client._storage_provider = Mock(spec=BaseStorageProvider)
+    storage_client._cache_manager = None
+
+    object_file = ObjectFile(storage_client=storage_client, remote_path="object", mode="wb")
+    open_files_before = len(object_file._open_files)
+
+    descriptors = {object_file.fileno() for _ in range(5)}
+
+    assert len(descriptors) == 1
+    assert len(object_file._open_files) == open_files_before + 1
+    object_file.close()
+
+
+def test_object_file_close_releases_descriptors_when_upload_fails():
+    """A failed upload must not leak the fileno() placeholder or other tracked local files."""
+    storage_client = Mock()
+    storage_client._storage_provider = Mock(spec=BaseStorageProvider)
+    storage_client._cache_manager = None
+    storage_client.upload_file.side_effect = RuntimeError("upload failed")
+
+    object_file = ObjectFile(storage_client=storage_client, remote_path="object", mode="wb")
+    object_file.write(b"payload")
+    object_file.fileno()
+    tracked = list(object_file._open_files)
+    assert tracked
+
+    with pytest.raises(RuntimeError, match="upload failed"):
+        object_file.close()
+
+    assert all(fp.closed for fp in tracked)
+
+
+def test_object_file_append_removes_staging_file_when_upload_fails(tmp_path):
+    """Append mode stages the merged content in a temp file; it must be removed when the upload raises."""
+    storage_client = Mock()
+    storage_client._storage_provider = Mock(spec=BaseStorageProvider)
+    storage_client._cache_manager = None
+    storage_client.download_file.side_effect = FileNotFoundError("no existing object")
+    storage_client.upload_file.side_effect = RuntimeError("upload failed")
+    staging_path = tmp_path / "staging.bin"
+
+    object_file = ObjectFile(storage_client=storage_client, remote_path="object", mode="ab")
+    object_file._generate_temp_file_path = lambda: str(staging_path)  # type: ignore
+    object_file.write(b"appended")
+
+    with pytest.raises(RuntimeError, match="upload failed"):
+        object_file.close()
+
+    storage_client.upload_file.assert_called_once()
+    assert not staging_path.exists()
+
+
 def test_non_posix_files_do_not_record_file_descriptor_metrics():
     provider = Mock(spec=BaseStorageProvider)
     storage_client = Mock()


### PR DESCRIPTION
## Description

For BytesIO/StringIO-backed ObjectFiles every `fileno()` call created a
fresh `TemporaryFile` and appended it to `_open_files`, so libraries that
call `fileno()` per read (e.g. for `os.posix_fadvise`) leaked descriptors
until `close()` and observed a different descriptor each time. Memoise the
holder the same way `RemoteFileReader.fileno()` already does.

Release note: `ObjectFile.fileno()` on in-memory files now returns one stable temporary descriptor instead of allocating a new one on every call (which leaked a descriptor per call until `close()`).

_Found during a review of the commit history; no tracked issue._

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.

## Testing

Regression tests added/extended:
- `multi-storage-client/tests/test_multistorageclient/unit/test_file.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - In-memory files now reuse a stable temporary file descriptor when accessed repeatedly.
  - File descriptors are reliably released when files are closed, including after failed uploads.
  - Temporary append-mode staging files are cleaned up when download, append, or upload operations fail.

- **Tests**
  - Added regression coverage for descriptor reuse, descriptor cleanup, and staging-file removal after failed operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->