### PR TITLE
fix(client): stop mutating metadata-provider objects when prefixing URLs

### DIFF
--- a/.release_notes/.unreleased.md
+++ b/.release_notes/.unreleased.md
@@ -7,3 +7,4 @@
 ## Bug Fixes
 - `open(path, "r", encoding=...)` with caching enabled now honors the requested mode and encoding when the object is served from the cache; the cache-first fast path previously opened the cached file in binary mode (so `read()` returned `bytes`), and cached text opens ignored a non-default `encoding`.
 - Cache access-time updates no longer raise when the cached file was concurrently evicted or is owned by another user, and they operate on an open file descriptor so a concurrently recreated cache file is never chmod'ed by mistake; the permission restore in the `finally` block previously re-raised the error the method was meant to swallow.
+- Return copies from `list(..., include_url_prefix=True)` and the single-file path of `list()` instead of rewriting the key of `ObjectMetadata` objects owned by the metadata provider; a single `msc.list()` previously corrupted the in-memory manifest keys.

--- a/multi-storage-client/src/multistorageclient/client/composite.py
+++ b/multi-storage-client/src/multistorageclient/client/composite.py
@@ -463,7 +463,8 @@ class CompositeStorageClient(AbstractStorageClient):
                 continue
 
             if include_url_prefix:
-                obj.key = join_paths(f"{MSC_PROTOCOL}{self._config.profile}", obj.key)
+                # Return a copy: the object is owned by the metadata provider and must not be mutated.
+                obj = obj.replace(key=join_paths(f"{MSC_PROTOCOL}{self._config.profile}", obj.key))
 
             yield obj
 

--- a/multi-storage-client/src/multistorageclient/client/single.py
+++ b/multi-storage-client/src/multistorageclient/client/single.py
@@ -836,18 +836,18 @@ class SingleStorageClient(AbstractStorageClient):
                 if end_at and object_metadata.key > end_at:
                     return None, None
                 if include_url_prefix:
-                    self._prepend_url_prefix(object_metadata)
+                    object_metadata = self._with_url_prefix(object_metadata)
                 return object_metadata, path
             except FileNotFoundError:
                 return None, path.rstrip("/") + "/"
         else:
             return None, path.rstrip("/") + "/"
 
-    def _prepend_url_prefix(self, obj: ObjectMetadata) -> None:
+    def _with_url_prefix(self, obj: ObjectMetadata) -> ObjectMetadata:
+        # Return a copy: listed objects may be owned by the metadata provider and must not be mutated.
         if self.is_default_profile():
