### PR TITLE
fix(sync): queue the target key for pruned objects in delete batches

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -5,4 +5,5 @@
 ## New Features
 
 ## Bug Fixes
+- `sync` / `sync_from` with `delete_unmatched_files=True` now reports the correct target key for pruned objects in subdirectories. When the target has a metadata provider (e.g. manifest), the sync previously failed with `SyncError: Object ... does not exist` and, in multi-process mode, committed a manifest that still listed the deleted objects.
 - `open(path, "r", encoding=...)` with caching enabled now honors the requested mode and encoding when the object is served from the cache; the cache-first fast path previously opened the cached file in binary mode (so `read()` returned `bytes`), and cached text opens ignored a non-default `encoding`.

--- a/multi-storage-client/src/multistorageclient/sync/metadata_proxy.py
+++ b/multi-storage-client/src/multistorageclient/sync/metadata_proxy.py
@@ -37,8 +37,9 @@ class QueueBackedMetadataProvider(MetadataProvider):
 
     ``remove_file`` is intentionally NOT queued here because it does not
     carry :py:class:`ObjectMetadata` (needed by the monitor for byte
-    counting).  DELETE propagation is handled by the sync worker which
-    constructs the metadata and queues the result directly.
+    counting).  DELETE propagation is handled by the sync worker, which
+    queues the pruned object's *target* key and its :py:class:`ObjectMetadata`
+    (taken from the target listing) directly.
     """
 
     def __init__(self, delegate: MetadataProvider, result_queue: QueueLike):

--- a/multi-storage-client/src/multistorageclient/sync/worker.py
+++ b/multi-storage-client/src/multistorageclient/sync/worker.py
@@ -268,8 +268,9 @@ class BatchSyncHandler(ABC):
         """Process a DELETE batch."""
         self.target_client.delete_many([file_metadata.key for file_metadata, _ in batch.items])
         for file_metadata, _ in batch.items:
-            target_file_path = build_target_file_path(self.source_path, self.target_path, file_metadata)
-            self.result_queue.put((OperationType.DELETE, target_file_path, file_metadata))
+            # DELETE items come from the *target* listing, so the key is already the
+            # target logical path; do not map it through build_target_file_path.
+            self.result_queue.put((OperationType.DELETE, file_metadata.key, file_metadata))
 
     def process_symlink_batch(self, worker_id: str, batch: OperationBatch) -> None:
         """Process a SYMLINK batch: recreate each symlink on the target via ``make_symlink``.

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_sync.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_sync.py
@@ -30,6 +30,7 @@ from multistorageclient.config import StorageClientConfig
 from multistorageclient.constants import MEMORY_LOAD_LIMIT
 from multistorageclient.providers.base import BaseStorageProvider
 from multistorageclient.providers.manifest_metadata import DEFAULT_MANIFEST_BASE_DIR
+from multistorageclient.sync import manager as sync_manager
 from multistorageclient.types import ExecutionMode, ObjectMetadata, PatternType, SymlinkHandling, SyncError
 from test_multistorageclient.unit.utils import config, tempdatastore
 
