### PR TITLE
fix(cache): make the access-time update race-free and tolerant of permission errors

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -6,3 +6,4 @@
 
 ## Bug Fixes
 - `open(path, "r", encoding=...)` with caching enabled now honors the requested mode and encoding when the object is served from the cache; the cache-first fast path previously opened the cached file in binary mode (so `read()` returned `bytes`), and cached text opens ignored a non-default `encoding`.
+- Cache access-time updates no longer raise when the cached file was concurrently evicted or is owned by another user, and they operate on an open file descriptor so a concurrently recreated cache file is never chmod'ed by mistake; the permission restore in the `finally` block previously re-raised the error the method was meant to swallow.

--- a/multi-storage-client/src/multistorageclient/cache.py
+++ b/multi-storage-client/src/multistorageclient/cache.py
@@ -442,23 +442,23 @@ class CacheManager:
         lock_file = os.path.join(file_dir, lock_name)
         return FileLock(lock_file, timeout=self.DEFAULT_FILE_LOCK_TIMEOUT)
 
-    def _make_writable(self, file_path: str) -> None:
+    def _make_writable(self, file: str | int) -> None:
         """Make file writable by owner while keeping it readable by all.
 
         Changes permissions to 644 (rw-r--r--).
 
-        :param file_path: Path to the file to make writable.
+        :param file: Path or open file descriptor of the file to make writable.
         """
