### PR TITLE
fix(rust): handle zero-size objects in download_multipart_to_bytes

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -22,4 +22,5 @@
 - Azure batch-delete failures now include the response body in the raised error instead of a bound-method repr.
 - Declare the record method explicitly on the cross-process `Counter`/`Gauge` telemetry proxies (derived from each instrument class's public methods). Proxy generation no longer depends on the installed OpenTelemetry's instrument shape, fixing `AttributeError: 'AutoProxy[opentelemetry.metrics.Counter]' object has no attribute 'add'` under OpenTelemetry version skew.
 - `MultiStoragePath.read_text()` now honors its `errors` argument (`"ignore"`, `"replace"`, ...) instead of always decoding strictly.
+- `RustClient.download_multipart_to_bytes` now returns `b""` for zero-byte objects and empty ranges instead of failing with an integer underflow / invalid range error.
 - `msc ls` now shows the size of files whose provider reports no modification time (for example HuggingFace or AIStore); the size column was previously blanked for every row without a date.

--- a/multi-storage-client/rust/src/lib.rs
+++ b/multi-storage-client/rust/src/lib.rs
@@ -884,18 +884,31 @@ impl RustClient {
         let concurrency = max_concurrency.unwrap_or(self.max_concurrency);
 
         future_into_py(py, async move {
-            let (start_offset, end_offset, total_size) = if let Some(byte_range) = range {
+            let (start_offset, total_size) = if let Some(byte_range) = range {
                 // Range read - no HEAD request needed, we know the exact range
-                let start_val = byte_range.offset;
-                let length = byte_range.size;
-                let end_val = start_val + length - 1;
-                (start_val, end_val, length)
+                (byte_range.offset, byte_range.size)
             } else {
                 // Full file download - need HEAD request to get total size for chunking
                 let result = store.head(&remote_path).await.map_err(StorageError::from)?;
-                let file_size = result.size;
-                (0, file_size - 1, file_size)
+                (0, result.size)
             };
+
+            // Zero-byte objects (or empty ranges) have nothing to fetch; return before the
+            // inclusive end offset below would underflow.
+            if total_size == 0 {
+                return Ok(PyBytes::new(bytes::Bytes::new()));
+            }
+            // `offset + size` must stay representable (the exclusive end `end_offset + 1` is used below).
+            let end_offset = start_offset
+                .checked_add(total_size)
+                .filter(|end| *end < u64::MAX)
+                .map(|end| end - 1)
+                .ok_or_else(|| {
+                    StorageError::ObjectStoreError(format!(
+                        "Invalid byte range: offset {} + size {} overflows",
+                        start_offset, total_size
+                    ))
+                })?;
 
             if total_size <= chunksize as u64 {
                 let range = start_offset..end_offset + 1;


### PR DESCRIPTION
## Description

`file_size - 1` / `length - 1` on a `u64` underflowed for empty objects
and `Range(offset, size=0)`: a debug build panicked (surfacing in Python
as a `BaseException`-derived `PanicException`) and a release build
wrapped to `u64::MAX` and issued `get_range(0..0)`, which object_store
rejects. Return an empty buffer before computing the inclusive end
offset, matching `download_multipart_to_file`, which already tolerates
zero-size objects.

Release note: `RustClient.download_multipart_to_bytes` now returns `b""` for zero-byte objects and empty ranges instead of failing with an integer underflow / invalid range error.

_Found during a review of the commit history; no tracked issue._

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.

## Testing

Compile-checked with `cargo check`; behaviour is exercised by the existing Rust client tests (simulator-backed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multipart downloads for zero-byte objects and empty ranges, which now return an empty byte string instead of producing errors.
  * Prevented invalid or overflowing range calculations from causing unexpected download failures.
  * Preserved existing behavior for full-object downloads and ranged requests, including the appropriate request handling for each download type.
  * Downloads now report a storage error before attempting a request when range arithmetic cannot be safely completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->