@@ -1439,3 +1440,80 @@ def test_sync_uses_strict_false_for_get_object_metadata(
             msc.sync(source_url=source_url, target_url=target_url)
 
         verify_sync_and_contents(target_url, test_files)
+
+
+@pytest.mark.parametrize(
+    argnames=["source_subdir", "target_subdir"],
+    argvalues=[
+        # len(source_path) < len(target key): the old code sliced the target key mid-string.
+        ["a", "deeper/out"],
+        # len(source_path) >= len(target key): the old code collapsed the key to its basename.
+        ["a/very/long/source/prefix", "o"],
+    ],
+)
+@pytest.mark.parametrize(
+    argnames="worker_processes_and_threads",
+    argvalues=[(1, 4), (2, 2)],
+    ids=["threads", "processes"],
+)
+def test_sync_delete_unmatched_files_in_subdirectory_with_manifest(
+    source_subdir: str, target_subdir: str, worker_processes_and_threads: tuple[int, int]
+):
+    """``delete_unmatched_files`` must report the *target* key of each pruned object to the result monitor.
+
+    Regression test: the DELETE path used to map the target key through ``build_target_file_path``
+    (which strips ``source_path``), producing a corrupted key whenever the source and target prefixes
+    differed in length. The monitor's ``remove_file`` replay then failed, the sync raised ``SyncError``,
+    and in multi-process mode the manifest was committed with entries for objects that no longer existed.
+    """
+    msc.shortcuts._STORAGE_CLIENT_CACHE.clear()
+
+    with (
+        tempdatastore.TemporaryPOSIXDirectory() as source_store,
+        tempdatastore.TemporaryPOSIXDirectory() as target_store,
+    ):
+        config.setup_msc_config(
+            config_dict={
+                "profiles": {
+                    "source": source_store.profile_config_dict(),
+                    "target": target_store.profile_config_dict()
+                    | {
+                        "metadata_provider": {
+                            "type": "manifest",
+                            "options": {"manifest_path": DEFAULT_MANIFEST_BASE_DIR, "writable": True},
+                        }
+                    },
+                }
+            }
+        )
+        source_url = f"msc://source/{source_subdir}"
+        target_url = f"msc://target/{target_subdir}"
+
+        for key in ["dir1/a.txt", "dir1/sub/b.txt", "top.txt"]:
+            msc.write(f"{source_url}/{key}", b"x" * 10)
+
+        # POSIX-to-POSIX syncs normally run in a single process; force the requested layout so the
+        # multi-process path (pickled metadata provider copy in the worker) is exercised too.
+        with mock.patch.object(
+            sync_manager, "calculate_worker_processes_and_threads", return_value=worker_processes_and_threads
+        ):
+            result = msc.sync(source_url, target_url)
+            assert result.total_files_added == 3
+
+            msc.delete(f"{source_url}/dir1/a.txt")
+            msc.delete(f"{source_url}/dir1/sub/b.txt")
+            result = msc.sync(source_url, target_url, delete_unmatched_files=True)
+
+        assert result.total_files_added == 0
+        assert result.total_files_deleted == 2
+        assert result.total_bytes_deleted == 20
+
+        # The live client and a fresh client (which reloads the committed manifest) must agree that
+        # only ``top.txt`` remains, and the physical files must be gone.
+        assert sorted(f.key for f in msc.list(target_url)) == [f"{target_url}/top.txt"]
+        msc.shortcuts._STORAGE_CLIENT_CACHE.clear()
+        assert sorted(f.key for f in msc.list(target_url)) == [f"{target_url}/top.txt"]
+        target_root = os.path.join(target_store._directory.name, target_subdir)
+        assert not os.path.exists(os.path.join(target_root, "dir1/a.txt"))
+        assert not os.path.exists(os.path.join(target_root, "dir1/sub/b.txt"))
+        assert os.path.exists(os.path.join(target_root, "top.txt"))


### PR DESCRIPTION
## Description

`process_delete_batch` mapped each DELETE item through `build_target_file_path`,
which strips `source_path` from a *source* key. DELETE items come from the
target listing, so the key is already the target logical path and the slice
removed the wrong prefix: a short source path produced a mid-string slice
(`deeper/out/eeper/out/dir1/a.txt`), a long one collapsed the key to its
basename. The `ResultMonitorThread` then replayed `remove_file` on the real
metadata provider with that key, raised `FileNotFoundError`, and the sync
surfaced a `SyncError` even though the objects had been deleted.

In multi-process mode the worker holds a pickled copy of the metadata provider,
so the monitor replay is the only update that reaches the real provider; when
it died, the manifest was committed with entries for objects that no longer
existed.

The fix queues `file_metadata.key` directly. The `QueueBackedMetadataProvider`
docstring is adjusted to describe what the worker actually queues.

Release note: `sync` / `sync_from` with `delete_unmatched_files=True` now reports the correct target key for pruned objects in subdirectories. When the target has a metadata provider (e.g. manifest), the sync previously failed with `SyncError: Object ... does not exist` and, in multi-process mode, committed a manifest that still listed the deleted objects.

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.

## Testing

Regression test added:
- `multi-storage-client/tests/test_multistorageclient/unit/test_sync.py::test_sync_delete_unmatched_files_in_subdirectory_with_manifest`

Parametrised over both slice branches (`len(source_path)` shorter and longer than the target key) and over thread / forced multi-process execution. All four cases fail on `main` with the `SyncError` above and pass with this change. In the multi-process cases the test also reloads the committed manifest through a fresh client to confirm the pruned entries are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed synchronization when deleting unmatched files in subdirectories with different source and target paths.
  * Corrected target-key reporting for deleted objects during synchronization.
  * Prevented stale objects from remaining in manifests during threaded and multiprocess synchronization.
  * Improved deletion handling for metadata providers and persisted manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->