### PR TITLE
feat: release MSC 1.1.0

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -2,33 +2,6 @@
 
 ## Breaking Changes
 
-- Removed the `msc.zarr` and `msc.xarray` adapters, their `multistorageclient.contrib` modules, and the corresponding `zarr` and `xarray` optional extras. Install `multi-storage-client[fsspec]` and use the libraries' native fsspec support instead, such as `zarr.open("msc://...")` or `xarray.open_zarr("msc://...")`.
-
 ## New Features
 
-- Add OpenTelemetry metrics for POSIX file descriptor usage: `multistorageclient.file_descriptor.open` tracks file descriptors held by `PosixFile`, and `multistorageclient.file_descriptor.duration` records how long each descriptor remains open.
-- Add an optional `s3_cuobject` provider backed by NVIDIA cuObject for direct S3-over-RDMA buffer transfers to RDMA-capable endpoints.
-- Add MSFS write support for S3 backends. Writable mounts stream large objects through multipart upload and buffer newly created objects locally until `multipart_upload_threshold_bytes`, so small objects commit with a single `PutObject`. `fsync`/`fdatasync` is the durability barrier; `flush_on_close` optionally makes release wait for the backend commit.
-- Commit deferred small MSFS objects through a bounded worker pool, so independent files upload concurrently without holding the global filesystem lock. Tunable via `write_commit_workers`, `write_commit_queue_depth`, and `write_deferral_max_bytes`.
-- Add `write_cache_promotion` to admit bytes retained after a successful MSFS write commit into the read cache, avoiding a backend GET when a file is read back right after being written.
-- Added Python 3.14 support.
-
 ## Bug Fixes
