### PR TITLE
fix(file): prevent ObjectFile read deadlocks

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -15,6 +15,7 @@
 
 ## Bug Fixes
 
+- `ObjectFile` reads no longer block indefinitely when opening a missing cached object or when a background download fails before creating the local file. Waiting callers now wake and receive the download error.
 - `PosixFile.readall()` no longer emits READ metrics twice (once for itself and once for the instrumented `read()` it delegated to).
 - Ingest MSFS manifests on writable mounts. Ingest previously ran only for read-only backends, so a writable manifest-backed mount appended delta records that nothing replayed and lost every mutation on remount. Only manifest generation, which lists the entire namespace, still requires a read-only backend.
 - `info("")` on a POSIX profile now reports the modification time of the profile's `base_path` instead of the process working directory.

--- a/multi-storage-client/src/multistorageclient/file.py
+++ b/multi-storage-client/src/multistorageclient/file.py
@@ -245,6 +245,7 @@ class ObjectFile(IOBase, IO):
         self._cache_manager = storage_client._cache_manager
         self._memory_load_limit = memory_load_limit
         self._open_files = []
+        self._download_error: Exception | None = None
         self._check_source_version = check_source_version
 
         if disable_read_cache:
@@ -333,20 +334,20 @@ class ObjectFile(IOBase, IO):
         """
         Download the file to the cache directory.
         """
-        if not self._cache_manager:
-            raise ValueError(f"Cannot download file {self._remote_path}, cache is not configured.")
-
-        # Check if the file can be put into the cache
-        if self._object_metadata.content_length >= self._cache_manager.get_max_cache_size():
-            logger.warning(
-                f'The object "{self._remote_path}" is not cached because the file size ({self._object_metadata.content_length}) '
-                f"exceeds the cache size ({self._cache_manager.get_max_cache_size()}). Please increase the cache size "
-                f"in the config file to cache the file."
-            )
-
-            return self._open_large_file()
-
         try:
+            if not self._cache_manager:
+                raise ValueError(f"Cannot download file {self._remote_path}, cache is not configured.")
+
+            # Check if the file can be put into the cache
+            if self._object_metadata.content_length >= self._cache_manager.get_max_cache_size():
+                logger.warning(
+                    f'The object "{self._remote_path}" is not cached because the file size ({self._object_metadata.content_length}) '
+                    f"exceeds the cache size ({self._cache_manager.get_max_cache_size()}). Please increase the cache size "
+                    f"in the config file to cache the file."
+                )
+
+                return self._open_large_file()
+
             if self._check_source_version == SourceVersionCheckMode.INHERIT:
                 if self._cache_manager.check_source_version():
                     source_version = self._object_metadata.etag
@@ -386,8 +387,8 @@ class ObjectFile(IOBase, IO):
 
             self._file = file_object
             self._open_files.append(self._file)
-        except Exception as e:
-            raise OSError(f"Failed to download file {self._remote_path}") from e
+        except Exception as error:
+            self._download_error = error
         finally:
             self._download_complete.set()
 
@@ -405,17 +406,17 @@ class ObjectFile(IOBase, IO):
         """
         Download the file to a file-like object.
         """
-        file_size = self._object_metadata.content_length
-
-        if file_size > self._memory_load_limit:
-            return self._open_large_file()
-
         try:
+            file_size = self._object_metadata.content_length
+
+            if file_size > self._memory_load_limit:
+                return self._open_large_file()
+
             self._create_fileobj()
             self._storage_client.download_file(self._remote_path, self._file)
             self._file.seek(0)
-        except Exception as e:
-            raise OSError(f"Failed to download file {self._remote_path}") from e
+        except Exception as error:
+            self._download_error = error
         finally:
             self._download_complete.set()
 
@@ -443,15 +444,20 @@ class ObjectFile(IOBase, IO):
     def name(self) -> str:
         return self._remote_path
 
+    def _wait_for_download(self) -> None:
+        self._download_complete.wait()
+        if self._download_error is not None:
+            raise OSError(f"Failed to download file {self._remote_path}") from self._download_error
+
     @property
     def closed(self) -> bool:
-        if self.readable():
+        if self.readable() and hasattr(self, "_download_thread") and self._download_thread.is_alive():
             self._download_complete.wait()
