### PR TITLE
fix(sync): do not count pattern-excluded unchanged-path files as work

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -6,4 +6,5 @@
 
 ## Bug Fixes
 - `open(path, "r", encoding=...)` with caching enabled now honors the requested mode and encoding when the object is served from the cache; the cache-first fast path previously opened the cached file in binary mode (so `read()` returned `bytes`), and cached text opens ignored a non-default `encoding`.
+- Stop counting pattern-excluded files that exist on both sides with differing metadata as sync work units; they inflated the progress-bar total and `SyncResult.total_work_units`.
 - Cache access-time updates no longer raise when the cached file was concurrently evicted or is owned by another user, and they operate on an open file descriptor so a concurrently recreated cache file is never chmod'ed by mistake; the permission restore in the `finally` block previously re-raised the error the method was meant to swallow.

--- a/multi-storage-client/src/multistorageclient/sync/producer.py
+++ b/multi-storage-client/src/multistorageclient/sync/producer.py
@@ -304,12 +304,13 @@ class ProducerThread(threading.Thread):
                             # Check if file should be included based on patterns
                             if not self.pattern_matcher or self.pattern_matcher.should_include_file(source_key):
                                 self._enqueue_operation(OperationType.ADD, source_file, target_file)
+                                self.total_work_units += 1
                         else:
                             self.progress.update_progress()
+                            self.total_work_units += 1
 
                         source_file = next(source_iter, None)
                         target_file = next(target_iter, None)
-                        self.total_work_units += 1
                 elif source_file:
                     source_key = source_file.key[len(self.source_path) :].lstrip("/")
 

--- a/multi-storage-client/tests/test_multistorageclient/unit/sync/test_producer.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/sync/test_producer.py
@@ -31,8 +31,8 @@ from multistorageclient.sync.producer import (
 )
 from multistorageclient.sync.progress_bar import ProgressBar
 from multistorageclient.sync.types import OperationType
-from multistorageclient.types import ObjectMetadata
-from multistorageclient.utils import NullStorageClient
+from multistorageclient.types import ObjectMetadata, PatternType
+from multistorageclient.utils import NullStorageClient, PatternMatcher
 from test_multistorageclient.unit.utils import config
 
 
@@ -610,6 +610,58 @@ def test_progress_bar_update_in_producer_thread_with_deletion():
     assert progress.pbar is not None
     assert progress.pbar.total == len(target_files)
     assert progress.pbar.n == 0
+
+
+def test_progress_total_excludes_pattern_excluded_files_present_on_both_sides():
+    """A changed file that the pattern excludes is neither enqueued nor counted as a work unit."""
+    source_client = MockStorageClient()
+    target_client = MockStorageClient()
+    old = datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    new = datetime(2025, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
+
+    source_files = [
+        ObjectMetadata(key="changed.log", content_length=100, last_modified=new),
+        ObjectMetadata(key="changed.txt", content_length=100, last_modified=new),
+        ObjectMetadata(key="same.log", content_length=100, last_modified=old),
+    ]
+    target_files = [
+        ObjectMetadata(key="changed.log", content_length=100, last_modified=old),
+        ObjectMetadata(key="changed.txt", content_length=100, last_modified=old),
+        ObjectMetadata(key="same.log", content_length=100, last_modified=old),
+    ]
+    source_client.list = lambda **kwargs: iter(source_files)  # type: ignore
+    target_client.list = lambda **kwargs: iter(target_files)  # type: ignore
+
+    progress = ProgressBar(desc="Syncing", show_progress=True)
+    file_queue: queue.Queue = queue.Queue()
+    producer_thread = ProducerThread(
+        source_client=cast(StorageClient, source_client),
+        source_path="",
+        target_client=cast(StorageClient, target_client),
+        target_path="",
+        progress=progress,
+        file_queue=file_queue,
+        num_workers=1,
+        shutdown_event=threading.Event(),
+        pattern_matcher=PatternMatcher([(PatternType.EXCLUDE, "*.log")]),
+    )
+
+    producer_thread.start()
+    producer_thread.join()
+
+    assert producer_thread.error is None
+    enqueued = []
+    while True:
+        batch = file_queue.get_nowait()
+        if batch.operation == OperationType.STOP:
+            break
+        enqueued.extend(file_metadata.key for file_metadata, _ in batch.items)
+    assert enqueued == ["changed.txt"]
+    # One ADD plus one unchanged file that was marked complete immediately; the excluded changed file is not work.
+    assert producer_thread.total_work_units == 2
+    assert progress.pbar is not None
+    assert progress.pbar.total == 2
+    assert progress.pbar.n == 1
 
 
 def test_batch_flushing_on_operation_type_change():


### PR DESCRIPTION
## Description

In the "both exist" branch of the producer merge loop, a file whose
metadata differed but which the pattern matcher excluded was neither
enqueued nor marked complete, yet `total_work_units` was still
incremented. The progress bar total therefore exceeded the reachable count
(sticking at 99.9%) and `SyncResult.total_work_units` over-reported. Count
a unit only when an ADD is enqueued or an unchanged file is marked done,
matching the source-only branch.

Release note: Stop counting pattern-excluded files that exist on both sides with differing metadata as sync work units; they inflated the progress-bar total and `SyncResult.total_work_units`.

_Found during a review of the commit history; no tracked issue._

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.

## Testing

Regression tests added/extended:
- `multi-storage-client/tests/test_multistorageclient/unit/sync/test_producer.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected sync progress totals so files excluded by configured patterns are not counted as work when they exist on both sides with differing metadata.
  - Ensured included metadata changes are still queued for processing and counted accurately.
  - Improved cache access-time handling during concurrent eviction and permission updates.
  - Added regression coverage for excluded, changed, and unchanged files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->