### PR TITLE
fix(client): serve full-file byte-range reads from the cache

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -5,5 +5,6 @@
 ## New Features
 
 ## Bug Fixes
+- Full-file `read(path, byte_range=Range(0, size))` calls with caching enabled now serve repeat reads from the cache instead of re-downloading and re-caching the whole object every time.
 - `open(path, "r", encoding=...)` with caching enabled now honors the requested mode and encoding when the object is served from the cache; the cache-first fast path previously opened the cached file in binary mode (so `read()` returned `bytes`), and cached text opens ignored a non-default `encoding`.
 - Cache access-time updates no longer raise when the cached file was concurrently evicted or is owned by another user, and they operate on an open file descriptor so a concurrently recreated cache file is never chmod'ed by mistake; the permission restore in the `finally` block previously re-raised the error the method was meant to swallow.

--- a/multi-storage-client/src/multistorageclient/client/single.py
+++ b/multi-storage-client/src/multistorageclient/client/single.py
@@ -435,8 +435,13 @@ class SingleStorageClient(AbstractStorageClient):
                     # Only apply this optimization when metadata is already available (i.e., when version checking is enabled),
                     # to respect the user's choice to disable version checking and avoid extra HEAD requests.
                     if byte_range.offset == 0 and metadata and byte_range.size >= metadata.content_length:
-                        full_file_data = self._storage_provider.get_object(path)
-                        self._cache_manager.set(path, full_file_data, source_version)
+                        full_file_data = self._cache_manager.read(path, source_version)
+                        if full_file_data is None:
+                            if self._replica_manager:
+                                full_file_data = self._read_from_replica_or_primary(path)
+                            else:
+                                full_file_data = self._storage_provider.get_object(path)
+                            self._cache_manager.set(path, full_file_data, source_version)
                         return full_file_data[: metadata.content_length]
 
                     # Use chunk-based caching for partial reads or when optimization doesn't apply

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_cache.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_cache.py
@@ -1400,6 +1400,63 @@ def test_concurrent_chunk_creation_with_locking():
         assert len(chunk_files) == 1, f"Expected 1 chunk0 file, found {len(chunk_files)}"
 
 
+def test_full_file_byte_range_read_is_served_from_cache(tmpdir):
+    """A full-file byte_range read must hit the cache on repeat instead of re-downloading the object."""
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
+        profile = "data"
+        config_dict = {
+            "profiles": {profile: temp_data_store.profile_config_dict() | {"caching_enabled": True}},
+            "cache": {
+                "size": "50M",
+                "cache_line_size": "1M",
+                "location": str(tmpdir),
+                "check_source_version": True,
+            },
+        }
+        storage_client = SingleStorageClient(config=StorageClientConfig.from_dict(config_dict, profile=profile))
+        provider = storage_client._storage_provider
+        content = b"x" * (3 * 1024 * 1024)
+        storage_client.write("data/x.bin", content)
+
+        # Exercise the remote cache path with a stable source version.
+        storage_client._is_posix_file_storage_provider = lambda: False  # type: ignore
+        original_get_object_metadata = provider.get_object_metadata
+
+        def get_object_metadata_with_etag(path: str, strict: bool = True):
+            metadata = original_get_object_metadata(path, strict=strict)
+            metadata.etag = "etag-1"
+            return metadata
+
+        provider.get_object_metadata = get_object_metadata_with_etag  # type: ignore
+        get_object_calls = 0
+        original_get_object = provider.get_object
+
+        def counting_get_object(path: str, byte_range: Range | None = None):
+            nonlocal get_object_calls
+            get_object_calls += 1
+            return original_get_object(path, byte_range=byte_range)
+
+        provider.get_object = counting_get_object  # type: ignore
+        cache_manager = storage_client._cache_manager
+        assert cache_manager is not None
+        cache_set_calls = 0
+        original_cache_set = cache_manager.set
+
+        def counting_cache_set(*args, **kwargs):
+            nonlocal cache_set_calls
+            cache_set_calls += 1
+            return original_cache_set(*args, **kwargs)
+
+        cache_manager.set = counting_cache_set  # type: ignore
+
+        for _ in range(3):
+            assert storage_client.read("data/x.bin", byte_range=Range(offset=0, size=len(content))) == content
+
+        # One download and one cache write on the miss; the two repeats are served from the cache.
+        assert get_object_calls == 1
+        assert cache_set_calls == 1
+
+
 @pytest.mark.parametrize(
     argnames=["temp_data_store_type"],
     argvalues=[


### PR DESCRIPTION
## Description

The full-file `byte_range` optimisation in `SingleStorageClient.read`
unconditionally called `storage_provider.get_object` and then wrote the
cache, but never consulted it first, so the object it had just cached was
never served and every identical read re-downloaded it. Read from the
cache and only fall back to the provider on a miss, matching the plain
full-read path.

Release note: Full-file `read(path, byte_range=Range(0, size))` calls with caching enabled now serve repeat reads from the cache instead of re-downloading and re-caching the whole object every time.

_Found during a review of the commit history; no tracked issue._

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.

## Testing

Regression tests added/extended:
- `multi-storage-client/tests/test_multistorageclient/unit/test_cache.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Repeated full-file range reads now reuse cached data instead of downloading and caching the object again.
  - Cache misses continue to support replica failover when configured before storing the retrieved content.

- **Tests**
  - Added regression coverage confirming that repeated reads perform only one remote download and one cache insertion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->