-        return self._file.closed
+        return not hasattr(self, "_file") or self._file.closed
 
     def read(self, size: int = -1) -> Any:
         if self.readable():
-            self._download_complete.wait()
+            self._wait_for_download()
         return self._file.read(size)
 
     def readable(self) -> bool:
@@ -462,27 +468,27 @@ class ObjectFile(IOBase, IO):
 
     def seekable(self) -> bool:
         if self.readable():
-            self._download_complete.wait()
+            self._wait_for_download()
         return self._file.seekable()
 
     def seek(self, position: int, whence: int = 0) -> int:
         if self.readable():
-            self._download_complete.wait()
+            self._wait_for_download()
         return self._file.seek(position, whence)
 
     def tell(self) -> int:
         if self.readable():
-            self._download_complete.wait()
+            self._wait_for_download()
         return self._file.tell()
 
     def readline(self, size: int = -1) -> Any:
         if self.readable():
-            self._download_complete.wait()
+            self._wait_for_download()
         return self._file.readline(size)
 
     def readlines(self, hint: int = -1) -> list[Any]:
         if self.readable():
-            self._download_complete.wait()
+            self._wait_for_download()
         return self._file.readlines()
 
     def __iter__(self) -> Iterator[Any]:
@@ -490,7 +496,7 @@ class ObjectFile(IOBase, IO):
 
     def __next__(self) -> Any:
         if self.readable():
-            self._download_complete.wait()
+            self._wait_for_download()
         return next(self._file)
 
     def __enter__(self) -> ObjectFile:  # noqa: PYI034
@@ -510,7 +516,7 @@ class ObjectFile(IOBase, IO):
 
     def isatty(self) -> bool:
         if self.readable():
-            self._download_complete.wait()
+            self._wait_for_download()
         return self._file.isatty()
 
     def fileno(self) -> int:
@@ -521,7 +527,7 @@ class ObjectFile(IOBase, IO):
         first use and its descriptor is returned on every call; it is released by :py:meth:`close`.
         """
         if self.readable():
-            self._download_complete.wait()
+            self._wait_for_download()
 
         if isinstance(self._file, (StringIO, BytesIO)):
             # In-memory file objects (StringIO/BytesIO) don't have real file descriptors.
@@ -547,7 +553,7 @@ class ObjectFile(IOBase, IO):
 
     def readinto(self, b: Any) -> int:
         if self.readable():
-            self._download_complete.wait()
+            self._wait_for_download()
         if hasattr(self._file, "readinto"):
             return self._file.readinto(b)  # type: ignore
         raise io.UnsupportedOperation(f"readinto operation is not supported on file {self._remote_path}")
@@ -624,7 +630,7 @@ class ObjectFile(IOBase, IO):
         :return: Path to local file in read mode, raises a ValueError in write mode
         """
         if self.readable():
-            self._download_complete.wait()
+            self._wait_for_download()
             if self._cache_manager:
                 # Get the cached path of the file
                 return self._file.name

--- a/multi-storage-client/src/multistorageclient/file.py
+++ b/multi-storage-client/src/multistorageclient/file.py
@@ -451,11 +451,13 @@ class ObjectFile(IOBase, IO):
 
     @property
     def closed(self) -> bool:
+        """Return whether the local file is unavailable or closed."""
         if self.readable() and hasattr(self, "_download_thread") and self._download_thread.is_alive():
             self._download_complete.wait()
         return not hasattr(self, "_file") or self._file.closed
 
     def read(self, size: int = -1) -> Any:
+        """Read and return up to ``size`` bytes or characters."""
         if self.readable():
             self._wait_for_download()
         return self._file.read(size)
@@ -467,26 +469,31 @@ class ObjectFile(IOBase, IO):
         return self._mode in ("w", "wb", "a", "ab")
 
     def seekable(self) -> bool:
+        """Return whether the underlying file supports seeking."""
         if self.readable():
             self._wait_for_download()
         return self._file.seekable()
 
     def seek(self, position: int, whence: int = 0) -> int:
+        """Change the stream position and return the new position."""
         if self.readable():
             self._wait_for_download()
         return self._file.seek(position, whence)
 
     def tell(self) -> int:
+        """Return the current stream position."""
         if self.readable():
             self._wait_for_download()
         return self._file.tell()
 
     def readline(self, size: int = -1) -> Any:
