### PR TITLE
fix(huggingface): restore last_modified from last_commit

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -5,4 +5,5 @@
 ## New Features
 
 ## Bug Fixes
+- HuggingFace `info()` and `list()` report the last commit date as `last_modified` again instead of always returning the epoch sentinel.
 - `open(path, "r", encoding=...)` with caching enabled now honors the requested mode and encoding when the object is served from the cache; the cache-first fast path previously opened the cached file in binary mode (so `read()` returned `bytes`), and cached text opens ignored a non-default `encoding`.

--- a/multi-storage-client/src/multistorageclient/providers/huggingface.py
+++ b/multi-storage-client/src/multistorageclient/providers/huggingface.py
@@ -516,7 +516,11 @@ class HuggingFaceStorageProvider(BaseStorageProvider):
         :param item: The RepoFile or RepoFolder item from HuggingFace API.
         :return: ObjectMetadata representing the item.
         """
+        # expand=True populates last_commit; fall back to the epoch sentinel when it is absent.
         last_modified = AWARE_DATETIME_MIN
+        last_commit = getattr(item, "last_commit", None)
+        if last_commit is not None and getattr(last_commit, "date", None):
+            last_modified = last_commit.date
 
         if isinstance(item, RepoFile):
             etag = item.blob_id

--- a/multi-storage-client/tests/test_multistorageclient/unit/providers/test_huggingface_metadata.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/providers/test_huggingface_metadata.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from huggingface_hub.hf_api import RepoFile, RepoFolder
+
+from multistorageclient.providers.huggingface import HuggingFaceStorageProvider
+from multistorageclient.types import AWARE_DATETIME_MIN
+
+LAST_COMMIT = {"id": "c1", "title": "initial", "date": "2025-01-02T03:04:05.000Z"}
+
+
+@pytest.fixture
+def hf_provider():
+    with patch("multistorageclient.providers.huggingface.HfApi", return_value=MagicMock()):
+        yield HuggingFaceStorageProvider(repository_id="org/repo")
+
+
+def test_item_to_metadata_uses_last_commit_date(hf_provider):
+    """expand=True is requested precisely so that last_commit is available; its date must be surfaced."""
+    file_item = RepoFile(path="data/a.bin", size=3, oid="blob1", lfs=None, last_commit=LAST_COMMIT, security=None)
+    folder_item = RepoFolder(path="data", oid="tree1", last_commit=LAST_COMMIT)
+
+    file_metadata = hf_provider._item_to_metadata(file_item)
+    folder_metadata = hf_provider._item_to_metadata(folder_item)
+
+    expected = datetime(2025, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    assert file_metadata.type == "file"
+    assert file_metadata.content_length == 3
+    assert file_metadata.etag == "blob1"
+    assert file_metadata.last_modified == expected
+    assert folder_metadata.type == "directory"
+    assert folder_metadata.etag == "tree1"
+    assert folder_metadata.last_modified == expected
+
+
+def test_item_to_metadata_without_last_commit_uses_sentinel(hf_provider):
+    file_item = RepoFile(path="data/a.bin", size=3, oid="blob1", lfs=None, last_commit=None, security=None)
+
+    assert hf_provider._item_to_metadata(file_item).last_modified == AWARE_DATETIME_MIN


### PR DESCRIPTION
## Description

The refactor into `_item_to_metadata` (33112ef) dropped the
`item.last_commit.date` branch that both `_get_object_metadata` and
`_list_objects` previously had, so every HF object reported
`AWARE_DATETIME_MIN` even though `expand=True` is still requested (and
paid for) precisely to populate `last_commit`. `sync` compares
`last_modified` and `msc ls` shows a blank date for every HF file.

Release note: HuggingFace `info()` and `list()` report the last commit date as `last_modified` again instead of always returning the epoch sentinel.

_Found during a review of the commit history; no tracked issue._

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.

## Testing

Regression tests added/extended:
- `multi-storage-client/tests/test_multistorageclient/unit/providers/test_huggingface_metadata.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Hugging Face `info()` and `list()` now report the latest commit date as `last_modified` instead of an epoch fallback when available.
  - Metadata continues to use the fallback timestamp when no commit information exists, ensuring consistent results for items without commit history.

- **Tests**
  - Added coverage for file and directory metadata, commit timestamp propagation, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->