-        os.chmod(file_path, mode=stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+        os.chmod(file, mode=stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
 
-    def _make_readonly(self, file_path: str) -> None:
+    def _make_readonly(self, file: str | int) -> None:
         """Make file read-only for all users.
 
         Changes permissions to 444 (r--r--r--).
 
-        :param file_path: Path to the file to make read-only.
+        :param file: Path or open file descriptor of the file to make read-only.
         """
-        os.chmod(file_path, mode=stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+        os.chmod(file, mode=stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
 
     def _update_access_time(self, file_path: str) -> None:
         """Update access time to current time for LRU policy.
@@ -466,22 +466,35 @@ class CacheManager:
         Only updates atime, preserving mtime for FIFO ordering.
         This is used to track when files are accessed for LRU eviction.
 
+        All operations go through one open file descriptor so they apply to the same inode: another process may
+        evict and recreate the same cache path concurrently, and a path-based restore would chmod the replacement.
+
         :param file_path: Path to the file to update access time.
         """
         current_time = time.time()
         try:
-            # Make file writable to update timestamps
-            self._make_writable(file_path)
-            # Only update atime, preserve mtime for FIFO ordering
-            stat = os.stat(file_path)
-            os.utime(file_path, (current_time, stat.st_mtime))
-        except (OSError, FileNotFoundError):
-            # File might be deleted by another process or have permission issues
-            # Just continue without updating the access time
-            pass
+            fd = os.open(file_path, os.O_RDONLY)
+        except OSError:
+            # File might be deleted by another process; nothing to update
+            return
+        try:
+            try:
+                # Make file writable to update timestamps
+                self._make_writable(fd)
+                # Only update atime, preserve mtime for FIFO ordering
+                stat = os.fstat(fd)
+                os.utime(fd, (current_time, stat.st_mtime))
+            except OSError:
+                # The file may be owned by another user; just continue without updating the access time
+                pass
+            finally:
+                # Restore read-only permissions on the same inode
+                try:
+                    self._make_readonly(fd)
+                except OSError:
+                    pass
         finally:
-            # Restore read-only permissions
-            self._make_readonly(file_path)
+            os.close(fd)
 
     def _should_refresh_cache(self) -> bool:
         """Check if enough time has passed since the last refresh."""

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_cache.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_cache.py
@@ -15,6 +15,7 @@
 
 import os
 import shutil
+import stat
 import tempfile
 import threading
 import time
@@ -36,6 +37,79 @@ from multistorageclient.config import StorageClientConfig
 from multistorageclient.types import Range, SourceVersionCheckMode
 from test_multistorageclient.unit.utils import tempdatastore
 from test_multistorageclient.unit.utils.tempdatastore import create_test_data
+
+
+def _cache_manager(tmpdir) -> CacheManager:
+    return CacheManager(
+        profile="data",
+        cache_config=CacheConfig(location=str(tmpdir), size="10M", cache_line_size="1M", check_source_version=False),
+    )
+
+
+def test_update_access_time_tolerates_permission_error_on_restore(tmpdir):
+    """A cached file owned by another user: the atime update may fail and the read-only restore must not raise."""
+    cache_manager = _cache_manager(tmpdir)
+    file_path = os.path.join(str(tmpdir), "shared.bin")
+    with open(file_path, "wb") as f:
+        f.write(b"data")
+    os.utime(file_path, (0, 0))  # atime far in the past so the update is observable
+    readonly_calls: list[int] = []
+
+    def make_readonly_denied(fd: int) -> None:
+        readonly_calls.append(fd)
+        raise PermissionError("Operation not permitted")
+
+    cache_manager._make_readonly = make_readonly_denied  # type: ignore
+    cache_manager._update_access_time(file_path)
+
+    # The atime update ran (so _make_writable succeeded) and the failing restore was attempted exactly once.
+    assert os.stat(file_path).st_atime > 0
+    assert len(readonly_calls) == 1
+
+
+def test_update_access_time_tolerates_missing_file(tmpdir):
+    """_update_access_time must swallow errors from a concurrently evicted file."""
+    cache_manager = _cache_manager(tmpdir)
+    cache_manager._update_access_time(os.path.join(str(tmpdir), "does-not-exist"))
+
+
+def test_update_access_time_does_not_touch_a_replacement_file(tmpdir):
+    """Eviction + recreation of the same path mid-update must not chmod the replacement to read-only."""
+    cache_manager = _cache_manager(tmpdir)
+    file_path = os.path.join(str(tmpdir), "file.bin")
+    with open(file_path, "wb") as f:
+        f.write(b"original")
+    cache_manager._make_readonly(file_path)
+    original_make_writable = cache_manager._make_writable
+
+    def make_writable_then_replace(fd: int) -> None:
+        original_make_writable(fd)
+        # Another process evicts the file and recreates the same path with a new inode.
+        os.unlink(file_path)
+        with open(file_path, "wb") as f:
+            f.write(b"replacement")
+        os.chmod(file_path, 0o644)
+
+    cache_manager._make_writable = make_writable_then_replace  # type: ignore
+    cache_manager._update_access_time(file_path)
+
+    assert stat.S_IMODE(os.stat(file_path).st_mode) == 0o644
+    with open(file_path, "rb") as f:
+        assert f.read() == b"replacement"
+
+
+def test_cache_set_tolerates_concurrent_eviction_during_access_time_update(tmpdir):
+    """set() must not raise when another process removes the file between the rename and the atime update."""
+    cache_manager = _cache_manager(tmpdir)
+    original_make_writable = cache_manager._make_writable
+
+    def make_writable_then_evict(fd: int) -> None:
+        original_make_writable(fd)
+        os.unlink(cache_manager._get_cache_file_path("file.bin"))
+
+    cache_manager._make_writable = make_writable_then_evict  # type: ignore
+    cache_manager.set("file.bin", b"data")
+    assert cache_manager.read("file.bin") is None
 
 
 class RangeAwareStorageProvider:


### PR DESCRIPTION
## Description

`_update_access_time` tolerates "file deleted by another process or
permission issues" in its `except`, but the `finally` block called
`os.chmod` unguarded, so the same errors were re-raised one line later.
This surfaced as `FileNotFoundError` from `CacheManager.set()` when another
process evicted the file between the rename and the atime update, and as
`PermissionError` (turned into a spurious "file not found" by `open()`)
when the cache directory is shared between users.

The path-based sequence also had a replacement race: another process could
evict and recreate the same cache path after `_make_writable()`, and the
restore then chmod'ed the replacement inode to 0444. All operations now go
through one open file descriptor (`os.chmod`/`os.fstat`/`os.utime` on the
fd), so they apply to the original inode only.

Release note: Cache access-time updates no longer raise when the cached file was concurrently evicted or is owned by another user, and they operate on an open file descriptor so a concurrently recreated cache file is never chmod'ed by mistake; the permission restore in the `finally` block previously re-raised the error the method was meant to swallow.

_Found during a review of the commit history; no tracked issue._

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.

## Testing

Regression tests added/extended:
- `multi-storage-client/tests/test_multistorageclient/unit/test_cache.py` (missing file, permission error on restore, concurrent eviction during `set()`, unlink+recreate replacement race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache reliability when entries are removed, replaced, or ownership changes during access-time updates.
  * Cache operations now continue without raising errors when cached files disappear or are changed concurrently.
  * Permission restoration failures during cache updates are safely handled, preventing avoidable interruptions.

* **Tests**
  * Added coverage for concurrent eviction, missing or replaced cache files, and permission-related cleanup errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->