+        """Read and return one line, limited to ``size`` when non-negative."""
         if self.readable():
             self._wait_for_download()
         return self._file.readline(size)
 
     def readlines(self, hint: int = -1) -> list[Any]:
+        """Read and return all remaining lines."""
         if self.readable():
             self._wait_for_download()
         return self._file.readlines()
@@ -515,6 +522,7 @@ class ObjectFile(IOBase, IO):
         return self._file.mode
 
     def isatty(self) -> bool:
+        """Return whether the underlying file is connected to a terminal."""
         if self.readable():
             self._wait_for_download()
         return self._file.isatty()
@@ -552,6 +560,7 @@ class ObjectFile(IOBase, IO):
         pass
 
     def readinto(self, b: Any) -> int:
+        """Read bytes into ``b`` and return the number of bytes read."""
         if self.readable():
             self._wait_for_download()
         if hasattr(self._file, "readinto"):

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_file.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_file.py
@@ -401,6 +401,55 @@ def test_object_file_close_releases_descriptors_when_upload_fails():
     assert all(fp.closed for fp in tracked)
 
 
+def test_object_file_missing_cached_object_does_not_wait_during_cleanup():
+    storage_client = Mock()
+    storage_client._cache_manager = Mock()
+    storage_client._cache_manager.prefetch_file.return_value = True
+    storage_client._cache_manager.check_source_version.return_value = True
+    storage_client.info.side_effect = FileNotFoundError("missing object")
+    download_complete = Mock()
+    object_file = ObjectFile.__new__(ObjectFile)
+
+    with (
+        patch("multistorageclient.file.threading.Event", return_value=download_complete),
+        pytest.raises(FileNotFoundError, match="missing object"),
+    ):
+        object_file.__init__(storage_client=storage_client, remote_path="missing", mode="rb")
+
+    object_file.close()
+    assert object_file.closed
+    download_complete.wait.assert_not_called()
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.parametrize("cache_enabled", [False, True])
+def test_object_file_large_text_read_propagates_background_error(cache_enabled):
+    storage_client = Mock()
+    cache_manager = Mock() if cache_enabled else None
+    storage_client._cache_manager = cache_manager
+    storage_client.info.return_value = Mock(content_length=2)
+    if cache_manager:
+        cache_manager.prefetch_file.return_value = True
+        cache_manager.check_source_version.return_value = True
+        cache_manager.get_max_cache_size.return_value = 1
+
+    object_file = ObjectFile(
+        storage_client=storage_client,
+        remote_path="large.txt",
+        mode="r",
+        memory_load_limit=1,
+    )
+
+    with pytest.raises(OSError, match="Failed to download file large.txt") as exc_info:
+        object_file.read()
+
+    assert isinstance(exc_info.value.__cause__, ValueError)
+    assert object_file._download_complete.is_set()
+    object_file._download_thread.join(timeout=1)
+    assert not object_file._download_thread.is_alive()
+    object_file.close()
+
+
 def test_object_file_append_removes_staging_file_when_upload_fails(tmp_path):
     """Append mode stages the merged content in a temp file; it must be removed when the upload raises."""
     storage_client = Mock()


### PR DESCRIPTION
## Description

Prevent `ObjectFile` reads and cleanup from blocking indefinitely when asynchronous initialization fails.

- Treat a partially initialized `ObjectFile` as closed when no download thread can complete it.
- Guarantee that cached and uncached background download paths signal `_download_complete` from an outer `finally` block.
- Preserve background failures and raise them to waiting file operations as `OSError`, with the original exception as the cause.
- Add regression coverage for missing cached objects and oversized text reads with and without caching.

## Validation

- `CI=1 just analyze`
- `CI=1 just run-unit-tests`
  - 1,108 Python tests passed; 3 skipped
  - 13 Rust tests passed
- Re-ran the original missing-file deadlock reproducer with caching enabled and disabled; both exit normally.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [ ] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [ ] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [ ] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file reads hanging when cached objects cannot be opened or background downloads fail.
  * Read operations now report the underlying download error instead of waiting indefinitely.
  * Improved cleanup and thread termination after failed downloads.

* **Documentation**
  * Added concise documentation for public file-handling methods.

* **Tests**
  * Added coverage for missing cached objects and download failures during large text reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->