-
-- `ObjectFile` reads no longer block indefinitely when opening a missing cached object or when a background download fails before creating the local file. Waiting callers now wake and receive the download error.
-- `PosixFile.readall()` no longer emits READ metrics twice (once for itself and once for the instrumented `read()` it delegated to).
-- Ingest MSFS manifests on writable mounts. Ingest previously ran only for read-only backends, so a writable manifest-backed mount appended delta records that nothing replayed and lost every mutation on remount. Only manifest generation, which lists the entire namespace, still requires a read-only backend.
-- Sort and de-duplicate `source_files` in `sync_from` before merging against the target listing; an unsorted list previously caused up-to-date target files to be deleted and re-copied.
-- `info("")` on a POSIX profile now reports the modification time of the profile's `base_path` instead of the process working directory.
-- Replay MSFS delta records for directories that have no base manifest part. Ingest walked only enumerated base TSVs, so a directory first written after manifest generation was never visited and its delta records were dropped.
-- OCI listings now strip the bucket from `start_after`/`end_at` like every other provider; with a `base_path` that includes the bucket, `end_at` previously filtered out every object and `start_after` was ignored.
-- `copy.deepcopy` of the immutable config dictionary now converts frozen tuples back to lists, so `msc config validate` no longer emits `!!python/tuple` tags that `yaml.safe_load` rejects.
-- Azure batch-delete failures now include the response body in the raised error instead of a bound-method repr.
-- Declare the record method explicitly on the cross-process `Counter`/`Gauge` telemetry proxies (derived from each instrument class's public methods). Proxy generation no longer depends on the installed OpenTelemetry's instrument shape, fixing `AttributeError: 'AutoProxy[opentelemetry.metrics.Counter]' object has no attribute 'add'` under OpenTelemetry version skew.
-- `MultiStoragePath.read_text()` now honors its `errors` argument (`"ignore"`, `"replace"`, ...) instead of always decoding strictly.
-- `RustClient.download_multipart_to_bytes` now returns `b""` for zero-byte objects and empty ranges instead of failing with an integer underflow / invalid range error.
-- `ObjectFile.fileno()` on in-memory files now returns one stable temporary descriptor instead of allocating a new one on every call (which leaked a descriptor per call until `close()`), and `close()` releases tracked descriptors and the append-mode staging file even when the upload fails.
-- `msc ls` now shows the size of files whose provider reports no modification time (for example HuggingFace or AIStore); the size column was previously blanked for every row without a date.
-- Percent-encode the container and blob path in Azure presigned (SAS) URLs; blob names containing spaces, `#`, `+` or `%` previously produced URLs that were truncated or rejected.
-- Azure downloads of large objects into a `StringIO` now decode the staged content as UTF-8 regardless of the host locale, matching the small-object path and the upload encoding.
-- Rust recursive listing now reports a failed listing task as a regular storage error instead of a Rust panic that bypasses MSC's exception translation.

--- a/.release_notes/1.1.0.md
+++ b/.release_notes/1.1.0.md
@@ -1,0 +1,40 @@
+## Multi-Storage Client (MSC)
+
+This release adds Python 3.14 support to Multi-Storage Client, including Python 3.14 in the tested build matrix and published package metadata.
+
+### Breaking Changes
+
+- Removed the `msc.zarr` and `msc.xarray` adapters, their `multistorageclient.contrib` modules, and the corresponding `zarr` and `xarray` optional extras. Install `multi-storage-client[fsspec]` and use the libraries' native fsspec support instead, such as `zarr.open("msc://...")` or `xarray.open_zarr("msc://...")`.
+
+### New Features
+
+- Added Python 3.14 support.
+- Add OpenTelemetry metrics for POSIX file descriptor usage: `multistorageclient.file_descriptor.open` tracks file descriptors held by `PosixFile`, and `multistorageclient.file_descriptor.duration` records how long each descriptor remains open.
+- Add strict handling for POSIX symlinks that target paths outside the configured base path.
+
+### Performance Improvements
+
+- Cache the resolved POSIX base path when evaluating symlinks to avoid repeated `realpath` system calls.
+
+### Bug Fixes
+
+- `ObjectFile` reads no longer block indefinitely when opening a missing cached object or when a background download fails before creating the local file. Waiting callers now wake and receive the download error.
+- `PosixFile.readall()` no longer emits READ metrics twice (once for itself and once for the instrumented `read()` it delegated to).
+- Sort and de-duplicate `source_files` in `sync_from` before merging against the target listing; an unsorted list previously caused up-to-date target files to be deleted and re-copied.
+- `info("")` on a POSIX profile now reports the modification time of the profile's `base_path` instead of the process working directory.
+- OCI listings now strip the bucket from `start_after`/`end_at` like every other provider; with a `base_path` that includes the bucket, `end_at` previously filtered out every object and `start_after` was ignored.
+- `copy.deepcopy` of the immutable config dictionary now converts frozen tuples back to lists, so `msc config validate` no longer emits `!!python/tuple` tags that `yaml.safe_load` rejects.
+- Azure batch-delete failures now include the response body in the raised error instead of a bound-method repr.
+- Declare the record method explicitly on the cross-process `Counter`/`Gauge` telemetry proxies (derived from each instrument class's public methods). Proxy generation no longer depends on the installed OpenTelemetry's instrument shape, fixing `AttributeError: 'AutoProxy[opentelemetry.metrics.Counter]' object has no attribute 'add'` under OpenTelemetry version skew.
+- `MultiStoragePath.read_text()` now honors its `errors` argument (`"ignore"`, `"replace"`, ...) instead of always decoding strictly.
+- `RustClient.download_multipart_to_bytes` now returns `b""` for zero-byte objects and empty ranges instead of failing with an integer underflow / invalid range error.
+- `ObjectFile.fileno()` on in-memory files now returns one stable temporary descriptor instead of allocating a new one on every call (which leaked a descriptor per call until `close()`), and `close()` releases tracked descriptors and the append-mode staging file even when the upload fails.
+- `msc ls` now shows the size of files whose provider reports no modification time (for example HuggingFace or AIStore); the size column was previously blanked for every row without a date.
+- Percent-encode the container and blob path in Azure presigned (SAS) URLs; blob names containing spaces, `#`, `+` or `%` previously produced URLs that were truncated or rejected.
+- Azure downloads of large objects into a `StringIO` now decode the staged content as UTF-8 regardless of the host locale, matching the small-object path and the upload encoding.
+- Rust recursive listing now reports a failed listing task as a regular storage error instead of a Rust panic that bypasses MSC's exception translation.
+- Numeric literals in object attribute filters now compare correctly with string-valued metadata for equality and inequality operations.
+
+## Multi-Storage File System (MSFS)
+
+MSFS is planned to move to a separate repository and adopt an independent release process.

--- a/multi-storage-client/pyproject.toml
+++ b/multi-storage-client/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 
 [project]
 name = "multi-storage-client"
-version = "1.0.1"
+version = "1.1.0"
 description = "Unified high-performance Python client for object and file stores."
 authors = [
     { name = "NVIDIA Multi-Storage Client Team" }

--- a/uv.lock
+++ b/uv.lock
@@ -2347,7 +2347,7 @@ wheels = [
 
 [[package]]
 name = "multi-storage-client"
-version = "1.0.1"
+version = "1.1.0"
 source = { editable = "multi-storage-client" }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Description

Release MSC 1.1.0

Relates to NGCDP-000

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [ ] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.
- Release PR
  - CI/CD
    - [x] The default branch pipelines are passing in both GitHub + GitLab (latter for SwiftStack E2E tests).
  - `multi-storage-client/pyproject.toml`
    - [x] The package version has been bumped.
  - `.release_notes/.unreleased.md`
    - [x] This file's contents have been moved into a `.release_notes/{bumped package version}.md` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Python 3.14.
  - Added file-descriptor telemetry, stricter external-symlink handling, and POSIX base-path caching.

- **Bug Fixes**
  - Improved downloads, multipart transfers, synchronization, metrics, provider listings, configuration serialization, Azure errors and URLs, telemetry proxies, text decoding, resource cleanup, CLI size reporting, and metadata filtering.
  - Improved error translation and UTF-8 handling.

- **Breaking Changes**
  - Removed Zarr/Xarray adapters and extras; use native fsspec integrations instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->