-            obj.key = str(PurePosixPath("/") / obj.key)
-        else:
-            obj.key = join_paths(f"{MSC_PROTOCOL}{self._config.profile}", obj.key)
+            return obj.replace(key=str(PurePosixPath("/") / obj.key))
+        return obj.replace(key=join_paths(f"{MSC_PROTOCOL}{self._config.profile}", obj.key))
 
     def _filter_and_decorate(
         self,
@@ -859,7 +859,7 @@ class SingleStorageClient(AbstractStorageClient):
             if pattern_matcher and not pattern_matcher.should_include_file(obj.key):
                 continue
             if include_url_prefix:
-                self._prepend_url_prefix(obj)
+                obj = self._with_url_prefix(obj)
             yield obj
 
     def list_recursive(

--- a/multi-storage-client/tests/test_multistorageclient/unit/client/test_client.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/client/test_client.py
@@ -1028,3 +1028,13 @@ def test_single_info_root_reports_base_path_mtime(tmp_path, monkeypatch):
         metadata = client.info(path)
         assert metadata.type == "directory"
         assert metadata.last_modified.timestamp() == 0.0
+
+
+def test_composite_client_list_with_url_prefix_does_not_mutate_metadata_provider_objects(multi_backend_config):
+    """CompositeStorageClient.list(include_url_prefix=True) must return copies, not rewrite the provider's objects."""
+    client = StorageClient(multi_backend_config)
+    expected = [f"msc://{multi_backend_config.profile}/webdataset-0000{i}.tar" for i in (1, 2)]
+
+    assert sorted(obj.key for obj in client.list(include_url_prefix=True)) == expected
+    assert sorted(obj.key for obj in client.list(include_url_prefix=True)) == expected
+    assert sorted(client._metadata_provider._files) == ["webdataset-00001.tar", "webdataset-00002.tar"]  # type: ignore[union-attr]

--- a/multi-storage-client/tests/test_multistorageclient/unit/test_shortcuts.py
+++ b/multi-storage-client/tests/test_multistorageclient/unit/test_shortcuts.py
@@ -1625,3 +1625,36 @@ def test_fork_safety_multiple_forks(file_storage_config):
 
     # Verify parent cache is still intact
     assert len(msc.shortcuts._STORAGE_CLIENT_CACHE) == 1
+
+
+def test_list_with_url_prefix_does_not_mutate_metadata_provider_objects():
+    """msc.list() must not rewrite the keys of objects owned by the metadata provider."""
+    msc.shortcuts._STORAGE_CLIENT_CACHE.clear()
+    with tempdatastore.TemporaryPOSIXDirectory() as temp_data_store:
+        profile = "manifest-list"
+        config.setup_msc_config(
+            config_dict={
+                "profiles": {
+                    profile: temp_data_store.profile_config_dict()
+                    | {
+                        "metadata_provider": {
+                            "type": "manifest",
+                            "options": {"manifest_path": DEFAULT_MANIFEST_BASE_DIR, "writable": True},
+                        }
+                    }
+                }
+            }
+        )
+        msc.write(f"{MSC_PROTOCOL}{profile}/backup/data/f1.txt", b"hello")
+        msc.commit_metadata(f"{MSC_PROTOCOL}{profile}")
+
+        expected = [f"{MSC_PROTOCOL}{profile}/backup/data/f1.txt"]
+        # Directory listing and the single-file listing path each go through the prefixing code twice.
+        assert [obj.key for obj in msc.list(f"{MSC_PROTOCOL}{profile}/backup/data")] == expected
+        assert [obj.key for obj in msc.list(f"{MSC_PROTOCOL}{profile}/backup/data")] == expected
+        assert [obj.key for obj in msc.list(f"{MSC_PROTOCOL}{profile}/backup/data/f1.txt")] == expected
+        assert [obj.key for obj in msc.list(f"{MSC_PROTOCOL}{profile}/backup/data/f1.txt")] == expected
+
+        client, _ = msc.resolve_storage_client(f"{MSC_PROTOCOL}{profile}")
+        assert [obj.key for obj in client.list("backup/data")] == ["backup/data/f1.txt"]
+        assert client.info("backup/data/f1.txt").key == "backup/data/f1.txt"


### PR DESCRIPTION
## Description

`ManifestMetadataProvider.list_objects`/`get_object_metadata` hand out
their internal `ObjectMetadata` instances. `_prepend_url_prefix` rewrote
`.key` in place, so one `msc.list("msc://profile/dir")` (the shortcut and
`msc ls` pass `include_url_prefix=True`) permanently changed the provider's
stored keys: a second listing returned `msc://p/msc://p/dir/f`, and a
later `sync_from` into that profile mis-compared every entry. Return a
copy via `ObjectMetadata.replace` in both `SingleStorageClient` and
`CompositeStorageClient`.

Release note: Return copies from `list(..., include_url_prefix=True)` and the single-file path of `list()` instead of rewriting the key of `ObjectMetadata` objects owned by the metadata provider; a single `msc.list()` previously corrupted the in-memory manifest keys.

_Found during a review of the commit history; no tracked issue._

## Checklist

- Development PR
  - `.release_notes/.unreleased.md`
    - [x] Notable changes to the client (i.e. not related to tooling, CI/CD, etc.) from this PR have been added.

## Testing

Regression tests added/extended:
- `multi-storage-client/tests/test_multistorageclient/unit/test_shortcuts.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL-prefixed listings so metadata remains consistent across repeated requests.
  * Single-file lookups and listings now preserve original unprefixed keys for subsequent `list()` and `info()` calls.
  * Prevented provider metadata from being altered when URL prefixes are applied.
  * Improved cache access-time updates for safer cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->